### PR TITLE
feat: validate inputs in create_subscription

### DIFF
--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -1,36 +1,168 @@
 #![no_std]
 
-//! Subscription Vault stub.
-//!
-//! The previous implementation was left in an unbuildable state (hundreds of
-//! duplicate definitions and a corrupted `types.rs`). This file replaces it
-//! with a minimal, compiling placeholder so the CI pipeline can move past the
-//! `cargo test --all` step while the contract is rewritten on a future
-//! branch.
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env};
 
-use soroban_sdk::{contract, contractimpl, Env};
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum Error {
+    NotFound = 1,
+    Unauthorized = 2,
+    InvalidArgument = 3,
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SubscriptionStatus {
+    Active = 0,
+    Paused = 1,
+    Cancelled = 2,
+    InsufficientBalance = 3,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Subscription {
+    pub subscriber: Address,
+    pub token: Address,
+    pub merchant: Address,
+    pub amount: i128,
+    pub interval_seconds: u64,
+    pub last_payment_timestamp: u64,
+    pub status: SubscriptionStatus,
+    pub prepaid_balance: i128,
+    pub usage_enabled: bool,
+    pub expires_at: Option<u64>,
+}
+
+#[contracttype]
+pub enum DataKey {
+    NextId,
+    Sub(u32),
+    DefaultToken,
+    Admin,
+}
 
 #[contract]
 pub struct SubscriptionVault;
 
 #[contractimpl]
 impl SubscriptionVault {
-    /// Returns the schema version of this contract.
+    pub fn init(env: Env, admin: Address, default_token: Address) {
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::DefaultToken, &default_token);
+    }
+
+    pub fn create_subscription(
+        env: Env,
+        subscriber: Address,
+        merchant: Address,
+        amount: i128,
+        interval_seconds: u64,
+        usage_enabled: bool,
+        expires_at: Option<u64>,
+    ) -> Result<u32, Error> {
+        subscriber.require_auth();
+
+        if amount <= 0 {
+            return Err(Error::InvalidArgument);
+        }
+        if interval_seconds == 0 {
+            return Err(Error::InvalidArgument);
+        }
+        if let Some(ts) = expires_at {
+            if ts <= env.ledger().timestamp() {
+                return Err(Error::InvalidArgument);
+            }
+        }
+
+        let token: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::DefaultToken)
+            .ok_or(Error::NotFound)?;
+
+        let id = Self::_next_id(&env);
+        let sub = Subscription {
+            subscriber,
+            token,
+            merchant,
+            amount,
+            interval_seconds,
+            last_payment_timestamp: env.ledger().timestamp(),
+            status: SubscriptionStatus::Active,
+            prepaid_balance: 0,
+            usage_enabled,
+            expires_at,
+        };
+        env.storage().instance().set(&DataKey::Sub(id), &sub);
+        Ok(id)
+    }
+
+    pub fn create_subscription_with_token(
+        env: Env,
+        subscriber: Address,
+        token: Address,
+        merchant: Address,
+        amount: i128,
+        interval_seconds: u64,
+        usage_enabled: bool,
+        expires_at: Option<u64>,
+    ) -> Result<u32, Error> {
+        subscriber.require_auth();
+
+        if amount <= 0 {
+            return Err(Error::InvalidArgument);
+        }
+        if interval_seconds == 0 {
+            return Err(Error::InvalidArgument);
+        }
+        if let Some(ts) = expires_at {
+            if ts <= env.ledger().timestamp() {
+                return Err(Error::InvalidArgument);
+            }
+        }
+
+        let id = Self::_next_id(&env);
+        let sub = Subscription {
+            subscriber,
+            token,
+            merchant,
+            amount,
+            interval_seconds,
+            last_payment_timestamp: env.ledger().timestamp(),
+            status: SubscriptionStatus::Active,
+            prepaid_balance: 0,
+            usage_enabled,
+            expires_at,
+        };
+        env.storage().instance().set(&DataKey::Sub(id), &sub);
+        Ok(id)
+    }
+
+    pub fn get_subscription(env: Env, id: u32) -> Result<Subscription, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Sub(id))
+            .ok_or(Error::NotFound)
+    }
+
     pub fn version(_env: Env) -> u32 {
         0
+    }
+
+    fn _next_id(env: &Env) -> u32 {
+        let id: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextId)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::NextId, &(id + 1));
+        id
     }
 }
 
 #[cfg(test)]
-mod test {
-    use super::*;
-    use soroban_sdk::Env;
-
-    #[test]
-    fn version_is_zero() {
-        let env = Env::default();
-        let contract_id = env.register(SubscriptionVault, ());
-        let client = SubscriptionVaultClient::new(&env, &contract_id);
-        assert_eq!(client.version(), 0);
-    }
-}
+mod test;

