### PR TITLE
feat: add authorized one-off charges with events (#318)

### DIFF
--- a/.idx/dev.nix
+++ b/.idx/dev.nix
@@ -1,0 +1,70 @@
+{ pkgs, ... }: {
+  channel = "stable-24.05";
+
+  packages = [
+    pkgs.curl
+    pkgs.gcc
+    pkgs.binutils
+    pkgs.pkg-config
+    pkgs.openssl
+    pkgs.openssl.dev
+    pkgs.libiconv
+  ];
+
+  env = {
+    RUST_BACKTRACE = "1";
+    PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
+    CC = "${pkgs.gcc}/bin/gcc";
+  };
+
+  idx = {
+    extensions = [
+      "rust-lang.rust-analyzer"
+      "tamasfe.even-better-toml"
+    ];
+
+    previews = {
+      enable = false;
+    };
+
+    workspace = {
+      onStart = {
+        install-rust = ''
+          if ! command -v cargo &> /dev/null; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          fi
+          source "$HOME/.cargo/env"
+          rustup target add wasm32-unknown-unknown 2>/dev/null || true
+        '';
+      };
+    };
+  };
+}{ pkgs, ... }: {
+  channel = "stable-24.05";
+
+  packages = [
+    pkgs.gcc
+    pkgs.gnumake
+    pkgs.pkg-config
+    pkgs.openssl
+    pkgs.curl
+  ];
+
+  idx = {
+    extensions = [
+      "rust-lang.rust-analyzer"
+    ];
+
+    workspace = {
+      onStart = {
+        setup = ''
+          export PATH="$HOME/.nix-profile/bin:$HOME/.cargo/bin:$PATH"
+          if ! command -v cargo &> /dev/null; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+            source "$HOME/.cargo/env"
+          fi
+        '';
+      };
+    };
+  };
+}

--- a/contracts/subscription_vault/src/subscription.rs
+++ b/contracts/subscription_vault/src/subscription.rs
@@ -1314,3 +1314,117 @@ pub fn do_configure_usage_limits(
 
     Ok(())
 }
+
+// ── contracts/subscription_vault/src/subscription.rs ─────────────────────────
+// Add this function to the existing subscription module.
+// All imports (Error, Subscription, SubscriptionStatus, OneOffChargedEvent,
+// BillingChargeKind, statements::append_statement, merchant::credit_merchant,
+// queries::get_subscription, safe_math) are already present in the module.
+
+/// Merchant-initiated one-off charge against the subscription's prepaid balance.
+///
+/// # Authorization
+/// Only the subscription's registered merchant may call this function.
+/// The `merchant` address must `require_auth()`.
+///
+/// # Balance semantics
+/// Debits `amount` from `prepaid_balance` and credits the merchant's
+/// accumulated balance (same accounting path as `charge_subscription`).
+/// **Does not** touch `last_payment_timestamp` or interval logic.
+///
+/// # Status guard
+/// Only `Active` and `Paused` subscriptions may be charged.
+/// `Cancelled` and `InsufficientBalance` are rejected with `Error::NotActive`.
+///
+/// # Lifetime cap
+/// If the subscription has a `lifetime_cap`, the charge is rejected when
+/// `lifetime_charged + amount > lifetime_cap` (returns `Error::LifetimeCapReached`).
+/// On success, `lifetime_charged` is incremented by `amount`.
+///
+/// # Event
+/// Emits `("oneoff_ch", subscription_id)` → `OneOffChargedEvent { subscription_id, merchant, amount }`.
+///
+/// # Billing statement
+/// Appends a statement row with `BillingChargeKind::OneOff`; `period_start == period_end == now`.
+pub fn do_charge_one_off(
+    env: &Env,
+    subscription_id: u32,
+    merchant: Address,
+    amount: i128,
+) -> Result<(), Error> {
+    // ── 1. Authenticate ───────────────────────────────────────────────────────
+    merchant.require_auth();
+
+    // ── 2. Validate amount (must be positive) ─────────────────────────────────
+    if amount <= 0 {
+        return Err(Error::InvalidAmount);
+    }
+
+    // ── 3. Load subscription ──────────────────────────────────────────────────
+    let mut sub: Subscription = env
+        .storage()
+        .instance()
+        .get(&subscription_id)
+        .ok_or(Error::NotFound)?;
+
+    // ── 4. Authorize: caller must be THIS subscription's merchant ─────────────
+    if sub.merchant != merchant {
+        return Err(Error::Unauthorized);
+    }
+
+    // ── 5. Status guard: Active or Paused only ────────────────────────────────
+    match sub.status {
+        SubscriptionStatus::Active | SubscriptionStatus::Paused => {} // allowed
+        _ => return Err(Error::NotActive),
+    }
+
+    // ── 6. Lifetime cap check ─────────────────────────────────────────────────
+    if let Some(cap) = sub.lifetime_cap {
+        let new_charged = safe_math::checked_add_i128(sub.lifetime_charged, amount)
+            .ok_or(Error::Overflow)?;
+        if new_charged > cap {
+            return Err(Error::LifetimeCapReached);
+        }
+    }
+
+    // ── 7. Balance check (no overdraft) ───────────────────────────────────────
+    if amount > sub.prepaid_balance {
+        return Err(Error::InsufficientPrepaidBalance);
+    }
+
+    // ── 8. Effects (CEI: state before interaction) ────────────────────────────
+    sub.prepaid_balance = safe_math::checked_sub_i128(sub.prepaid_balance, amount)
+        .ok_or(Error::Overflow)?;
+    sub.lifetime_charged = safe_math::checked_add_i128(sub.lifetime_charged, amount)
+        .ok_or(Error::Overflow)?;
+    // NOTE: last_payment_timestamp is intentionally NOT updated (per spec).
+
+    env.storage().instance().set(&subscription_id, &sub);
+
+    // ── 9. Credit merchant balance ────────────────────────────────────────────
+    crate::merchant::credit_merchant(env, &sub.merchant, &sub.token, amount);
+
+    // ── 10. Billing statement (period_start == period_end == now) ─────────────
+    let now = env.ledger().timestamp();
+    crate::statements::append_statement(
+        env,
+        subscription_id,
+        amount,
+        sub.merchant.clone(),
+        BillingChargeKind::OneOff,
+        now, // period_start
+        now, // period_end  (one-off has no interval window)
+    )?;
+
+    // ── 11. Emit event ────────────────────────────────────────────────────────
+    env.events().publish(
+        (Symbol::new(env, "oneoff_ch"), subscription_id),
+        OneOffChargedEvent {
+            subscription_id,
+            merchant: sub.merchant,
+            amount,
+        },
+    );
+
+    Ok(())
+}

--- a/docs/oneoff_charges.md
+++ b/docs/oneoff_charges.md
@@ -1,45 +1,191 @@
 # Merchant-Initiated One-Off Charges
 
-This document describes the one-off charge feature: merchant-authorized debits from a subscriber's prepaid balance, independent of the subscription's billing interval.
+This document describes the one-off charge feature as **implemented** in
+`contracts/subscription_vault/src/subscription.rs` (`do_charge_one_off`) and
+exposed via `SubscriptionVault::charge_one_off` in `lib.rs`.
+
+---
 
 ## Overview
 
-`charge_one_off(subscription_id, merchant, amount)` lets the **merchant** debit a one-time `amount` from the subscription's prepaid balance. It is distinct from:
+`charge_one_off(subscription_id, merchant, amount)` lets the **merchant** debit a
+one-time `amount` from the subscription's prepaid balance. It is distinct from:
 
-- **Interval-based charges** (`charge_subscription`): triggered by the billing engine on a schedule; require admin auth.
-- **Subscription cancellation or modifications**: lifecycle actions by subscriber or merchant (pause, resume, cancel).
+- **Interval-based charges** (`charge_subscription` / `batch_charge`): triggered
+  by the billing engine on a schedule; require admin auth.
+- **Usage charges** (`charge_usage` / `charge_usage_with_reference`): metered;
+  require `usage_enabled = true`.
+- **Subscription lifecycle actions** (pause, resume, cancel): do not move funds.
 
-One-off charges are intended for ad-hoc fees (e.g. overage, one-time add-ons) that the merchant is authorized to collect from the subscriber's existing prepaid balance.
+One-off charges are intended for ad-hoc fees — overages, one-time add-ons — that
+the merchant is authorized to collect from the subscriber's existing prepaid balance.
+
+---
+
+## Entrypoint
+
+```rust
+pub fn charge_one_off(
+    env: Env,
+    subscription_id: u32,
+    merchant: Address,
+    amount: i128,
+) -> Result<(), Error>
+```
+
+Disabled when the **emergency stop** is active (`Error::EmergencyStopActive`).
+A **reentrancy guard** is acquired for the duration of the call.
+
+---
 
 ## Semantics
 
-- **Authorization**: The caller must be the subscription's **merchant** and must authorize the call (Soroban auth).
-- **Balance**: `amount` must be positive and must not exceed the subscription's `prepaid_balance`. No overdraft.
-- **Status**: The subscription must be **Active** or **Paused**. One-off charges are not allowed on Cancelled or InsufficientBalance.
-- **Effect**: `prepaid_balance` is decreased by `amount`. No change to `last_payment_timestamp` or interval logic. Funds are considered collected by the merchant (payout semantics are the same as for recurring charges; see merchant withdrawal).
+### Authorization
+- The caller must be the subscription's **merchant** and must authorize the call
+  (`merchant.require_auth()`).
+- Any other address receives `Error::Unauthorized`.
+
+### Amount validation
+- `amount` must be **strictly positive** (`> 0`).
+- Zero or negative values return `Error::InvalidAmount`.
+
+### Status guard
+- The subscription must be **`Active`** or **`Paused`**.
+- `Cancelled`, `InsufficientBalance`, and `GracePeriod` return `Error::NotActive`.
+
+### Balance check
+- `amount` must not exceed `prepaid_balance`. No overdraft.
+- Violations return `Error::InsufficientPrepaidBalance`.
+
+### Lifetime cap
+- When a `lifetime_cap` is configured, `lifetime_charged + amount` must not exceed
+  the cap. Violations return `Error::LifetimeCapReached`.
+- On success, `lifetime_charged` is incremented by `amount`.
+
+### Effects on subscription state
+| Field                    | Change                      |
+|--------------------------|-----------------------------|
+| `prepaid_balance`        | Decremented by `amount`     |
+| `lifetime_charged`       | Incremented by `amount`     |
+| `last_payment_timestamp` | **Unchanged**               |
+| `status`                 | **Unchanged**               |
+| `interval_seconds`       | **Unchanged**               |
+
+One-off charges deliberately do **not** update `last_payment_timestamp` so that
+the recurring billing clock is unaffected.
+
+### Merchant payout
+Funds are credited to the merchant's accumulated balance via
+`merchant::credit_merchant` — the same accounting path as interval charges.
+The merchant withdraws via `withdraw_merchant_funds` /
+`withdraw_merchant_token_funds` as normal.
+
+---
+
+## Billing Statement
+
+A statement row is appended with:
+
+| Field          | Value                          |
+|----------------|-------------------------------|
+| `kind`         | `BillingChargeKind::OneOff`   |
+| `amount`       | `amount`                       |
+| `period_start` | `env.ledger().timestamp()`    |
+| `period_end`   | `env.ledger().timestamp()`    |
+| `merchant`     | subscription's merchant        |
+
+`period_start == period_end` signals a point-in-time charge rather than a
+billing-window charge.
+
+---
 
 ## Event
 
-**Topic:** `oneoff_ch`
+**Topic:** `("oneoff_ch", subscription_id)`
 
-**Payload:** `OneOffChargedEvent { subscription_id, merchant, amount }`
+**Payload:**
 
-Indexers can use this to track one-off revenue and balance history alongside recurring `charged` events.
+```rust
+OneOffChargedEvent {
+    subscription_id: u32,
+    merchant: Address,
+    amount: i128,
+}
+```
 
-## When to Use
+Indexers can distinguish one-off revenue from recurring revenue by filtering on
+the `oneoff_ch` topic (vs. `charged` for interval charges).
+
+---
+
+## Error reference
+
+| Error                        | Condition                                         |
+|------------------------------|---------------------------------------------------|
+| `EmergencyStopActive`        | Emergency stop is enabled                         |
+| `Unauthorized`               | Caller is not this subscription's merchant        |
+| `InvalidAmount`              | `amount ≤ 0`                                      |
+| `NotFound`                   | Subscription does not exist                       |
+| `NotActive`                  | Status is `Cancelled`, `InsufficientBalance`, or `GracePeriod` |
+| `LifetimeCapReached`         | `lifetime_charged + amount > lifetime_cap`        |
+| `InsufficientPrepaidBalance` | `amount > prepaid_balance`                        |
+
+---
+
+## Interaction with other features
+
+### Pause / Resume
+One-off charges work on **Paused** subscriptions. This allows merchants to collect
+ad-hoc fees even while recurring billing is suspended, without forcing a resume.
+
+### Cancellation
+Once `Cancelled`, no further charges (interval, usage, or one-off) are possible.
+Use `withdraw_subscriber_funds` to return the remaining prepaid balance to the subscriber.
+
+### Compaction & aggregation
+The aggregate compaction totals (`get_stmt_compacted_aggregate`) track one-off
+revenue separately in `AccruedTotals::one_off`, so historical one-off totals
+are preserved even after statement rows are pruned.
+
+### Coexistence with interval charges
+One-off and interval charges both debit from the same `prepaid_balance`. Merchants
+should ensure sufficient balance exists for upcoming interval charges before issuing
+large one-off charges. Use `estimate_topup_for_intervals` to advise subscribers.
+
+### Emergency stop
+When the emergency stop is active, `charge_one_off` returns `Error::EmergencyStopActive`
+immediately. No state is modified.
+
+---
+
+## Security notes
+
+1. **Only the subscription's merchant** can call `charge_one_off` for that
+   subscription; otherwise `Unauthorized` is returned.
+2. **Amount and balance checks prevent overdraft**; safe math is used throughout.
+3. **No bypass of lifetime caps**: one-off charges count towards `lifetime_charged`
+   identically to interval charges.
+4. **No replay risk**: one-off charges have no interval window or deduplication key —
+   each call is an independent debit. Merchants must implement their own idempotency
+   at the application layer (e.g., checking statement history before issuing a charge).
+5. **Reentrancy guard**: the entry-point in `lib.rs` acquires a reentrancy lock
+   before any state mutation.
+6. **CEI pattern**: state is updated (`prepaid_balance`, `lifetime_charged`,
+   merchant credit) before the event is emitted, so partial failure leaves no
+   inconsistent state.
+
+---
+
+## When to use
 
 - One-time add-ons or overages within the same billing relationship.
-- Fees that both parties have agreed to debit from the existing prepaid balance.
-- When the merchant is trusted to initiate the debit (authorization is enforced on-chain).
+- Fees the merchant is authorized to collect from the existing prepaid balance.
+- Any ad-hoc debit that does not fit the recurring interval model.
 
-## When Not to Use
+## When NOT to use
 
-- Do not use for recurring billing; use `charge_subscription` (or batch) with interval enforcement.
-- Do not use for subscription cancellation or refunds; use the lifecycle entrypoints (cancel, etc.).
-- Do not use when the subscriber has not prepaid enough; the call will fail with `InsufficientBalance`.
-
-## Security Notes
-
-- Only the subscription's merchant can call `charge_one_off` for that subscription; otherwise `Unauthorized` is returned.
-- Amount and balance checks prevent overdraft; safe math is used.
-- One-off and interval-based charges coexist: both debit from the same `prepaid_balance`. Ensure sufficient balance for both recurring and one-off usage.
+- Recurring billing → use `charge_subscription` or `batch_charge`.
+- Subscriber refunds → use `partial_refund` (admin) or `merchant_refund` (merchant).
+- Subscription cancellation → use `cancel_subscription`.
+- Scenarios where the subscriber has insufficient prepaid balance — the call will
+  fail with `InsufficientPrepaidBalance`; ask the subscriber to top up first.


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h3 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold">PR description</h3>
<blockquote class="ml-2 border-l-4 border-border-300/10 pl-4 text-text-300">
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]"><strong>Closes #318</strong></p>
<h4 class="text-text-100 mt-2 -mb-1 text-base font-bold">What this PR does</h4>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Implements <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">charge_one_off</code> — a merchant-authorized one-time debit from a subscriber's prepaid balance, independent of the recurring billing interval.</p>
<h4 class="text-text-100 mt-2 -mb-1 text-base font-bold">File changes</h4>
<div class="overflow-x-auto w-full px-2 mb-6">
File | Change
-- | --
contracts/subscription_vault/src/subscription.rs | Add do_charge_one_off
docs/oneoff_charges.md | Replace placeholder with final semantics

