### PR TITLE
test: validate emergency stop behavior across subscription vault functions

### DIFF
--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -23,6 +23,7 @@ impl SubscriptionVault {
     }
 
     pub fn set_min_topup(env: Env, admin: Address, min_topup: i128) -> Result<(), Error> {
+        admin::require_not_stopped(&env)?;
         admin::do_set_min_topup(&env, admin, min_topup)
     }
 
@@ -38,6 +39,7 @@ impl SubscriptionVault {
         interval_seconds: u64,
         usage_enabled: bool,
     ) -> Result<u32, Error> {
+        admin::require_not_stopped(&env)?;
         subscription::do_create_subscription(
             &env,
             subscriber,
@@ -54,10 +56,12 @@ impl SubscriptionVault {
         subscriber: Address,
         amount: i128,
     ) -> Result<(), Error> {
+        admin::require_not_stopped(&env)?;
         subscription::do_deposit_funds(&env, subscription_id, subscriber, amount)
     }
 
     pub fn charge_subscription(env: Env, subscription_id: u32) -> Result<(), Error> {
+        admin::require_not_stopped(&env)?;
         subscription::do_charge_subscription(&env, subscription_id)
     }
 
@@ -81,6 +85,7 @@ impl SubscriptionVault {
         subscription_id: u32,
         authorizer: Address,
     ) -> Result<(), Error> {
+        admin::require_not_stopped(&env)?;
         subscription::do_cancel_subscription(&env, subscription_id, authorizer)
     }
 
@@ -89,6 +94,7 @@ impl SubscriptionVault {
         subscription_id: u32,
         authorizer: Address,
     ) -> Result<(), Error> {
+        admin::require_not_stopped(&env)?;
         subscription::do_pause_subscription(&env, subscription_id, authorizer)
     }
 
@@ -97,19 +103,29 @@ impl SubscriptionVault {
         subscription_id: u32,
         authorizer: Address,
     ) -> Result<(), Error> {
+        admin::require_not_stopped(&env)?;
         subscription::do_resume_subscription(&env, subscription_id, authorizer)
     }
 
-    pub fn withdraw_merchant_funds(
-        env: Env,
-        merchant: Address,
-        amount: i128,
-    ) -> Result<(), Error> {
+    pub fn withdraw_merchant_funds(env: Env, merchant: Address, amount: i128) -> Result<(), Error> {
+        admin::require_not_stopped(&env)?;
         merchant::withdraw_merchant_funds(&env, merchant, amount)
     }
 
     pub fn get_subscription(env: Env, subscription_id: u32) -> Result<Subscription, Error> {
         queries::get_subscription(&env, subscription_id)
+    }
+
+    pub fn emergency_stop(env: Env, admin: Address) -> Result<(), Error> {
+        admin::do_emergency_stop(&env, admin)
+    }
+
+    pub fn resume_contract(env: Env, admin: Address) -> Result<(), Error> {
+        admin::do_resume_contract(&env, admin)
+    }
+
+    pub fn is_stopped(env: Env) -> bool {
+        admin::is_stopped(&env)
     }
 }
 

--- a/contracts/subscription_vault/src/types.rs
+++ b/contracts/subscription_vault/src/types.rs
@@ -21,6 +21,8 @@ pub enum Error {
     Overflow = 403,
     /// Charge failed due to insufficient prepaid balance.
     InsufficientBalance = 1003,
+    /// Operation rejected because the contract is in emergency stop mode.
+    ContractStopped = 1004,
 }
 
 impl Error {
@@ -35,6 +37,7 @@ impl Error {
             Error::BelowMinimumTopup => 402,
             Error::Overflow => 403,
             Error::InsufficientBalance => 1003,
+            Error::ContractStopped => 1004,
         }
     }
 }

--- a/contracts/subscription_vault/test_snapshots/test/test_charge_subscription_admin.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_charge_subscription_admin.1.json
@@ -40,6 +40,34 @@
         }
       ]
     ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "deposit_funds",
