### PR TITLE
Enhance charge functionality with idempotency and replay protection

### DIFF
--- a/contracts/subscription_vault/src/admin.rs
+++ b/contracts/subscription_vault/src/admin.rs
@@ -54,7 +54,7 @@ pub fn do_batch_charge(
 
     let mut results = Vec::new(env);
     for id in subscription_ids.iter() {
-        let r = charge_one(env, id);
+        let r = charge_one(env, id, None);
         let res = match &r {
             Ok(()) => BatchChargeResult {
                 success: true,

--- a/contracts/subscription_vault/src/charge_core.rs
+++ b/contracts/subscription_vault/src/charge_core.rs
@@ -1,13 +1,49 @@
 //! Single charge logic (no auth). Used by charge_subscription and batch_charge.
 //!
 //! **PRs that only change how one subscription is charged should edit this file only.**
+//!
+//! # Replay protection and idempotency
+//!
+//! Charges are protected against replay by:
+//! - **Period-based key**: We record the last charged billing period index per subscription.
+//!   A charge for the same period is rejected with [`Error::Replay`].
+//! - **Optional idempotency key**: If the caller supplies an idempotency key (e.g. for retries),
+//!   we store one key per subscription. A second call with the same key returns `Ok(())` without
+//!   debiting again (idempotent success). Storage stays bounded (one key and one period per sub).
 
 use crate::queries::get_subscription;
 use crate::state_machine::validate_status_transition;
-use crate::types::{Error, SubscriptionStatus};
-use soroban_sdk::Env;
+use crate::types::{Error, SubscriptionChargedEvent, SubscriptionStatus};
+use soroban_sdk::{symbol_short, Env, Symbol};
 
-pub fn charge_one(env: &Env, subscription_id: u32) -> Result<(), Error> {
+const KEY_CHARGED_PERIOD: Symbol = symbol_short!("cp");
+const KEY_IDEM: Symbol = symbol_short!("idem");
+
+fn charged_period_key(subscription_id: u32) -> (Symbol, u32) {
+    (KEY_CHARGED_PERIOD, subscription_id)
+}
+
+fn idem_key(subscription_id: u32) -> (Symbol, u32) {
+    (KEY_IDEM, subscription_id)
+}
+
+/// Performs a single interval-based charge with optional replay protection.
+///
+/// # Idempotency
+///
+/// - If `idempotency_key` is `Some(k)` and we already processed this subscription with key `k`,
+///   returns `Ok(())` without changing state (idempotent success).
+/// - Otherwise we derive a period from `now / interval_seconds`. If this period was already
+///   charged, returns `Err(Error::Replay)`.
+///
+/// # Storage
+///
+/// Bounded: one `u64` (last charged period) and optionally one idempotency key per subscription.
+pub fn charge_one(
+    env: &Env,
+    subscription_id: u32,
+    idempotency_key: Option<soroban_sdk::BytesN<32>>,
+) -> Result<(), Error> {
     let mut sub = get_subscription(env, subscription_id)?;
 
     if sub.status != SubscriptionStatus::Active {
@@ -15,6 +51,32 @@ pub fn charge_one(env: &Env, subscription_id: u32) -> Result<(), Error> {
     }
 
     let now = env.ledger().timestamp();
+    let period_index = now / sub.interval_seconds;
+
+    // Idempotent return: same idempotency key already processed for this subscription
+    if let Some(ref k) = idempotency_key {
+        if let Some(stored) = env
+            .storage()
+            .instance()
+            .get::<_, soroban_sdk::BytesN<32>>(&idem_key(subscription_id))
+        {
+            if stored == *k {
+                return Ok(());
+            }
+        }
+    }
+
+    // Replay: already charged for this billing period (derived key)
+    if let Some(stored_period) = env
+        .storage()
+        .instance()
+        .get::<_, u64>(&charged_period_key(subscription_id))
+    {
+        if period_index <= stored_period {
+            return Err(Error::Replay);
+        }
+    }
+
     let next_allowed = sub
         .last_payment_timestamp
         .checked_add(sub.interval_seconds)
@@ -36,5 +98,23 @@ pub fn charge_one(env: &Env, subscription_id: u32) -> Result<(), Error> {
         .ok_or(Error::Overflow)?;
     sub.last_payment_timestamp = now;
     env.storage().instance().set(&subscription_id, &sub);
+
+    // Record charged period and optional idempotency key (bounded storage)
+    env.storage()
+        .instance()
+        .set(&charged_period_key(subscription_id), &period_index);
+    if let Some(k) = idempotency_key {
+        env.storage().instance().set(&idem_key(subscription_id), &k);
+    }
+
+    env.events().publish(
+        (symbol_short!("charged"),),
+        SubscriptionChargedEvent {
+            subscription_id,
+            merchant: sub.merchant.clone(),
+            amount: sub.amount,
+        },
+    );
+
     Ok(())
 }

--- a/contracts/subscription_vault/src/types.rs
+++ b/contracts/subscription_vault/src/types.rs
@@ -21,6 +21,10 @@ pub enum Error {
     Overflow = 403,
     /// Charge failed due to insufficient prepaid balance.
     InsufficientBalance = 1003,
+    /// Replay: charge for this billing period or idempotency key already processed.
+    Replay = 1004,
+    /// One-off or other operation used an invalid amount (e.g. non-positive).
+    InvalidAmount = 1005,
 }
 
 impl Error {
@@ -35,6 +39,8 @@ impl Error {
             Error::BelowMinimumTopup => 402,
             Error::Overflow => 403,
             Error::InsufficientBalance => 1003,
+            Error::Replay => 1004,
+            Error::InvalidAmount => 1005,
         }
     }
 }
@@ -152,6 +158,15 @@ pub struct SubscriptionResumedEvent {
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct MerchantWithdrawalEvent {
+    pub merchant: Address,
+    pub amount: i128,
+}
+
+/// Emitted when a merchant-initiated one-off charge is applied to a subscription.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct OneOffChargedEvent {
+    pub subscription_id: u32,
     pub merchant: Address,
     pub amount: i128,
 }

--- a/contracts/subscription_vault/test_snapshots/test/test_charge_subscription_admin.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_charge_subscription_admin.1.json
@@ -80,7 +80,8 @@
               "args": [
                 {
                   "u32": 0
-                }
+                },
+                "void"
               ]
             }
           },
@@ -234,6 +235,21 @@
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "cp"
+                            },
+                            {
+                              "u32": 0
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 1
                         }
                       }
                     ]