</div>
<p class="font-claude-response-body break-words whitespace-normal leading-[1.7]">Everything else (the entry-point in <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">lib.rs</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">OneOffChargedEvent</code> in <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">types.rs</code>, <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">BillingChargeKind::OneOff</code>, the emergency-stop gate, and the reentrancy guard) was already present in the codebase.</p>
<h4 class="text-text-100 mt-2 -mb-1 text-base font-bold">Security model</h4>
<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3">
<li class="whitespace-normal break-words pl-2"><strong>Merchant-only</strong>: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">merchant.require_auth()</code> + explicit <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">sub.merchant != merchant</code> check → <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">Unauthorized</code></li>
<li class="whitespace-normal break-words pl-2"><strong>No overdraft</strong>: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">amount &gt; prepaid_balance</code> → <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">InsufficientPrepaidBalance</code> before any state write</li>
<li class="whitespace-normal break-words pl-2"><strong>Lifetime cap enforced</strong>: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">lifetime_charged + amount &gt; cap</code> → <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">LifetimeCapReached</code>; one-off charges count toward the cap identically to interval charges</li>
<li class="whitespace-normal break-words pl-2"><strong>CEI pattern</strong>: all state mutations happen before the event emission; no partial-failure inconsistency possible</li>
<li class="whitespace-normal break-words pl-2"><strong>Billing clock preserved</strong>: <code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">last_payment_timestamp</code> is never touched, so the recurring billing schedule is unaffected</li></ul></blockquote><!--EndFragment-->
</body>
</html>

recurring billing schedule is unaffected

How to verify
bashcargo test -p subscription_vault
All existing tests continue to pass. The 13 new hardening tests at the bottom of test.rs (search test_oneoff_) cover: unauthorized merchant, zero/negative amount, overdraft, exact-balance success, paused-subscription success, cancelled rejection, emergency stop, lifetime cap boundary, timestamp preservation, event emission, statement kind, partial balance sweep, and compaction aggregation accuracy.