### PR TITLE
feat: prevent re-initialization in init

### DIFF
--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -1,14 +1,38 @@
 #![no_std]
 
-//! Subscription Vault stub.
+//! Subscription Vault contract.
 //!
-//! The previous implementation was left in an unbuildable state (hundreds of
-//! duplicate definitions and a corrupted `types.rs`). This file replaces it
-//! with a minimal, compiling placeholder so the CI pipeline can move past the
-//! `cargo test --all` step while the contract is rewritten on a future
-//! branch.
+//! This contract manages prepaid subscriptions with recurring USDC billing on Stellar.
+//! The contract includes initialization protection to prevent re-initialization attacks.
 
-use soroban_sdk::{contract, contractimpl, Env};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, symbol_short, Address, Env, Symbol,
+};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 1,
+}
+
+/// Storage keys for instance data.
+#[derive(Clone)]
+pub enum DataKey {
+    Admin = 0,
+    Token = 1,
+    MinTopup = 2,
+}
+
+impl DataKey {
+    pub fn to_symbol(&self) -> Symbol {
+        match self {
+            DataKey::Admin => symbol_short!("admin"),
+            DataKey::Token => symbol_short!("token"),
+            DataKey::MinTopup => symbol_short!("min_topup"),
+        }
+    }
+}
 
 #[contract]
 pub struct SubscriptionVault;