--- a/contracts/subscription_vault/src/test.rs
+++ b/contracts/subscription_vault/src/test.rs
@@ -1,0 +1,229 @@
+use super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::Env;
+
+fn setup() -> (Env, SubscriptionVaultClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(SubscriptionVault, ());
+    let client = SubscriptionVaultClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let default_token = Address::generate(&env);
+    client.init(&admin, &default_token);
+    (env, client, default_token)
+}
+
+fn make_account(env: &Env) -> Address {
+    Address::generate(&env)
+}
+
+#[test]
+fn test_create_subscription_ok() {
+    let (env, client, _default_token) = setup();
+    let sub = make_account(&env);
+    let merchant = make_account(&env);
+
+    let id = client.create_subscription(&sub, &merchant, &1000i128, &3600u64, &false, &None);
+    assert_eq!(id, 0);
+}
+
+#[test]
+fn test_create_subscription_with_expires_at_ok() {
+    let (env, client, _default_token) = setup();
+    let sub = make_account(&env);
+    let merchant = make_account(&env);
+
+    let now = env.ledger().timestamp();
+    let future = now + 86400;
+
+    let id = client.create_subscription(&sub, &merchant, &1000i128, &3600u64, &false, &Some(future));
+    assert_eq!(id, 0);
+}
+
+#[test]
+fn test_create_subscription_increments_id() {
+    let (env, client, _default_token) = setup();
+    let sub = make_account(&env);
+    let merchant = make_account(&env);
+
+    let id1 = client.create_subscription(&sub, &merchant, &1000i128, &3600u64, &false, &None);
+    let id2 = client.create_subscription(&sub, &merchant, &1000i128, &3600u64, &false, &None);
+    assert_eq!(id1, 0);
+    assert_eq!(id2, 1);
+}
+
+#[test]
+fn test_create_subscription_zero_amount_rejected() {
+    let (env, client, _default_token) = setup();
+    let sub = make_account(&env);
+    let merchant = make_account(&env);
+
+    let result = client.try_create_subscription(&sub, &merchant, &0i128, &3600u64, &false, &None);
+    assert_eq!(result, Err(Ok(Error::InvalidArgument)));
+}
+
+#[test]
+fn test_create_subscription_negative_amount_rejected() {
+    let (env, client, _default_token) = setup();
+    let sub = make_account(&env);
+    let merchant = make_account(&env);
+
+    let result = client.try_create_subscription(&sub, &merchant, &(-1i128), &3600u64, &false, &None);
+    assert_eq!(result, Err(Ok(Error::InvalidArgument)));
+}
+
+#[test]
+fn test_create_subscription_zero_interval_rejected() {
+    let (env, client, _default_token) = setup();
+    let sub = make_account(&env);
+    let merchant = make_account(&env);
+
+    let result = client.try_create_subscription(&sub, &merchant, &1000i128, &0u64, &false, &None);
+    assert_eq!(result, Err(Ok(Error::InvalidArgument)));
+}
+
+#[test]
+fn test_create_subscription_past_expiration_rejected() {
+    let (env, client, _default_token) = setup();
+    let sub = make_account(&env);
+    let merchant = make_account(&env);
+
+    let now = env.ledger().timestamp();
+    let result = client.try_create_subscription(&sub, &merchant, &1000i128, &3600u64, &false, &Some(now));
+    assert_eq!(result, Err(Ok(Error::InvalidArgument)));
+}
+
+#[test]
+fn test_create_subscription_expiration_before_now_rejected() {
+    let (env, client, _default_token) = setup();
+    let sub = make_account(&env);
+    let merchant = make_account(&env);
+
+    let now = env.ledger().timestamp();
+    let past = now.saturating_sub(1);
+    let result = client.try_create_subscription(&sub, &merchant, &1000i128, &3600u64, &false, &Some(past));
+    assert_eq!(result, Err(Ok(Error::InvalidArgument)));
+}
+
+#[test]
+fn test_create_subscription_with_token_ok() {
+    let (env, client, _default_token) = setup();
+    let sub = make_account(&env);
+    let token = make_account(&env);
+    let merchant = make_account(&env);
+
+    let id = client.create_subscription_with_token(&sub, &token, &merchant, &1000i128, &3600u64, &false, &None);
+    assert_eq!(id, 0);
+}
+
+#[test]
+fn test_create_subscription_with_token_zero_amount_rejected() {
+    let (env, client, _default_token) = setup();
+    let sub = make_account(&env);
+    let token = make_account(&env);
+    let merchant = make_account(&env);
+
+    let result = client.try_create_subscription_with_token(&sub, &token, &merchant, &0i128, &3600u64, &false, &None);
+    assert_eq!(result, Err(Ok(Error::InvalidArgument)));
+}
+
+#[test]
+fn test_create_subscription_with_token_negative_amount_rejected() {
+    let (env, client, _default_token) = setup();
+    let sub = make_account(&env);
+    let token = make_account(&env);
+    let merchant = make_account(&env);
+
+    let result = client.try_create_subscription_with_token(&sub, &token, &merchant, &(-5i128), &3600u64, &false, &None);
+    assert_eq!(result, Err(Ok(Error::InvalidArgument)));
+}
+
+#[test]
+fn test_create_subscription_with_token_zero_interval_rejected() {
+    let (env, client, _default_token) = setup();
+    let sub = make_account(&env);
+    let token = make_account(&env);
+    let merchant = make_account(&env);
+
+    let result = client.try_create_subscription_with_token(&sub, &token, &merchant, &1000i128, &0u64, &false, &None);
+    assert_eq!(result, Err(Ok(Error::InvalidArgument)));
+}
+
+#[test]
+fn test_create_subscription_with_token_past_expiration_rejected() {
+    let (env, client, _default_token) = setup();
+    let sub = make_account(&env);
+    let token = make_account(&env);
+    let merchant = make_account(&env);
+
+    let now = env.ledger().timestamp();
+    let result = client.try_create_subscription_with_token(&sub, &token, &merchant, &1000i128, &3600u64, &false, &Some(now));
+    assert_eq!(result, Err(Ok(Error::InvalidArgument)));
+}
+
+#[test]
+fn test_create_subscription_with_token_future_expiration_ok() {
+    let (env, client, _default_token) = setup();
+    let sub = make_account(&env);
+    let token = make_account(&env);
+    let merchant = make_account(&env);
+
+    let now = env.ledger().timestamp();
+    let future = now + 7200;
+    let id = client.create_subscription_with_token(&sub, &token, &merchant, &1000i128, &3600u64, &false, &Some(future));
+    assert_eq!(id, 0);
+}
+
+#[test]
+fn test_subscription_stored_correctly() {
+    let (env, client, default_token) = setup();
+    let sub = make_account(&env);
+    let merchant = make_account(&env);
+    let now = env.ledger().timestamp();
+    let future = now + 86400;
+
+    let id = client.create_subscription(&sub, &merchant, &5000i128, &7200u64, &true, &Some(future));
+
+    let stored = client.get_subscription(&id);
+    assert_eq!(stored.subscriber, sub);
+    assert_eq!(stored.token, default_token);
+    assert_eq!(stored.merchant, merchant);
+    assert_eq!(stored.amount, 5000);
+    assert_eq!(stored.interval_seconds, 7200);
+    assert_eq!(stored.last_payment_timestamp, now);
+    assert_eq!(stored.status, SubscriptionStatus::Active);
+    assert_eq!(stored.prepaid_balance, 0);
+    assert!(stored.usage_enabled);
+    assert_eq!(stored.expires_at, Some(future));
+}
+
+#[test]
+fn test_create_subscription_with_token_stores_correctly() {
+    let (env, client, _default_token) = setup();
+    let sub = make_account(&env);
+    let token = make_account(&env);
+    let merchant = make_account(&env);
+    let now = env.ledger().timestamp();
+    let future = now + 86400;
+
+    let id = client.create_subscription_with_token(&sub, &token, &merchant, &5000i128, &7200u64, &true, &Some(future));
+
+    let stored = client.get_subscription(&id);
+    assert_eq!(stored.subscriber, sub);
+    assert_eq!(stored.token, token);
+    assert_eq!(stored.merchant, merchant);
+    assert_eq!(stored.amount, 5000);
+    assert_eq!(stored.interval_seconds, 7200);
+    assert_eq!(stored.last_payment_timestamp, now);
+    assert_eq!(stored.status, SubscriptionStatus::Active);
+    assert_eq!(stored.prepaid_balance, 0);
+    assert!(stored.usage_enabled);
+    assert_eq!(stored.expires_at, Some(future));
+}
+
+#[test]
+fn test_get_subscription_not_found() {
+    let (_env, client, _default_token) = setup();
+    let result = client.try_get_subscription(&999u32);
+    assert_eq!(result, Err(Ok(Error::NotFound)));
+}


### PR DESCRIPTION
Validate create_subscription inputs (amount, interval_seconds, expiration) 

closing #378 