@@ -400,5 +416,54 @@
       ]
     ]
   },
-  "events": []
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "charged"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "amount"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 1000
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "merchant"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "subscription_id"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
 }

--- a/contracts/subscription_vault/test_snapshots/test/test_charge_subscription_auth.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_charge_subscription_auth.1.json
@@ -79,7 +79,8 @@
               "args": [
                 {
                   "u32": 0
-                }
+                },
+                "void"
               ]
             }
           },
@@ -234,6 +235,21 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "cp"
+                            },
+                            {
+                              "u32": 0
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": 1
+                        }
                       }
                     ]
                   }
@@ -367,5 +383,54 @@
       ]
     ]
   },
-  "events": []
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "charged"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "amount"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 1000
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "merchant"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "subscription_id"
+                  },
+                  "val": {
+                    "u32": 0
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
 }

--- a/docs/multi_actor_scenarios.md
+++ b/docs/multi_actor_scenarios.md
@@ -1,0 +1,51 @@
+# Multi-Merchant and Multi-Subscriber Scenarios
+
+This document describes the integration-style tests and scenarios that validate the subscription vault with many actors (subscribers, merchants, subscriptions) interacting concurrently.
+
+## Purpose
+
+- **Correctness**: Verify balances, statuses, and view helpers when multiple subscriptions exist across different subscriber/merchant pairs.
+- **Stress**: Exercise internal indexing and accounting (subscription IDs, per-subscription state) under combined operations.
+- **Realism**: Reflect real-world usage: multiple merchants, subscribers with multiple subscriptions, batch charges, one-off and recurring mix.
+
+## Scenario Setup
+
+The multi-actor tests use a fixed topology:
+
+- **2 merchants**, **3 subscribers**.
+- **5 subscriptions**:
+  - Subscriber 0 → Merchant 0, Subscriber 0 → Merchant 1
+  - Subscriber 1 → Merchant 0, Subscriber 1 → Merchant 1
+  - Subscriber 2 → Merchant 0
+
+Each subscription is created with the same interval and amount, and receives an initial deposit so that charges can succeed.
+
+## Scenarios Covered
+
+1. **Balances and statuses after setup**  
+   All subscriptions are Active, have the expected subscriber/merchant and prepaid balance. Confirms `get_subscription` and storage consistency.
+
+2. **Batch charge all then verify**  
+   All 5 subscriptions are charged in one `batch_charge` call. Every result is success; each subscription’s balance and `last_payment_timestamp` are updated correctly.
+
+3. **One-off and recurring mixed**  
+   One-off charges are applied to two subscriptions (same merchant); then a batch charge runs for all. Verifies that one-off and interval-based charges share the same prepaid balance and that batch and single-charge semantics stay consistent.
+
+4. **Pause and resume subset**  
+   Two subscriptions are paused (different subscribers); a third stays active. Resume one of the paused. Confirms state transitions and that only the intended subscriptions change status.
+
+5. **Cancel one subscription, others unchanged**  
+   One subscription is cancelled; the rest remain Active. Confirms cancellation is isolated and does not affect other subscriptions.
+
+6. **View helpers consistent**  
+   For each subscription, `estimate_topup_for_intervals(0)` returns 0 and `estimate_topup_for_intervals(2)` matches the expected shortfall from current balance and amount. Validates query logic in a multi-subscription setup.
+
+## Expectations
+
+- **No cross-subscription leakage**: Operations on one subscription do not change another’s balance, status, or charged period.
+- **Batch and single charge parity**: Batch charge results and per-subscription state match what would occur from individual `charge_subscription` calls (subject to replay/period rules).
+- **Events and indexing**: Events are emitted per action; indexers can rely on subscription_id and merchant/subscriber for filtering (see events.md).
+
+## Performance
+
+Tests are kept fast by using a single env and a small, fixed number of actors (5 subscriptions). For heavier stress (e.g. many more IDs in one batch), consider running benchmarks or dedicated performance tests; the same invariants should hold.