@@ -19,12 +43,69 @@ impl SubscriptionVault {
     pub fn version(_env: Env) -> u32 {
         0
     }
+
+    /// Initialize the contract with admin, token, and minimum topup amount.
+    ///
+    /// # Security
+    /// This function can only be called once. The admin key serves as a sentinel
+    /// to detect whether initialization has already occurred. Any attempt to
+    /// re-initialize will return `Error::AlreadyInitialized` and leave the existing
+    /// configuration unchanged.
+    ///
+    /// # Arguments
+    /// * `admin` - The admin address that will control the contract
+    /// * `token` - The token address used for payments
+    /// * `min_topup` - The minimum topup amount in token units
+    ///
+    /// # Errors
+    /// * `Error::AlreadyInitialized` - If the contract has already been initialized
+    pub fn init(env: Env, admin: Address, token: Address, min_topup: i128) -> Result<(), Error> {
+        // Check if already initialized by verifying the admin key exists
+        if env.storage().instance().has(&DataKey::Admin.to_symbol()) {
+            return Err(Error::AlreadyInitialized);
+        }
+
+        // Store initial configuration
+        env.storage()
+            .instance()
+            .set(&DataKey::Admin.to_symbol(), &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::Token.to_symbol(), &token);
+        env.storage()
+            .instance()
+            .set(&DataKey::MinTopup.to_symbol(), &min_topup);
+
+        Ok(())
+    }
+
+    /// Get the current admin address.
+    pub fn get_admin(env: Env) -> Option<Address> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin.to_symbol())
+    }
+
+    /// Get the token address.
+    pub fn get_token(env: Env) -> Option<Address> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Token.to_symbol())
+    }
+
+    /// Get the minimum topup amount.
+    pub fn get_min_topup(env: Env) -> Option<i128> {
+        env.storage()
+            .instance()
+            .get(&DataKey::MinTopup.to_symbol())
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use soroban_sdk::Env;
+    use soroban_sdk::{Address, Env};
+    use soroban_sdk::testutils::Address as _;
 
     #[test]
     fn version_is_zero() {
@@ -32,5 +113,82 @@ mod test {
         let contract_id = env.register(SubscriptionVault, ());
         let client = SubscriptionVaultClient::new(&env, &contract_id);
         assert_eq!(client.version(), 0);
+    }
+
+    #[test]
+    fn init_succeeds_on_first_call() {
+        let env = Env::default();
+        let contract_id = env.register(SubscriptionVault, ());
+        let client = SubscriptionVaultClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let token = Address::generate(&env);
+        let min_topup = 1000;
+
+        // First init should succeed
+        client.init(&admin, &token, &min_topup);
+
+        // Verify values were stored
+        assert_eq!(client.get_admin(), Some(admin));
+        assert_eq!(client.get_token(), Some(token));
+        assert_eq!(client.get_min_topup(), Some(min_topup));
+    }
+
+    #[test]
+    fn init_fails_on_second_call() {
+        let env = Env::default();
+        let contract_id = env.register(SubscriptionVault, ());
+        let client = SubscriptionVaultClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let token = Address::generate(&env);
+        let min_topup = 1000;
+
+        // First init should succeed
+        client.init(&admin, &token, &min_topup);
+
+        // Second init should fail with AlreadyInitialized error
+        let result = client.try_init(&admin, &token, &min_topup);
+        assert!(result.is_err());
+        assert_eq!(result.err(), Some(Ok(Error::AlreadyInitialized)));
+    }
+
+    #[test]
+    fn re_init_does_not_modify_existing_values() {
+        let env = Env::default();
+        let contract_id = env.register(SubscriptionVault, ());
+        let client = SubscriptionVaultClient::new(&env, &contract_id);
+
+        let admin1 = Address::generate(&env);
+        let token1 = Address::generate(&env);
+        let min_topup1 = 1000;
+
+        // First init
+        client.init(&admin1, &token1, &min_topup1);
+
+        // Attempt re-init with different values
+        let admin2 = Address::generate(&env);
+        let token2 = Address::generate(&env);
+        let min_topup2 = 2000;
+
+        let result = client.try_init(&admin2, &token2, &min_topup2);
+        assert!(result.is_err());
+
+        // Verify original values are unchanged
+        assert_eq!(client.get_admin(), Some(admin1));
+        assert_eq!(client.get_token(), Some(token1));
+        assert_eq!(client.get_min_topup(), Some(min_topup1));
+    }
+
+    #[test]
+    fn get_functions_return_none_before_init() {
+        let env = Env::default();
+        let contract_id = env.register(SubscriptionVault, ());
+        let client = SubscriptionVaultClient::new(&env, &contract_id);
+
+        // Before init, all get functions should return None
+        assert_eq!(client.get_admin(), None);
+        assert_eq!(client.get_token(), None);
+        assert_eq!(client.get_min_topup(), None);
     }
 }

--- a/docs/init_guard_security.md
+++ b/docs/init_guard_security.md
@@ -1,0 +1,143 @@
+# Init Guard Security Documentation
+
+## Overview
+
+The `init` function in the Subscription Vault contract is protected against re-initialization attacks. This document describes the security mechanism, validation, and testing approach.
+
+## Security Mechanism
+
+### Sentinel-Based Initialization Guard
+
+The contract uses the admin key (`Symbol::new(&env, "admin")`) as a sentinel to detect whether initialization has already occurred. This is a natural choice because:
+
+1. **Admin is required for operation**: The admin address is essential for all privileged operations in the contract.
+2. **Written during init**: The admin key is always set during the first initialization.
+3. **Never deleted**: The admin key persists for the lifetime of the contract.
+4. **Atomic check**: The `has()` check and subsequent writes happen in the same transaction.
+
+### Implementation
+
+```rust
+pub fn init(env: Env, admin: Address, token: Address, min_topup: i128) -> Result<(), Error> {
+    // Check if already initialized by verifying the admin key exists
+    if env.storage().instance().has(&DataKey::Admin.to_symbol()) {
+        return Err(Error::AlreadyInitialized);
+    }
+
+    // Store initial configuration
+    env.storage().instance().set(&DataKey::Admin.to_symbol(), &admin);
+    env.storage().instance().set(&DataKey::Token.to_symbol(), &token);
+    env.storage().instance().set(&DataKey::MinTopup.to_symbol(), &min_topup);
+
+    Ok(())
+}
+```
+
+## Security Properties
+
+### 1. One-Time Initialization
+
+- **Property**: `init` can only be called successfully once per contract instance.
+- **Enforcement**: The admin key serves as an immutable sentinel. Once set, any subsequent call to `init` will fail with `Error::AlreadyInitialized`.
+- **Atomicity**: The check and write operations are atomic within the same transaction.
+
+### 2. State Preservation on Re-Init Attempt
+
+- **Property**: A failed re-initialization attempt leaves all existing state unchanged.
+- **Enforcement**: The guard check happens before any writes. If the check fails, the function returns early without modifying storage.
+- **Validation**: Tested in `re_init_does_not_modify_existing_values` test.
+
+### 3. No Race Conditions
+
+- **Property**: The guard is not susceptible to race conditions.
+- **Reason**: Soroban transactions are atomic. Multiple concurrent `init` calls will be serialized, and only the first will succeed.
+
+## Error Handling
+
+### Error::AlreadyInitialized
+
+- **When returned**: When `init` is called on an already-initialized contract.
+- **Effect**: No state changes occur; the function returns immediately.
+- **Recovery**: No recovery needed; this is the expected behavior for a protected contract.
+
+## Test Coverage
+
+### Test Cases
+
+1. **`init_succeeds_on_first_call`**
+   - Verifies that the first `init` call succeeds.
+   - Validates that admin, token, and min_topup are stored correctly.
+
+2. **`init_fails_on_second_call`**
+   - Verifies that a second `init` call fails with `Error::AlreadyInitialized`.
+   - Confirms the error variant is correct.
+
+3. **`re_init_does_not_modify_existing_values`**
+   - Verifies that a failed re-initialization attempt does not modify existing state.
+   - Tests with different values to ensure no partial writes occur.
+
+4. **`get_functions_return_none_before_init`**
+   - Verifies that getter functions return `None` before initialization.
+   - Confirms the contract starts in a clean state.
+
+### Running Tests
+
+```bash
+cargo test -p subscription_vault
+```
+
+## Security Assumptions
+
+### Valid Assumptions
+
+1. **Admin key is never deleted**: The contract design assumes the admin key persists. If admin rotation is implemented, it should update the key rather than delete it.
+2. **Storage is reliable**: Soroban's persistent storage guarantees that the admin key will persist across transactions.
+3. **Atomic transactions**: Soroban's transaction model ensures that the check and write operations are atomic.
+
+### Future Considerations
+
+1. **Admin rotation**: If admin rotation is added, ensure it updates the admin key rather than deleting and recreating it, which could potentially allow re-initialization.
+2. **Migration scenarios**: If contract migration is needed, ensure the migration process preserves the initialization guard.
+
+## Comparison to Alternative Approaches
+
+### Alternative 1: Boolean Flag
+
+A dedicated boolean flag (e.g., `initialized`) could be used instead of the admin key.
+
+**Pros**:
+- Explicit purpose
+- Clear semantic meaning
+
+**Cons**:
+- Additional storage entry
+- Redundant with admin key
+- More complex state management
+
+**Decision**: Using the admin key as the sentinel is more efficient and leverages existing state.
+
+### Alternative 2: Contract Version
+
+A contract version number could be checked.
+
+**Pros**:
+- Provides upgrade path
+- Can track multiple initialization phases
+
+**Cons**:
+- More complex logic
+- Overkill for simple one-time initialization
+- Requires version management
+
+**Decision**: The sentinel approach is simpler and sufficient for the current requirements.
+
+## Recommendations
+
+1. **Always call init first**: Ensure `init` is called before any other contract operations.
+2. **Handle AlreadyInitialized error**: Clients should handle `Error::AlreadyInitialized` gracefully, as it indicates the contract is already set up.
+3. **Monitor init events**: If events are added to `init`, monitor them to detect unexpected initialization attempts.
+4. **Audit logs**: Review audit logs for `Error::AlreadyInitialized` to detect potential attack attempts.
+
+## Conclusion
+
+The init guard using the admin key as a sentinel provides a simple, efficient, and secure mechanism to prevent re-initialization attacks. The implementation is atomic, well-tested, and leverages existing contract state without additional complexity.


### PR DESCRIPTION
Closes #379

---

All test created and passed:


unning 5 tests
test test::version_is_zero ... ok
test test::get_functions_return_none_before_init ... ok
test test::init_succeeds_on_first_call ... ok
test test::init_fails_on_second_call ... ok
test test::re_init_does_not_modify_existing_values ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s