+              "args": [
+                {
+                  "u32": 0
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10000000
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
     [],
     [
       [
@@ -64,7 +92,7 @@
   "ledger": {
     "protocol_version": 22,
     "sequence_number": 0,
-    "timestamp": 0,
+    "timestamp": 3600,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
     "min_persistent_entry_ttl": 4096,
@@ -124,7 +152,7 @@
                                 "symbol": "last_payment_timestamp"
                               },
                               "val": {
-                                "u64": 0
+                                "u64": 3600
                               }
                             },
                             {
@@ -142,7 +170,7 @@
                               "val": {
                                 "i128": {
                                   "hi": 0,
-                                  "lo": 0
+                                  "lo": 9999000
                                 }
                               }
                             },
@@ -305,6 +333,39 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
                   }
                 },
                 "durability": "temporary",

--- a/contracts/subscription_vault/test_snapshots/test/test_charge_subscription_auth.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_charge_subscription_auth.1.json
@@ -42,6 +42,34 @@
     ],
     [
       [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "deposit_funds",
+              "args": [
+                {
+                  "u32": 0
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 10000000
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
@@ -63,7 +91,7 @@
   "ledger": {
     "protocol_version": 22,
     "sequence_number": 0,
-    "timestamp": 0,
+    "timestamp": 3600,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
     "min_persistent_entry_ttl": 4096,
@@ -123,7 +151,7 @@
                                 "symbol": "last_payment_timestamp"
                               },
                               "val": {
-                                "u64": 0
+                                "u64": 3600
                               }
                             },
                             {
@@ -141,7 +169,7 @@
                               "val": {
                                 "i128": {
                                   "hi": 0,
-                                  "lo": 0
+                                  "lo": 9999000
                                 }
                               }
                             },
@@ -223,7 +251,7 @@
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
             "key": {
               "ledger_key_nonce": {
-                "nonce": 5541220902715666415
+                "nonce": 1033654523790656264
               }
             },
             "durability": "temporary"
@@ -238,7 +266,7 @@
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
                 "key": {
                   "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
+                    "nonce": 1033654523790656264
                   }
                 },
                 "durability": "temporary",
@@ -272,6 +300,39 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
                   }
                 },
                 "durability": "temporary",

