### PR TITLE
feat: introduce migration-friendly hooks for future subscription vault

### DIFF
--- a/contracts/subscription_vault/test_snapshots/test/test_all_valid_transitions_coverage.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_all_valid_transitions_coverage.1.json
@@ -210,25 +210,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/contracts/subscription_vault/test_snapshots/test/test_all_valid_transitions_coverage.2.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_all_valid_transitions_coverage.2.json
@@ -210,25 +210,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/contracts/subscription_vault/test_snapshots/test/test_all_valid_transitions_coverage.3.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_all_valid_transitions_coverage.3.json
@@ -190,25 +190,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/contracts/subscription_vault/test_snapshots/test/test_all_valid_transitions_coverage.4.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_all_valid_transitions_coverage.4.json
@@ -232,25 +232,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/contracts/subscription_vault/test_snapshots/test/test_all_valid_transitions_coverage.5.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_all_valid_transitions_coverage.5.json
@@ -232,25 +232,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/contracts/subscription_vault/test_snapshots/test/test_all_valid_transitions_coverage.6.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_all_valid_transitions_coverage.6.json
@@ -212,25 +212,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/contracts/subscription_vault/test_snapshots/test/test_all_valid_transitions_coverage.7.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_all_valid_transitions_coverage.7.json
@@ -212,25 +212,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/contracts/subscription_vault/test_snapshots/test/test_cancel_subscription_from_active.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_cancel_subscription_from_active.1.json
@@ -210,25 +210,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/contracts/subscription_vault/test_snapshots/test/test_cancel_subscription_from_cancelled_is_idempotent.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_cancel_subscription_from_cancelled_is_idempotent.1.json
@@ -233,25 +233,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/contracts/subscription_vault/test_snapshots/test/test_cancel_subscription_from_paused.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_cancel_subscription_from_paused.1.json
@@ -232,25 +232,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/contracts/subscription_vault/test_snapshots/test/test_full_lifecycle_active_cancel.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_full_lifecycle_active_cancel.1.json
@@ -210,25 +210,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/contracts/subscription_vault/test_snapshots/test/test_full_lifecycle_active_pause_resume.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_full_lifecycle_active_pause_resume.1.json
@@ -256,25 +256,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/contracts/subscription_vault/test_snapshots/test/test_invalid_cancelled_to_active.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_invalid_cancelled_to_active.1.json
@@ -210,25 +210,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/contracts/subscription_vault/test_snapshots/test/test_invalid_insufficient_balance_to_paused.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_invalid_insufficient_balance_to_paused.1.json
@@ -190,25 +190,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/contracts/subscription_vault/test_snapshots/test/test_min_topup_above_threshold.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_min_topup_above_threshold.1.json
@@ -1,45 +1,11 @@
 {
   "generators": {
-    "address": 5,
+    "address": 4,
     "nonce": 0
   },
   "auth": [
     [],
     [],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "create_subscription",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 1000
-                  }
-                },
-                {
-                  "u64": 86400
-                },
-                {
-                  "bool": false
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
@@ -104,85 +70,6 @@
                     "storage": [
                       {
                         "key": {
-                          "u32": 0
-                        },
-                        "val": {
-                          "map": [
-                            {
-                              "key": {
-                                "symbol": "amount"
-                              },
-                              "val": {
-                                "i128": {
-                                  "hi": 0,
-                                  "lo": 1000
-                                }
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "interval_seconds"
-                              },
-                              "val": {
-                                "u64": 86400
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "last_payment_timestamp"
-                              },
-                              "val": {
-                                "u64": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "merchant"
-                              },
-                              "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "prepaid_balance"
-                              },
-                              "val": {
-                                "i128": {
-                                  "hi": 0,
-                                  "lo": 10000000
-                                }
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "status"
-                              },
-                              "val": {
-                                "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "subscriber"
-                              },
-                              "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "usage_enabled"
-                              },
-                              "val": {
-                                "bool": false
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
                           "symbol": "admin"
                         },
                         "val": {
@@ -202,37 +89,10 @@
                       },
                       {
                         "key": {
-                          "symbol": "next_id"
-                        },
-                        "val": {
-                          "u32": 1
-                        }
-                      },
-                      {
-                        "key": {
                           "symbol": "token"
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
                         }
                       }
                     ]
@@ -267,39 +127,6 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 5541220902715666415
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
                   }
                 },
                 "durability": "temporary",

--- a/contracts/subscription_vault/test_snapshots/test/test_min_topup_exactly_at_threshold.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_min_topup_exactly_at_threshold.1.json
@@ -1,45 +1,11 @@
 {
   "generators": {
-    "address": 5,
+    "address": 4,
     "nonce": 0
   },
   "auth": [
     [],
     [],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "create_subscription",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                },
-                {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 1000
-                  }
-                },
-                {
-                  "u64": 86400
-                },
-                {
-                  "bool": false
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
@@ -104,85 +70,6 @@
                     "storage": [
                       {
                         "key": {
-                          "u32": 0
-                        },
-                        "val": {
-                          "map": [
-                            {
-                              "key": {
-                                "symbol": "amount"
-                              },
-                              "val": {
-                                "i128": {
-                                  "hi": 0,
-                                  "lo": 1000
-                                }
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "interval_seconds"
-                              },
-                              "val": {
-                                "u64": 86400
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "last_payment_timestamp"
-                              },
-                              "val": {
-                                "u64": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "merchant"
-                              },
-                              "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "prepaid_balance"
-                              },
-                              "val": {
-                                "i128": {
-                                  "hi": 0,
-                                  "lo": 5000000
-                                }
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "status"
-                              },
-                              "val": {
-                                "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "subscriber"
-                              },
-                              "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "usage_enabled"
-                              },
-                              "val": {
-                                "bool": false
-                              }
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
                           "symbol": "admin"
                         },
                         "val": {
@@ -202,37 +89,10 @@
                       },
                       {
                         "key": {
-                          "symbol": "next_id"
-                        },
-                        "val": {
-                          "u32": 1
-                        }
-                      },
-                      {
-                        "key": {
                           "symbol": "token"
                         },
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
                         }
                       }
                     ]
@@ -267,39 +127,6 @@
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
-                  }
-                },
-                "durability": "temporary",
-                "val": "void"
-              }
-            },
-            "ext": "v0"
-          },
-          6311999
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-            "key": {
-              "ledger_key_nonce": {
-                "nonce": 5541220902715666415
-              }
-            },
-            "durability": "temporary"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-                "key": {
-                  "ledger_key_nonce": {
-                    "nonce": 5541220902715666415
                   }
                 },
                 "durability": "temporary",

