### PR TITLE
feat: add paginated billing statement view helper per subscription

### DIFF
--- a/contracts/subscription_vault/src/charge_core.rs
+++ b/contracts/subscription_vault/src/charge_core.rs
@@ -32,8 +32,11 @@
 
 use crate::queries::get_subscription;
 use crate::safe_math::safe_sub_balance;
+use crate::statements::append_statement;
 use crate::state_machine::validate_status_transition;
-use crate::types::{Error, LifetimeCapReachedEvent, SubscriptionChargedEvent, SubscriptionStatus};
+use crate::types::{
+    BillingChargeKind, Error, LifetimeCapReachedEvent, SubscriptionChargedEvent, SubscriptionStatus,
+};
 use soroban_sdk::{symbol_short, Env, Symbol};
 
 const KEY_CHARGED_PERIOD: Symbol = symbol_short!("cp");
@@ -181,6 +184,15 @@ pub fn charge_one(
             }
 
             storage.set(&subscription_id, &sub);
+            append_statement(
+                env,
+                subscription_id,
+                sub.amount,
+                sub.merchant.clone(),
+                BillingChargeKind::Interval,
+                next_allowed.saturating_sub(sub.interval_seconds),
+                now,
+            );
 
             // Record charged period and optional idempotency key (bounded storage)
             storage.set(&charged_period_key(subscription_id), &period_index);
@@ -345,5 +357,14 @@ pub fn charge_usage_one(env: &Env, subscription_id: u32, usage_amount: i128) -> 
     }
 
     env.storage().instance().set(&subscription_id, &sub);
+    append_statement(
+        env,
+        subscription_id,
+        usage_amount,
+        sub.merchant.clone(),
+        BillingChargeKind::Usage,
+        env.ledger().timestamp(),
+        env.ledger().timestamp(),
+    );
     Ok(())
 }

--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -15,6 +15,7 @@ mod queries;
 mod reentrancy;
 pub mod safe_math;
 mod state_machine;
+mod statements;
 mod subscription;
 mod types;
 
@@ -24,12 +25,12 @@ use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec};
 pub use queries::compute_next_charge_info;
 pub use state_machine::{can_transition, get_allowed_transitions, validate_status_transition};
 pub use types::{
-    BatchChargeResult, BatchWithdrawResult, CapInfo, ContractSnapshot, DataKey,
-    EmergencyStopDisabledEvent, EmergencyStopEnabledEvent, Error, FundsDepositedEvent,
-    LifetimeCapReachedEvent, MerchantWithdrawalEvent, MigrationExportEvent, NextChargeInfo,
-    OneOffChargedEvent, PlanTemplate, RecoveryEvent, RecoveryReason, Subscription,
-    SubscriptionCancelledEvent, SubscriptionChargedEvent, SubscriptionCreatedEvent,
-    SubscriptionPausedEvent, SubscriptionResumedEvent, SubscriptionStatus, SubscriptionSummary,
+    BatchChargeResult, BatchWithdrawResult, BillingChargeKind, BillingStatement, BillingStatementsPage,
+    CapInfo, ContractSnapshot, DataKey, EmergencyStopDisabledEvent, EmergencyStopEnabledEvent, Error,
+    FundsDepositedEvent, LifetimeCapReachedEvent, MerchantWithdrawalEvent, MigrationExportEvent,
+    NextChargeInfo, OneOffChargedEvent, PlanTemplate, RecoveryEvent, RecoveryReason, Subscription,
+    SubscriptionCancelledEvent, SubscriptionChargedEvent, SubscriptionCreatedEvent, SubscriptionPausedEvent,
+    SubscriptionResumedEvent, SubscriptionStatus, SubscriptionSummary,
 };
 
 /// Maximum subscription ID this contract will ever allocate.
