### PR TITLE
feat: enforce blocklist across mutating entrypoints

### DIFF
--- a/contracts/subscription_vault/src/blocklist.rs
+++ b/contracts/subscription_vault/src/blocklist.rs
@@ -1,0 +1,92 @@
+use soroban_sdk::{contracttype, Address, Env, String, Symbol};
+use crate::types::{DataKey, Error};
+use crate::admin::require_admin_auth;
+
+#[contracttype]
+#[derive(Clone)]
+pub struct BlocklistEntry {
+    pub reason: String,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct BlocklistAddedEvent {
+    pub subscriber: Address,
+    pub reason: String,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct BlocklistRemovedEvent {
+    pub subscriber: Address,
+}
+
+pub fn is_blocklisted(env: &Env, addr: &Address) -> bool {
+    env.storage().persistent().has(&DataKey::Blocklist(addr.clone()))
+}
+
+pub fn require_not_blocklisted(env: &Env, addr: &Address) -> Result<(), Error> {
+    if is_blocklisted(env, addr) {
+        Err(Error::SubscriberBlocklisted)
+    } else {
+        Ok(())
+    }
+}
+
+pub fn get_blocklist_entry(env: &Env, addr: Address) -> Result<BlocklistEntry, Error> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Blocklist(addr))
+        .ok_or(Error::NotFound)
+}
+
+pub fn do_add_to_blocklist(
+    env: &Env,
+    authorizer: Address,
+    subscriber: Address,
+    reason: Option<String>,
+) -> Result<(), Error> {
+    require_admin_auth(env, &authorizer)?;
+
+    if is_blocklisted(env, &subscriber) {
+        return Err(Error::SubscriberBlocklisted);
+    }
+
+    let reason_str = reason.unwrap_or_else(|| String::from_str(env, ""));
+    let entry = BlocklistEntry {
+        reason: reason_str.clone(),
+    };
+    
+    env.storage().persistent().set(&DataKey::Blocklist(subscriber.clone()), &entry);
+
+    env.events().publish(
+        (Symbol::new(env, "blocklist_added"), subscriber.clone()),
+        BlocklistAddedEvent {
+            subscriber,
+            reason: reason_str,
+        },
+    );
+
+    Ok(())
+}
+
+pub fn do_remove_from_blocklist(
+    env: &Env,
+    admin: Address,
+    subscriber: Address,
+) -> Result<(), Error> {
+    require_admin_auth(env, &admin)?;
+
+    if !is_blocklisted(env, &subscriber) {
+        return Err(Error::NotFound);
+    }
+
+    env.storage().persistent().remove(&DataKey::Blocklist(subscriber.clone()));
+
+    env.events().publish(
+        (Symbol::new(env, "blocklist_removed"), subscriber.clone()),
+        BlocklistRemovedEvent { subscriber },
+    );
+
+    Ok(())
+}

--- a/contracts/subscription_vault/src/charge_core.rs
+++ b/contracts/subscription_vault/src/charge_core.rs
@@ -57,10 +57,8 @@ pub fn charge_one(
         return Err(Error::MerchantPaused);
     }
 