--- a/docs/oneoff_charges.md
+++ b/docs/oneoff_charges.md
@@ -1,0 +1,45 @@
+# Merchant-Initiated One-Off Charges
+
+This document describes the one-off charge feature: merchant-authorized debits from a subscriber's prepaid balance, independent of the subscription's billing interval.
+
+## Overview
+
+`charge_one_off(subscription_id, merchant, amount)` lets the **merchant** debit a one-time `amount` from the subscription's prepaid balance. It is distinct from:
+
+- **Interval-based charges** (`charge_subscription`): triggered by the billing engine on a schedule; require admin auth.
+- **Subscription cancellation or modifications**: lifecycle actions by subscriber or merchant (pause, resume, cancel).
+
+One-off charges are intended for ad-hoc fees (e.g. overage, one-time add-ons) that the merchant is authorized to collect from the subscriber's existing prepaid balance.
+
+## Semantics
+
+- **Authorization**: The caller must be the subscription's **merchant** and must authorize the call (Soroban auth).
+- **Balance**: `amount` must be positive and must not exceed the subscription's `prepaid_balance`. No overdraft.
+- **Status**: The subscription must be **Active** or **Paused**. One-off charges are not allowed on Cancelled or InsufficientBalance.
+- **Effect**: `prepaid_balance` is decreased by `amount`. No change to `last_payment_timestamp` or interval logic. Funds are considered collected by the merchant (payout semantics are the same as for recurring charges; see merchant withdrawal).
+
+## Event
+
+**Topic:** `oneoff_ch`
+
+**Payload:** `OneOffChargedEvent { subscription_id, merchant, amount }`
+
+Indexers can use this to track one-off revenue and balance history alongside recurring `charged` events.
+
+## When to Use
+
+- One-time add-ons or overages within the same billing relationship.
+- Fees that both parties have agreed to debit from the existing prepaid balance.
+- When the merchant is trusted to initiate the debit (authorization is enforced on-chain).
+
+## When Not to Use
+
+- Do not use for recurring billing; use `charge_subscription` (or batch) with interval enforcement.
+- Do not use for subscription cancellation or refunds; use the lifecycle entrypoints (cancel, etc.).
+- Do not use when the subscriber has not prepaid enough; the call will fail with `InsufficientBalance`.
+
+## Security Notes
+
+- Only the subscription's merchant can call `charge_one_off` for that subscription; otherwise `Unauthorized` is returned.
+- Amount and balance checks prevent overdraft; safe math is used.
+- One-off and interval-based charges coexist: both debit from the same `prepaid_balance`. Ensure sufficient balance for both recurring and one-off usage.