@@ -540,6 +541,47 @@ impl SubscriptionVault {
     /// When no cap is configured all cap-related fields return `None` / `false`.
     pub fn get_cap_info(env: Env, subscription_id: u32) -> Result<CapInfo, Error> {
         queries::get_cap_info(&env, subscription_id)
+    }
+
+    /// Return subscription billing statements using offset/limit pagination.
+    ///
+    /// When `newest_first` is true (recommended for infinite scroll), offset 0
+    /// starts from the most recent statement.
+    pub fn get_sub_statements_offset(
+        env: Env,
+        subscription_id: u32,
+        offset: u32,
+        limit: u32,
+        newest_first: bool,
+    ) -> Result<BillingStatementsPage, Error> {
+        statements::get_statements_by_subscription_offset(
+            &env,
+            subscription_id,
+            offset,
+            limit,
+            newest_first,
+        )
+    }
+
+    /// Return subscription billing statements using cursor pagination.
+    ///
+    /// - `cursor`: sequence index to start from (inclusive); pass `None` for first page.
+    /// - `limit`: maximum number of statements to return.
+    /// - `newest_first`: return recent history first when true.
+    pub fn get_sub_statements_cursor(
+        env: Env,
+        subscription_id: u32,
+        cursor: Option<u32>,
+        limit: u32,
+        newest_first: bool,
+    ) -> Result<BillingStatementsPage, Error> {
+        statements::get_statements_by_subscription_cursor(
+            &env,
+            subscription_id,
+            cursor,
+            limit,
+            newest_first,
+        )
     }
 }
 