--- a/contracts/subscription_vault/test_snapshots/test/test_pause_subscription_from_active.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_pause_subscription_from_active.1.json
@@ -210,25 +210,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/contracts/subscription_vault/test_snapshots/test/test_pause_subscription_from_cancelled_should_fail.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_pause_subscription_from_cancelled_should_fail.1.json
@@ -210,25 +210,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/contracts/subscription_vault/test_snapshots/test/test_pause_subscription_from_paused_is_idempotent.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_pause_subscription_from_paused_is_idempotent.1.json
@@ -233,25 +233,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/contracts/subscription_vault/test_snapshots/test/test_resume_subscription_from_cancelled_should_fail.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_resume_subscription_from_cancelled_should_fail.1.json
@@ -210,25 +210,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/contracts/subscription_vault/test_snapshots/test/test_resume_subscription_from_paused.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_resume_subscription_from_paused.1.json
@@ -232,25 +232,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/contracts/subscription_vault/test_snapshots/test/test_state_transition_idempotent_same_status.1.json
+++ b/contracts/subscription_vault/test_snapshots/test/test_state_transition_idempotent_same_status.1.json
@@ -210,25 +210,6 @@
                         "val": {
                           "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "MerchantSubs"
-                            },
-                            {
-                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "u32": 0
-                            }
-                          ]
-                        }
                       }
                     ]
                   }