--- a/docs/replay_protection.md
+++ b/docs/replay_protection.md
@@ -1,0 +1,55 @@
+# Replay Protection and Idempotency for Charges
+
+This document describes how the subscription vault prevents double-charging and how off-chain billing engines should integrate with it.
+
+## Overview
+
+Charge operations (`charge_subscription` and, internally, each item in `batch_charge`) are protected against:
+
+1. **Replay**: Charging the same billing period more than once.
+2. **Idempotent retries**: Allowing the same logical charge to be submitted multiple times (e.g. network retry) without double-debiting.
+
+Storage usage is kept bounded: one period index and optionally one idempotency key per subscription.
+
+## Mechanisms
+
+### Period-based key (always on)
+
+- For each subscription we record the **last charged billing period** as `period_index = now / interval_seconds` (integer division).
+- Before charging we require that the current period has not already been charged. If it has, the contract returns `Error::Replay`.
+- After a successful charge we store the current `period_index` for that subscription.
+- **Storage**: One `u64` per subscription (key: `("cp", subscription_id)`).
+
+### Optional idempotency key (caller-provided)
+
+- `charge_subscription(subscription_id, idempotency_key)` accepts an optional `Option<BytesN<32>>`.
+- If the caller supplies a key and we have already processed a charge for this subscription with the **same** key, we return `Ok(())` without changing state (idempotent success).
+- If the caller supplies a key and we have not seen it for this subscription, we perform the normal checks (period replay, interval, balance), then charge and store the key.
+- **Storage**: At most one idempotency key per subscription (key: `("idem", subscription_id)`). Supplying a new key for a new period overwrites the previous one.
+
+### Batch charge
+
+- `batch_charge(subscription_ids)` does **not** take idempotency keys. Each subscription is charged with period-based replay protection only. Duplicate IDs in the list are processed independently (each may succeed or fail per period/balance/interval).
+
+## Integrator responsibilities
+
+1. **Use one idempotency key per billing event.** For a given subscription and billing period, use a single stable key (e.g. derived from `subscription_id` + period start or from your job id). Retries with the same key are safe; using a new key for the same period will be rejected as `Replay` once the period was already charged.
+
+2. **Do not reuse keys across periods.** Use a new key for each new billing period so that the next charge is not mistaken for a replay of the previous period.
+
+3. **Handle `Error::Replay`.** If you receive `Replay`, the charge for that period was already applied (by this or a previous request). Treat as success for reporting; do not retry with a different key for the same period.
+
+4. **Optional but recommended:** Persist idempotency keys in your billing engine (e.g. per subscription and period) so that retries use the same key.
+
+## Required parameters and behavior (Rustdoc summary)
+
+- **`charge_subscription(env, subscription_id, idempotency_key)`**
+  - `idempotency_key`: `Option<BytesN<32>>`. Use `Some(key)` for safe retries; use `None` for period-only protection.
+  - Returns `Ok(())` on success or idempotent match (same key already processed).
+  - Returns `Err(Error::Replay)` if this billing period was already charged (and the call did not match a stored idempotency key).
+
+## Residual risks and mitigations
+
+- **Clock skew / timestamp manipulation:** Period is derived from ledger timestamp. Validators set ledger time; contract does not rely on caller-provided time. Mitigation: trust the network’s ledger timestamp.
+- **Unbounded growth:** Only one period index and one idempotency key per subscription are stored. No unbounded growth from replay protection.
+- **Key collision:** If an integrator reuses the same 32-byte key for two different billing periods, the second period’s charge would be treated as idempotent (return Ok without charging). Mitigation: derive keys from period (e.g. include period start or index in the key).


### PR DESCRIPTION
- Updated `charge_one` to accept an optional idempotency key, allowing safe retries without double-charging.
- Implemented period-based replay protection to prevent charges for the same billing period.
- Added new error types for replay and invalid amounts in `types.rs`.
- Introduced a new function `charge_one_off` for merchant-initiated one-time charges from a subscription's prepaid balance.
- Updated relevant tests to cover new idempotency and replay protection features.


Closes #24, #30, #40