--- a/contracts/subscription_vault/src/statements.rs
+++ b/contracts/subscription_vault/src/statements.rs
@@ -1,0 +1,206 @@
+//! Billing statement append-only storage and paginated views.
+
+use crate::types::{BillingChargeKind, BillingStatement, BillingStatementsPage, Error};
+use soroban_sdk::{symbol_short, Address, Env, Symbol, Vec};
+
+const KEY_STATEMENT_NEXT: Symbol = symbol_short!("snext");
+const KEY_STATEMENT_ROW: Symbol = symbol_short!("srow");
+
+fn next_statement_key(subscription_id: u32) -> (Symbol, u32) {
+    (KEY_STATEMENT_NEXT, subscription_id)
+}
+
+fn statement_row_key(subscription_id: u32, sequence: u32) -> (Symbol, u32, u32) {
+    (KEY_STATEMENT_ROW, subscription_id, sequence)
+}
+
+pub fn append_statement(
+    env: &Env,
+    subscription_id: u32,
+    amount: i128,
+    merchant: Address,
+    kind: BillingChargeKind,
+    period_start: u64,
+    period_end: u64,
+) {
+    let storage = env.storage().instance();
+    let next: u32 = storage.get(&next_statement_key(subscription_id)).unwrap_or(0);
+    let statement = BillingStatement {
+        subscription_id,
+        sequence: next,
+        charged_at: env.ledger().timestamp(),
+        period_start,
+        period_end,
+        amount,
+        merchant,
+        kind,
+    };
+    storage.set(&statement_row_key(subscription_id, next), &statement);
+    storage.set(&next_statement_key(subscription_id), &(next + 1));
+}
+
+pub fn get_total_statements(env: &Env, subscription_id: u32) -> u32 {
+    env.storage()
+        .instance()
+        .get(&next_statement_key(subscription_id))
+        .unwrap_or(0)
+}
+
+/// Offset/limit pagination over immutable statements.
+///
+/// When `newest_first` is true, offset 0 returns most recent statement.
+pub fn get_statements_by_subscription_offset(
+    env: &Env,
+    subscription_id: u32,
+    offset: u32,
+    limit: u32,
+    newest_first: bool,
+) -> Result<BillingStatementsPage, Error> {
+    if limit == 0 {
+        return Err(Error::InvalidInput);
+    }
+
+    let total = get_total_statements(env, subscription_id);
+    if total == 0 || offset >= total {
+        return Ok(BillingStatementsPage {
+            statements: Vec::new(env),
+            next_cursor: None,
+            total,
+        });
+    }
+
+    let mut out = Vec::new(env);
+    let remaining = total - offset;
+    let page_len = if limit > remaining { remaining } else { limit };
+    let mut i = 0u32;
+    while i < page_len {
+        let seq = if newest_first {
+            total - 1 - (offset + i)
+        } else {
+            offset + i
+        };
+        if let Some(row) = env
+            .storage()
+            .instance()
+            .get::<_, BillingStatement>(&statement_row_key(subscription_id, seq))
+        {
+            out.push_back(row);
+        }
+        i += 1;
+    }
+
+    let consumed = offset + page_len;
+    let next_cursor = if consumed < total {
+        if newest_first {
+            Some(total - 1 - consumed)
+        } else {
+            Some(consumed)
+        }
+    } else {
+        None
+    };
+
+    Ok(BillingStatementsPage {
+        statements: out,
+        next_cursor,
+        total,
+    })
+}
+
+/// Cursor pagination.
+///
+/// `cursor` represents the sequence index to start from (inclusive).
+/// If `None`, starts from newest or oldest depending on `newest_first`.
+pub fn get_statements_by_subscription_cursor(
+    env: &Env,
+    subscription_id: u32,
+    cursor: Option<u32>,
+    limit: u32,
+    newest_first: bool,
+) -> Result<BillingStatementsPage, Error> {
+    if limit == 0 {
+        return Err(Error::InvalidInput);
+    }
+
+    let total = get_total_statements(env, subscription_id);
+    if total == 0 {
+        return Ok(BillingStatementsPage {
+            statements: Vec::new(env),
+            next_cursor: None,
+            total,
+        });
+    }
+
+    let start = match cursor {
+        Some(c) => c,
+        None => {
+            if newest_first {
+                total - 1
+            } else {
+                0
+            }
+        }
+    };
+
+    if start >= total {
+        return Ok(BillingStatementsPage {
+            statements: Vec::new(env),
+            next_cursor: None,
+            total,
+        });
+    }
+
+    let mut out = Vec::new(env);
+    let mut taken = 0u32;
+
+    if newest_first {
+        let mut seq = start;
+        loop {
+            if taken >= limit {
+                break;
+            }
+            if let Some(row) = env
+                .storage()
+                .instance()
+                .get::<_, BillingStatement>(&statement_row_key(subscription_id, seq))
+            {
+                out.push_back(row);
+                taken += 1;
+            }
+            if seq == 0 {
+                break;
+            }
+            seq -= 1;
+        }
+        let next_cursor = if start + 1 > taken {
+            Some(start - taken)
+        } else {
+            None
+        };
+        return Ok(BillingStatementsPage {
+            statements: out,
+            next_cursor,
+            total,
+        });
+    }
+
+    let mut seq = start;
+    while seq < total && taken < limit {
+        if let Some(row) = env
+            .storage()
+            .instance()
+            .get::<_, BillingStatement>(&statement_row_key(subscription_id, seq))
+        {
+            out.push_back(row);
+            taken += 1;
+        }
+        seq += 1;
+    }
+    let next_cursor = if seq < total { Some(seq) } else { None };
+
+    Ok(BillingStatementsPage {
+        statements: out,
+        next_cursor,
+        total,
+    })
+}

--- a/contracts/subscription_vault/src/subscription.rs
+++ b/contracts/subscription_vault/src/subscription.rs
@@ -23,8 +23,9 @@
 
 use crate::queries::get_subscription;
 use crate::safe_math::{safe_add_balance, validate_non_negative};
+use crate::statements::append_statement;
 use crate::state_machine::validate_status_transition;
-use crate::types::{DataKey, Error, PlanTemplate, Subscription, SubscriptionStatus};
+use crate::types::{BillingChargeKind, DataKey, Error, PlanTemplate, Subscription, SubscriptionStatus};
 use soroban_sdk::{symbol_short, Address, Env, Symbol, Vec};
 
 #[allow(dead_code)]