--- a/docs/migration_hooks.md
+++ b/docs/migration_hooks.md
@@ -1,0 +1,65 @@
+# Migration Hooks (Subscription Vault)
+
+This document describes the migration-friendly hooks added to the contract to support
+future upgrades while preserving security and minimizing risk.
+
+## Goals and scope
+
+- Provide **admin-only**, **read-only** export hooks for contract and subscription state.
+- Keep exports **bounded** and **auditable** via events.
+- Avoid any mechanism that could **move funds**, **corrupt state**, or **weaken auth**.
+
+These hooks are intended for carefully managed upgrades only. They do not implement
+an automatic migration, and they do not enable cross-contract transfers.
+
+## Export hooks
+
+The following entrypoints are implemented in `contracts/subscription_vault/src/lib.rs`:
+
+- `export_contract_snapshot(admin)`
+  - Returns `ContractSnapshot` containing `admin`, `token`, `min_topup`, `next_id`,
+    `storage_version`, and a `timestamp`.
+  - Emits a `migration_contract_snapshot` event.
+
+- `export_subscription_summary(admin, subscription_id)`
+  - Returns `SubscriptionSummary` for a single subscription.
+  - Emits a `migration_export` event.
+
+- `export_subscription_summaries(admin, start_id, limit)`
+  - Returns a paginated list of `SubscriptionSummary` records.
+  - `limit` is capped at `MAX_EXPORT_LIMIT` (currently 100) to keep responses bounded.
+  - Emits a `migration_export` event that includes `start_id`, `limit`, and `exported`.
+
+All export functions require **admin authentication** and are read-only.
+
+## Control and authorization
+
+- Only the stored admin address can invoke export hooks.
+- Each export produces an event for auditability.
+- Export hooks do not alter balances, subscription status, or any storage keys.
+
+## Suggested migration flow
+
+1. Admin calls `export_contract_snapshot` to capture config and storage version.
+2. Admin iterates through subscriptions with `export_subscription_summaries` using
+   pagination (for example, `start_id = 0` and `limit = 100` until done).
+3. Off-chain tooling persists the exported summaries and validates:
+   - counts and IDs are consistent
+   - balances and statuses are as expected
+4. A new contract version is deployed and imported using a controlled, external
+   migration process (out of scope for this contract).
+
+## Security and limitations
+
+- Exports are **read-only** and **admin-only** to avoid weakening security.
+- No funds can be moved via these hooks.
+- The contract does **not** include a generic import hook; imports are intentionally
+  excluded to prevent misuse and to keep the surface area minimal.
+- Storage versioning is exposed as a constant (`STORAGE_VERSION = 1`) to support
+  migration tooling decisions.
+
+## Caveats
+
+- Export pagination is based on `next_id` and will skip missing IDs.
+- Event contents are meant for audit logs, not for replay-based migrations.
+- Any migration must be reviewed and validated off-chain before use.


### PR DESCRIPTION
Closes #31

---

 Summary

  - Added admin-only, read-only export hooks to support controlled migrations.
  - Introduced contract snapshot and subscription summary export structures.
  - Added bounded pagination and audit events for exports.
  - Added migration hook tests and new documentation.

  Details

  - New entrypoints:
      - export_contract_snapshot
      - export_subscription_summary
      - export_subscription_summaries (bounded by MAX_EXPORT_LIMIT)
  - All export paths require admin auth and do not mutate state or balances.
  - Documented migration patterns in docs/migration_hooks.md.
  - Tests added for admin-only access, pagination/limits, and non-mutation.

  Testing

  - cargo test -p subscription_vault