### PR TITLE
fix: replace permissive state_machine stub with documented transition…

### DIFF
--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -50,20 +50,7 @@ pub mod blocklist {
 }
 
 /// State machine: validates and applies subscription status transitions.
-pub mod state_machine {
-    #![allow(unused_variables, dead_code)]
-    use crate::types::{Error, SubscriptionStatus};
-
-    pub fn transition_to(current: &mut SubscriptionStatus, next: SubscriptionStatus) -> Result<(), Error> {
-        *current = next;
-        Ok(())
-    }
-    pub fn can_transition(from: &SubscriptionStatus, to: &SubscriptionStatus) -> bool { true }
-    pub fn validate_status_transition(from: &SubscriptionStatus, to: &SubscriptionStatus) -> Result<(), Error> { Ok(()) }
-    pub fn get_allowed_transitions(from: &SubscriptionStatus) -> soroban_sdk::Vec<SubscriptionStatus> {
-        soroban_sdk::Vec::new(&soroban_sdk::Env::default())
-    }
-}
+pub mod state_machine;
 
 /// Billing statements: append-only ledger of charges per subscription.
 pub mod statements {

--- a/contracts/subscription_vault/src/state_machine.rs
+++ b/contracts/subscription_vault/src/state_machine.rs
@@ -1,0 +1,84 @@
+//! State machine: validates and applies subscription status transitions.
+//!
+//! Every status change MUST go through `transition_to`. The transition matrix
+//! is derived from `docs/subscription_state_machine.md`.
+
+use soroban_sdk::{Env, Vec};
+
+use crate::types::{Error, SubscriptionStatus};
+
+/// Returns `true` if transitioning from `from` to `to` is permitted.
+///
+/// Same-state (idempotent) transitions are always allowed.
+pub fn can_transition(from: &SubscriptionStatus, to: &SubscriptionStatus) -> bool {
+    if from == to {
+        return true;
+    }
+    use SubscriptionStatus::*;
+    matches!(
+        (from, to),
+        (Active, Paused)
+            | (Active, Cancelled)
+            | (Active, InsufficientBalance)
+            | (Active, GracePeriod)
+            | (Active, Expired)
+            | (Paused, Active)
+            | (Paused, Cancelled)
+            | (Paused, Expired)
+            | (InsufficientBalance, Active)
+            | (InsufficientBalance, Cancelled)
+            | (InsufficientBalance, Expired)
+            | (GracePeriod, Active)
+            | (GracePeriod, Cancelled)
+            | (GracePeriod, InsufficientBalance)
+            | (GracePeriod, Expired)
+            | (Cancelled, Archived)
+            | (Expired, Archived)
+    )
+}
+
+/// Validates a transition, returning `Err(InvalidStatusTransition)` if not allowed.
+pub fn validate_status_transition(
+    from: &SubscriptionStatus,
+    to: &SubscriptionStatus,
+) -> Result<(), Error> {
+    if can_transition(from, to) {
+        Ok(())
+    } else {
+        Err(Error::InvalidStatusTransition)
+    }
+}
+
+/// Validates and applies a status transition atomically.
+///
+/// `current` is only mutated on success; on error it is left unchanged.
+pub fn transition_to(
+    current: &mut SubscriptionStatus,
+    next: SubscriptionStatus,
+) -> Result<(), Error> {
+    validate_status_transition(current, &next)?;
+    *current = next;
+    Ok(())
+}
+
+/// Returns the set of valid target statuses from `from`, excluding self.
+///
+/// Used by tests and tooling to enumerate the transition matrix.
+pub fn get_allowed_transitions(from: &SubscriptionStatus) -> Vec<SubscriptionStatus> {
+    let env = Env::default();
+    let mut out: Vec<SubscriptionStatus> = Vec::new(&env);
+    use SubscriptionStatus::*;
+    let targets: &[SubscriptionStatus] = match from {
+        Active => &[Paused, Cancelled, InsufficientBalance, GracePeriod, Expired],
+        Paused => &[Active, Cancelled, Expired],
+        Cancelled => &[Archived],
+        InsufficientBalance => &[Active, Cancelled, Expired],
+        GracePeriod => &[Active, Cancelled, InsufficientBalance, Expired],
+        Expired => &[Archived],
+        Archived => &[],
+    };
+    for t in targets {
+        out.push_back(t.clone());
+    }
+    out
+}


### PR DESCRIPTION
Closes #424

---

… matrix (#424)

- Create src/state_machine.rs with the full transition matrix from docs/subscription_state_machine.md
- transition_to validates before mutating (atomic, no partial state changes)
- validate_status_transition and can_transition enforce the matrix; same-state transitions are always allowed (idempotent)
- get_allowed_transitions returns the set of valid target states (excludes self)
- Remove the inline permissive stub from lib.rs; replace with pub mod state_machine;
closes #422 