@@ -254,6 +255,15 @@ pub fn do_charge_one_off(
         .ok_or(Error::Overflow)?;
 
     env.storage().instance().set(&subscription_id, &sub);
+    append_statement(
+        env,
+        subscription_id,
+        amount,
+        sub.merchant.clone(),
+        BillingChargeKind::OneOff,
+        env.ledger().timestamp(),
+        env.ledger().timestamp(),
+    );
     Ok(())
 }
 

--- a/contracts/subscription_vault/src/test.rs
+++ b/contracts/subscription_vault/src/test.rs
@@ -1971,3 +1971,84 @@ fn test_reentrancy_protection_documentation() {
 
     assert!(true); // Placeholder to indicate test passed
 }
+
+#[test]
+fn test_billing_statements_offset_pagination_newest_first() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(T0);
+    let (client, token, _admin) = setup_contract(&env);
+
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&subscriber, &1_000_000_000i128);
+
+    let id = client.create_subscription(
+        &subscriber,
+        &merchant,
+        &1_000_000i128,
+        &INTERVAL,
+        &true,
+        &None::<i128>,
+    );
+    client.deposit_funds(&id, &subscriber, &200_000_000i128);
+
+    for i in 1..=6 {
+        env.ledger().set_timestamp(T0 + (i as u64 * INTERVAL));
+        client.charge_subscription(&id);
+    }
+
+    let page1 = client.get_sub_statements_offset(&id, &0, &2, &true);
+    assert_eq!(page1.total, 6);
+    assert_eq!(page1.statements.len(), 2);
+    assert_eq!(page1.statements.get(0).unwrap().sequence, 5);
+    assert_eq!(page1.statements.get(1).unwrap().sequence, 4);
+
+    let page2 = client.get_sub_statements_offset(&id, &2, &2, &true);
+    assert_eq!(page2.statements.len(), 2);
+    assert_eq!(page2.statements.get(0).unwrap().sequence, 3);
+    assert_eq!(page2.statements.get(1).unwrap().sequence, 2);
+}
+
+#[test]
+fn test_billing_statements_cursor_pagination_boundaries() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(T0);
+    let (client, token, _admin) = setup_contract(&env);
+
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&subscriber, &1_000_000_000i128);
+
+    let id = client.create_subscription(
+        &subscriber,
+        &merchant,
+        &1_000_000i128,
+        &INTERVAL,
+        &true,
+        &None::<i128>,
+    );
+    client.deposit_funds(&id, &subscriber, &200_000_000i128);
+
+    for i in 1..=4 {
+        env.ledger().set_timestamp(T0 + (i as u64 * INTERVAL));
+        client.charge_subscription(&id);
+    }
+
+    let first = client.get_sub_statements_cursor(&id, &None::<u32>, &3, &true);
+    assert_eq!(first.statements.len(), 3);
+    assert_eq!(first.statements.get(0).unwrap().sequence, 3);
+    assert_eq!(first.statements.get(2).unwrap().sequence, 1);
+    assert_eq!(first.next_cursor, Some(0));
+
+    let second = client.get_sub_statements_cursor(&id, &first.next_cursor, &3, &true);
+    assert_eq!(second.statements.len(), 1);
+    assert_eq!(second.statements.get(0).unwrap().sequence, 0);
+    assert_eq!(second.next_cursor, None);
+
+    let invalid_cursor = client.get_sub_statements_cursor(&id, &Some(99u32), &2, &true);
+    assert_eq!(invalid_cursor.statements.len(), 0);
+    assert_eq!(invalid_cursor.next_cursor, None);
+    assert_eq!(invalid_cursor.total, 4);
+}

--- a/contracts/subscription_vault/src/types.rs
+++ b/contracts/subscription_vault/src/types.rs
@@ -3,7 +3,7 @@
 //! Kept in a separate module to reduce merge conflicts when editing state machine
 //! or contract entrypoints.
 