-    // Blocklist guard — do not charge subscriptions belonging to blocklisted subscribers
-    if crate::blocklist::is_blocklisted(env, &sub.subscriber) {
-        return Err(Error::SubscriberBlocklisted);
-    }
+    crate::blocklist::require_not_blocklisted(env, &sub.subscriber)?;
+    crate::blocklist::require_not_blocklisted(env, &sub.merchant)?;
 
     // Expiration guard
     if sub.is_expired(now) {
@@ -359,10 +357,8 @@ pub fn charge_usage_one(
         return Err(Error::MerchantPaused);
     }
 
-    // Blocklist guard — do not process usage charges for blocklisted subscribers
-    if crate::blocklist::is_blocklisted(env, &sub.subscriber) {
-        return Err(Error::SubscriberBlocklisted);
-    }
+    crate::blocklist::require_not_blocklisted(env, &sub.subscriber)?;
+    crate::blocklist::require_not_blocklisted(env, &sub.merchant)?;
 
     let now = env.ledger().timestamp();
     // Expiration guard

--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -13,6 +13,7 @@
 use soroban_sdk::{contract, contractimpl, Address, Env, String, Symbol, Vec};
 
 mod admin;
+pub mod blocklist;
 mod charge_core;
 mod merchant;
 mod queries;
@@ -23,33 +24,6 @@ mod types;
 pub use safe_math::*;
 
 // ── Stub modules for features not yet extracted to separate files ─────────────
-
-/// Blocklist: prevents blacklisted subscribers from creating or receiving charges.
-pub mod blocklist {
-    #![allow(unused_variables, dead_code)]
-    use soroban_sdk::{contracttype, Address, Env, String};
-    use crate::types::Error;
-
-    #[contracttype]
-    #[derive(Clone)]
-    pub struct BlocklistEntry { pub reason: String }
-
-    #[contracttype]
-    #[derive(Clone)]
-    pub struct BlocklistAddedEvent { pub subscriber: Address, pub reason: String }
-
-    #[contracttype]
-    #[derive(Clone)]
-    pub struct BlocklistRemovedEvent { pub subscriber: Address }
-
-    pub fn is_blocklisted(_env: &Env, _addr: &Address) -> bool { false }
-    pub fn require_not_blocklisted(_env: &Env, _addr: &Address) -> Result<(), Error> { Ok(()) }
-    pub fn get_blocklist_entry(_env: &Env, _addr: Address) -> Result<BlocklistEntry, Error> {
-        Err(Error::NotFound)
-    }
-    pub fn do_add_to_blocklist(_env: &Env, _authorizer: Address, _subscriber: Address, _reason: Option<String>) -> Result<(), Error> { Ok(()) }
-    pub fn do_remove_from_blocklist(_env: &Env, _admin: Address, _subscriber: Address) -> Result<(), Error> { Ok(()) }
-}
 
 /// State machine: validates and applies subscription status transitions.
 pub mod state_machine;

--- a/contracts/subscription_vault/src/subscription.rs
+++ b/contracts/subscription_vault/src/subscription.rs
@@ -361,9 +361,8 @@ pub fn do_create_subscription_with_token(
 ) -> Result<u32, Error> {
     subscriber.require_auth();
 
-    if crate::blocklist::is_blocklisted(env, &subscriber) {
-        return Err(Error::SubscriberBlocklisted);
-    }
+    crate::blocklist::require_not_blocklisted(env, &subscriber)?;
+    crate::blocklist::require_not_blocklisted(env, &merchant)?;
 
     if amount < 0 {
         return Err(Error::InvalidAmount);
@@ -480,6 +479,8 @@ pub fn do_deposit_funds(
     if subscriber != sub.subscriber {
         return Err(Error::Unauthorized);
     }
+
+    crate::blocklist::require_not_blocklisted(env, &sub.merchant)?;
 
     // Block deposits to subscriptions whose merchant is paused — paused
     // merchants must not accumulate new subscriber funds.
@@ -760,6 +761,9 @@ pub fn do_charge_one_off(
     merchant.require_auth();
 
     let mut sub = get_subscription(env, subscription_id)?;
+
+    crate::blocklist::require_not_blocklisted(env, &sub.subscriber)?;
+    crate::blocklist::require_not_blocklisted(env, &sub.merchant)?;
 
     let now = env.ledger().timestamp();
     // Expiration guard


### PR DESCRIPTION
Closes #423 

- Extracted blocklist module to `blocklist.rs` using persistent storage
- Added deduplication check in `do_add_to_blocklist` to return `SubscriberBlocklisted` when re-added
- Implemented dual checks (`require_not_blocklisted`) for both subscriber and merchant on critical paths
- Protected `do_create_subscription`, `do_deposit_funds`, `do_charge_one_off`, and `charge_core` logic against blocklisted participants