### PR TITLE
feat: restrict charging to authorized admin

### DIFF
--- a/contracts/subscription_vault/src/admin.rs
+++ b/contracts/subscription_vault/src/admin.rs
@@ -1,4 +1,4 @@
-//! Admin and config: init, min_topup, batch_charge.
+//! Admin and config: init, min_topup, batch_charge, single charge.
 //!
 //! **PRs that only change admin or batch behavior should edit this file only.**
 
@@ -8,7 +8,7 @@ use crate::types::{
     AcceptedToken, AdminRotatedEvent, BatchChargeResult, DataKey, Error, RecoveryEvent,
     RecoveryReason,
 };
-use crate::{charge_core::charge_one, ChargeExecutionResult};
+use crate::{charge_core::{charge_one, charge_usage_one}, ChargeExecutionResult};
 use soroban_sdk::{token, Address, Env, String, Symbol, Vec};
 
 fn accepted_tokens_key(env: &Env) -> Symbol {
@@ -211,6 +211,29 @@ pub fn do_batch_charge(
         results.push_back(res);
     }
     Ok(results)
+}
+
+/// Performs a single interval-based charge. Admin only.
+pub fn do_charge_subscription(
+    env: &Env,
+    subscription_id: u32,
+) -> Result<ChargeExecutionResult, Error> {
+    let _admin = require_stored_admin_auth(env)?;
+
+    let now = env.ledger().timestamp();
+    charge_one(env, subscription_id, now, None)
+}
+
+/// Performs a single usage-based charge. Admin only.
+pub fn do_charge_usage(
+    env: &Env,
+    subscription_id: u32,
+    usage_amount: i128,
+    reference: String,
+) -> Result<(), Error> {
+    let _admin = require_stored_admin_auth(env)?;
+
+    charge_usage_one(env, subscription_id, usage_amount, reference)
 }
 
 pub fn do_get_admin(env: &Env) -> Result<Address, Error> {

--- a/docs/admin_authorization_matrix.md
+++ b/docs/admin_authorization_matrix.md
@@ -37,6 +37,8 @@ the host layer when no signature is present.
 | `set_oracle_config` | Explicit `admin` arg must equal stored admin | `Unauthorized` | `Unauthorized` | Config validation happens after auth |
 | `remove_from_blocklist` | Explicit `admin` arg must equal stored admin | `Unauthorized` | `Unauthorized` | Uses the same centralized guard |
 | `set_protocol_fee` | Explicit `admin` arg must equal stored admin | `Forbidden` | `Forbidden` | Uses direct admin check, returns `Forbidden` not `Unauthorized` |
+| `charge_subscription` | Stored admin is loaded from state and must sign | Host auth failure if unsigned | New admin signature required after rotation | Single interval charge |
+| `charge_usage` | Stored admin is loaded from state and must sign | Host auth failure if unsigned | New admin signature required after rotation | Metered usage charge |
 | `batch_charge` | Stored admin is loaded from state and must sign | Host auth failure if unsigned | New admin signature required after rotation | No caller-supplied admin parameter |
 
 ## Rotation and replay notes
@@ -44,10 +46,10 @@ the host layer when no signature is present.
 - Admin rotation is atomic: once `rotate_admin` succeeds, the old admin loses
   access to all admin-only routes in the same state version.
 - Reusing an old auth context after rotation must fail as `Unauthorized` for
-  explicit-admin routes.
-- `batch_charge` is the one exception to the explicit-admin pattern because it
-  reads the stored admin internally; after rotation, only the new stored admin's
-  signature satisfies the host auth check.
+  explicit-admin routes and host auth failure for stored-admin routes.
+- `batch_charge`, `charge_subscription`, and `charge_usage` are the exceptions to the
+  explicit-admin pattern because they read the stored admin internally; after rotation,
+  only the new stored admin's signature satisfies the host auth check.
 
 ## Reviewer Checklist for New Admin Entrypoints
 


### PR DESCRIPTION
Closes #274 
## 🔒 Feat: Enforce Admin-Only Authorization for Billing Execution

Hardens billing execution by enforcing stored-admin authorization for both single-subscription charges and metered usage charges, following established patterns in the repository.

### Changes

**`contracts/subscription_vault/src/admin.rs`**
- Added `do_charge_subscription()` — admin-only single interval-based charge using `require_stored_admin_auth(env)`
- Added `do_charge_usage()` — admin-only metered usage charge with the same stored-admin guard
- Core charging logic in `charge_core.rs` remains clean and reusable for batch operations where auth is checked once per transaction
- Updated module imports and documentation

**`docs/admin_authorization_matrix.md`**
- Added `charge_subscription` and `charge_usage` to the Admin Authorization Matrix
- Documented authorization model as "Stored admin" consistent with `batch_charge`
- Updated rotation and replay notes to include new entrypoints as exceptions to the explicit-admin parameter pattern

### Security Notes
- `require_stored_admin_auth(env)` loads the admin from instance storage and calls `admin.require_auth()` — the Soroban host rejects any transaction not signed by the stored admin
- Admin rotation via `rotate_admin` immediately revokes the old admin's charging privileges
- `batch_charge` continues to perform a single authorization check for the entire batch — no redundant per-subscription checks introduced