--- a/contracts/subscription_vault/test_snapshots/test/test_min_topup_above_threshold.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_min_topup_above_threshold.1.json
@@ -1,11 +1,45 @@
 {
   "generators": {
-    "address": 4,
+    "address": 5,
     "nonce": 0
   },
   "auth": [
     [],
     [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_subscription",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                },
+                {
+                  "u64": 86400
+                },
+                {
+                  "bool": false
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
@@ -70,6 +104,85 @@
                     "storage": [
                       {
                         "key": {
+                          "u32": 0
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "amount"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 1000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "interval_seconds"
+                              },
+                              "val": {
+                                "u64": 86400
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "last_payment_timestamp"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "merchant"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "prepaid_balance"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 10000000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "status"
+                              },
+                              "val": {
+                                "u32": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "subscriber"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "usage_enabled"
+                              },
+                              "val": {
+                                "bool": false
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "admin"
                         },
                         "val": {
@@ -85,6 +198,14 @@
                             "hi": 0,
                             "lo": 5000000
                           }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "next_id"
+                        },
+                        "val": {
+                          "u32": 1
                         }
                       },
                       {
@@ -127,6 +248,39 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
                   }
                 },
                 "durability": "temporary",

--- a/contracts/subscription_vault/test_snapshots/test/test_min_topup_exactly_at_threshold.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_min_topup_exactly_at_threshold.1.json
@@ -1,11 +1,45 @@
 {
   "generators": {
-    "address": 4,
+    "address": 5,
     "nonce": 0
   },
   "auth": [
     [],
     [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_subscription",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                },
+                {
+                  "u64": 86400
+                },
+                {
+                  "bool": false
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
@@ -70,6 +104,85 @@
                     "storage": [
                       {
                         "key": {
+                          "u32": 0
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "amount"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 1000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "interval_seconds"
+                              },
+                              "val": {
+                                "u64": 86400
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "last_payment_timestamp"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "merchant"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "prepaid_balance"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 5000000
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "status"
+                              },
+                              "val": {
+                                "u32": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "subscriber"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "usage_enabled"
+                              },
+                              "val": {
+                                "bool": false
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
                           "symbol": "admin"
                         },
                         "val": {
@@ -85,6 +198,14 @@
                             "hi": 0,
                             "lo": 5000000
                           }
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "next_id"
+                        },
+                        "val": {
+                          "u32": 1
                         }
                       },
                       {
@@ -127,6 +248,39 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
                   }
                 },
                 "durability": "temporary",

--- a/docs/emergency_stop_tests.md
+++ b/docs/emergency_stop_tests.md
@@ -1,0 +1,112 @@
+# Emergency Stop Tests — `subscription_vault`
+
+## Overview
+
+This document describes the emergency stop test suite added to
+`contracts/subscription_vault/src/test.rs`. The tests verify that the
+emergency stop mechanism correctly blocks critical operations, allows
+safe read-only operations, and behaves consistently when toggled.
+
+---
+
+## Functions Under Test
+
+| Function              | Guarded? | Notes                              |
+|-----------------------|----------|------------------------------------|
+| `create_subscription` | Yes      | Blocked when stopped               |
+| `deposit_funds`       | Yes      | Blocked when stopped               |
+| `charge_subscription` | Yes      | Blocked when stopped               |
+| `cancel_subscription` | Yes      | Blocked when stopped               |
+| `pause_subscription`  | Yes      | Blocked when stopped               |
+| `resume_subscription` | Yes      | Blocked when stopped               |
+| `batch_charge`        | Yes      | Blocked when stopped               |
+| `get_subscription`    | No       | Read-only, always accessible       |
+| `get_min_topup`       | No       | Read-only, always accessible       |
+| `is_stopped`          | No       | Query function, always accessible  |
+
+---
+
+## Error Variant
+
+All guarded functions return `Error::ContractStopped` when the emergency
+stop is active. This maps to a distinct contract error code to allow
+callers to distinguish a stop condition from other error types.
+
+---
+
+## Test Scenarios
+
+### Toggling Behavior
+
+| Test | Description |
+|------|-------------|
+| `test_emergency_stop_sets_stopped_state` | Contract starts in running state |
+| `test_emergency_stop_flag_is_true_after_activation` | `is_stopped()` returns true after stop |
+| `test_resume_contract_clears_stopped_flag` | `is_stopped()` returns false after resume |
+| `test_toggle_stop_multiple_times_is_consistent` | Stop/resume cycles maintain correct state |
+
+### Access Control
+
+| Test | Description |
+|------|-------------|
+| `test_non_admin_cannot_trigger_emergency_stop` | Non-admin call to `emergency_stop` is rejected |
+| `test_non_admin_cannot_resume_contract` | Non-admin call to `resume_contract` is rejected |
+
+### Critical Operations Blocked
+
+| Test | Description |
+|------|-------------|
+| `test_create_subscription_blocked_when_stopped` | Returns `ContractStopped` |
+| `test_deposit_funds_blocked_when_stopped` | Returns `ContractStopped` |
+| `test_charge_subscription_blocked_when_stopped` | Returns `ContractStopped` |
+| `test_cancel_subscription_blocked_when_stopped` | Returns `ContractStopped` |
+| `test_pause_subscription_blocked_when_stopped` | Returns `ContractStopped` |
+| `test_resume_subscription_blocked_when_stopped` | Returns `ContractStopped` |
+| `test_batch_charge_blocked_when_stopped` | Returns `ContractStopped` |
+
+### Safe Operations Remain Allowed
+
+| Test | Description |
+|------|-------------|
+| `test_get_subscription_allowed_when_stopped` | Query succeeds during stop |
+| `test_get_min_topup_allowed_when_stopped` | Query succeeds during stop |
+| `test_is_stopped_query_always_accessible` | Returns true during stop |
+
+### Recovery After Resume
+
+| Test | Description |
+|------|-------------|
+| `test_create_subscription_succeeds_after_resume` | Normal operation restored |
+| `test_deposit_funds_succeeds_after_resume` | Normal operation restored |
+| `test_charge_subscription_succeeds_after_resume` | Normal operation restored |
+
+---
+
+## Incident Handling Notes
+
+- The emergency stop should be activated immediately upon detection of
+  a critical vulnerability or unexpected contract behavior.
+- Only the admin address registered during `init` can activate or
+  deactivate the stop.
+- All in-flight operations will fail with `ContractStopped` — callers
+  should handle this error gracefully and retry after the stop is lifted.
+- Read-only queries remain available so that the state of the contract
+  can be inspected by the admin during an incident without modifying storage.
+- After the root cause is resolved, call `resume_contract(admin)` to
+  restore normal operation.
+
+---
+
+## Running the Tests
+
+```bash
+cargo test -p subscription_vault
+```
+
+To run only emergency stop tests:
+
+```bash
+cargo test -p subscription_vault emergency_stop
+cargo test -p subscription_vault stopped
+cargo test -p subscription_vault resume_contract
+```


### PR DESCRIPTION
Closes #43

---

- Added emergency_stop and resume_contract to admin.rs
- Added ContractStopped error variant to types.rs
- Guarded all state-mutating functions with require_not_stopped
- Added 19 emergency stop tests to test.rs
- Added docs/emergency_stop_tests.md documenting all scenarios

All 64 tests pass, clippy clean, WASM build succeeds.