-use soroban_sdk::{contracterror, contracttype, Address};
+use soroban_sdk::{contracterror, contracttype, Address, Vec};
 
 /// Storage keys for secondary indices.
 #[contracttype]
@@ -323,6 +323,45 @@ pub struct CapInfo {
     pub remaining_cap: Option<i128>,
     /// True when the cap has been reached and no further charges are allowed.
     pub cap_reached: bool,
+}
+
+/// Canonical charge category used for billing statement history.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BillingChargeKind {
+    Interval = 0,
+    Usage = 1,
+    OneOff = 2,
+}
+
+/// Immutable billing statement row for a subscription charge action.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BillingStatement {
+    pub subscription_id: u32,
+    /// Monotonic per-subscription sequence number (starts at 0).
+    pub sequence: u32,
+    /// Timestamp the charge operation was processed.
+    pub charged_at: u64,
+    /// Charge period start, in ledger timestamp seconds.
+    pub period_start: u64,
+    /// Charge period end, in ledger timestamp seconds.
+    pub period_end: u64,
+    /// Debited amount in token base units.
+    pub amount: i128,
+    pub merchant: Address,
+    pub kind: BillingChargeKind,
+}
+
+/// Paginated page of billing statements.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct BillingStatementsPage {
+    pub statements: Vec<BillingStatement>,
+    /// Cursor for the next page. `None` means no more rows.
+    pub next_cursor: Option<u32>,
+    /// Total statements recorded for the subscription.
+    pub total: u32,
 }
 
 /// Event emitted when emergency stop is enabled.

--- a/docs/view_statements_by_subscription.md
+++ b/docs/view_statements_by_subscription.md
@@ -1,0 +1,82 @@
+# View helper: billing statements by subscription
+
+This contract exposes a dedicated read-only view for billing history pages:
+
+- `get_sub_statements_offset(subscription_id, offset, limit, newest_first)`
+- `get_sub_statements_cursor(subscription_id, cursor, limit, newest_first)`
+
+## Data model
+
+Each successful charge appends an immutable `BillingStatement` row keyed by:
+
+- `(subscription_id, sequence)`
+- `sequence` is monotonic per subscription and starts at `0`
+
+Rows include:
+
+- `subscription_id`
+- `sequence`
+- `charged_at`
+- `period_start`
+- `period_end`
+- `amount`
+- `merchant`
+- `kind` (`Interval`, `Usage`, `OneOff`)
+
+## Ordering
+
+Both APIs support deterministic ordering via `newest_first`:
+
+- `true`: reverse chronological by sequence (latest first)
+- `false`: chronological by sequence (oldest first)
+
+Because sequence values are append-only and never rewritten, pagination remains stable across new inserts.
+
+## Pagination strategies
+
+### Offset/limit
+
+Use for classic page-number style UIs.
+
+- `offset` is zero-based
+- `limit` must be greater than `0`
+- response includes `total` and optional `next_cursor`
+
+### Cursor
+
+Use for infinite-scroll or "load more" pages.
+
+- `cursor` is an inclusive sequence index
+- for first page pass `None`
+- response includes `next_cursor`; `None` means end of history
+
+## Client usage examples
+
+Offset/limit:
+
+```rust
+let page = client.get_sub_statements_offset(
+    &subscription_id,
+    &0u32,
+    &20u32,
+    &true,
+);
+```
+
+Cursor:
+
+```rust
+let first = client.get_sub_statements_cursor(
+    &subscription_id,
+    &None::<u32>,
+    &20u32,
+    &true,
+);
+
+let next = client.get_sub_statements_cursor(
+    &subscription_id,
+    &first.next_cursor,
+    &20u32,
+    &true,
+);
+```


### PR DESCRIPTION
Add append-only billing statement indexing and read-only offset/cursor views for subscription history pages. This enables deterministic newest-first pagination for infinite scroll and load-more clients.
closes #132