### PR TITLE
feat: add idempotency keys for charge and deposit entrypoints

### DIFF
--- a/contracts/subscription_vault/src/charge_core.rs
+++ b/contracts/subscription_vault/src/charge_core.rs
@@ -37,13 +37,10 @@ use crate::subscription::{next_charge_time, write_subscription};
 use crate::statements::append_statement;
 use crate::types::{
     BillingChargeKind, BillingPeriodSnapshot, ChargeExecutionResult, DataKey, Error,
-    LifetimeCapReachedEvent, SubscriptionChargeFailedEvent, SubscriptionChargedEvent,
-    SubscriptionStatus, UsageChargeRejectedEvent, UsageChargeResult, UsageLimits, UsageState,
-    UsageStatementEvent, SNAPSHOT_FLAG_CLOSED, SNAPSHOT_FLAG_INTERVAL_CHARGED, SNAPSHOT_FLAG_USAGE_CHARGED,
     GracePeriodEnteredEvent, LifetimeCapReachedEvent, SubscriptionChargeFailedEvent,
     SubscriptionChargedEvent, SubscriptionStatus, UsageChargeRejectedEvent, UsageChargeResult,
-    UsageLimits, UsageState, UsageStatementEvent, SNAPSHOT_FLAG_CLOSED,
-    SNAPSHOT_FLAG_INTERVAL_CHARGED,
+    UsageLimits, UsageState, UsageStatementEvent,
+    SNAPSHOT_FLAG_CLOSED, SNAPSHOT_FLAG_INTERVAL_CHARGED, SNAPSHOT_FLAG_USAGE_CHARGED,
 };
 use soroban_sdk::{symbol_short, Env, String, Symbol};
 
@@ -122,14 +119,14 @@ pub fn charge_one(
 
     // Idempotent return: same idempotency key already processed
     if let Some(ref k) = idempotency_key {
-        if let Some(stored) = env
-            .storage()
-            .instance()
-            .get::<_, soroban_sdk::BytesN<32>>(&DataKey::IdemKey(subscription_id))
-        {
-            if stored == *k {
-                return Ok(ChargeExecutionResult::Charged);
-            }
+        let hashed = crate::idempotency::hash_idem_key(
+            env,
+            crate::types::DOMAIN_CHARGE_INTERVAL,
+            subscription_id,
+            k,
+        );
+        if crate::idempotency::check_key(env, subscription_id, &hashed) {
+            return Ok(ChargeExecutionResult::Charged);
         }
     }
 
@@ -273,7 +270,13 @@ pub fn charge_one(
             // Record charged period and optional idempotency key
             storage.set(&DataKey::ChargedPeriod(subscription_id), &period_index);
             if let Some(k) = idempotency_key {
-                storage.set(&DataKey::IdemKey(subscription_id), &k);
+                let hashed = crate::idempotency::hash_idem_key(
+                    env,
+                    crate::types::DOMAIN_CHARGE_INTERVAL,
+                    subscription_id,
+                    &k,
+                );
+                crate::idempotency::push_key(env, subscription_id, &hashed);
             }
 
             env.events().publish(

--- a/contracts/subscription_vault/src/idempotency.rs
+++ b/contracts/subscription_vault/src/idempotency.rs
@@ -1,0 +1,100 @@
+//! Shared ring-buffer idempotency key helpers.
+//!
+//! Three entrypoints use idempotency keys: `charge_subscription`,
+//! `deposit_funds`, and `charge_one_off`.  Each domain is scoped with a
+//! unique domain constant so that reusing the same raw 32-byte key across
+//! different entrypoints does **not** produce a replay collision.
+//!
+//! Storage key: `DataKey::IdemKey(subscription_id)` stores `IdemRingBuffer`.
+
+use crate::types::{DataKey, IdemRingBuffer, IDEM_HISTORY};
+use soroban_sdk::{BytesN, Env, Vec};
+
+/// Return the raw byte representation of a 32-byte idempotency key.
+fn key_bytes(key: &BytesN<32>) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    let arr = key.to_array();
+    out.copy_from_slice(&arr);
+    out
+}
+
+/// Hash (domain, subscription_id, raw_key) into a 32-byte fingerprint.
+///
+/// The caller **must** supply the correct `domain` constant for their
+/// entrypoint so that two different operations receiving the same raw key
+/// produce different fingerprints.
+pub fn hash_idem_key(
+    env: &Env,
+    domain: u32,
+    subscription_id: u32,
+    raw_key: &BytesN<32>,
+) -> BytesN<32> {
+    let raw = key_bytes(raw_key);
+    let mut buf = [0u8; 40];
+    buf[..4].copy_from_slice(&domain.to_be_bytes());
+    buf[4..8].copy_from_slice(&subscription_id.to_be_bytes());
+    buf[8..40].copy_from_slice(&raw);
+    let input = soroban_sdk::Bytes::from_slice(env, &buf);
+    env.crypto().sha256(&input).into()
+}
+
+/// Load the ring buffer for `subscription_id`.
+///
+/// Returns an empty buffer when no idempotency key has ever been stored.
+fn load_buffer(env: &Env, subscription_id: u32) -> IdemRingBuffer {
+    env.storage()
+        .instance()
+        .get(&DataKey::IdemKey(subscription_id))
+        .unwrap_or(IdemRingBuffer {
+            entries: Vec::new(env),
+            cursor: 0,
+        })
+}
+
+/// Persist the ring buffer for `subscription_id`.
+fn save_buffer(env: &Env, subscription_id: u32, buf: &IdemRingBuffer) {
+    env.storage()
+        .instance()
+        .set(&DataKey::IdemKey(subscription_id), buf);
+}
+
+/// Check whether `hashed` already exists in the ring buffer.
+///
+/// Returns `true` when the key is a duplicate (replay).
+pub fn check_key(
+    env: &Env,
+    subscription_id: u32,
+    hashed: &BytesN<32>,
+) -> bool {
+    let buf = load_buffer(env, subscription_id);
+    for entry in buf.entries.iter() {
+        if entry == *hashed {
+            return true;
+        }
+    }
+    false
+}
+
+/// Insert a new idempotency key hash into the ring buffer.
+///
+/// When the buffer is full the oldest entry (at `cursor`) is silently
+/// overwritten.
+pub fn push_key(
+    env: &Env,
+    subscription_id: u32,
+    hashed: &BytesN<32>,
+) {
+    let mut buf = load_buffer(env, subscription_id);
+    if buf.entries.len() < IDEM_HISTORY {
+        buf.entries.push_back(hashed.clone());
+    } else {
+        let idx = buf.cursor as usize % IDEM_HISTORY as usize;
+        if idx < buf.entries.len() as usize {
+            buf.entries.set(idx as u32, hashed.clone());
+        } else {
+            buf.entries.push_back(hashed.clone());
+        }
+    }
+    buf.cursor = buf.cursor.wrapping_add(1) % IDEM_HISTORY;
+    save_buffer(env, subscription_id, &buf);
+}

--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -15,6 +15,7 @@ use soroban_sdk::{contract, contractimpl, Address, Env, String, Symbol, Vec};
 mod admin;
 pub mod blocklist;
 mod charge_core;
+mod idempotency;
 mod merchant;
 mod metadata;
 mod queries;
@@ -113,36 +114,9 @@ pub mod statements {
     }
 }
 
-/// Period snapshots: write billing-period summaries for reconciliation.
-pub mod period_snapshots {
-    #![allow(unused_variables, dead_code)]
-    use crate::types::{
-        BillingPeriodSnapshot, DataKey, Error, BILLING_PERIOD_SNAPSHOT_TTL_EXTEND_TO,
-        BILLING_PERIOD_SNAPSHOT_TTL_THRESHOLD,
-    };
-    use soroban_sdk::Env;
-
-    pub fn write_period_snapshot(
-        _env: &Env,
-        _snapshot: BillingPeriodSnapshot,
-    ) -> Result<(), Error> {
-        Ok(())
-    }
-    pub fn get_period_snapshot(
-        _env: &Env,
-        _subscription_id: u32,
-        _period_index: u64,
-    ) -> Option<BillingPeriodSnapshot> {
-        None
-    }
-    pub fn list_period_snapshots(
-        _env: &Env,
-        _subscription_id: u32,
-        _limit: u32,
-    ) -> soroban_sdk::Vec<BillingPeriodSnapshot> {
-        soroban_sdk::Vec::new(_env)
-    }
-}
+// ── Period snapshots (stub — separated into own file) ───────────────────────
+// The actual implementation lives in `period_snapshots.rs`.  The module is
+// declared at the top of this file.
 
 /// Accounting: tracks total tokens accounted for across all subscriptions.
 ///
@@ -246,7 +220,7 @@ pub mod operator {
         ids: &Vec<u32>,
         nonce: u64,
     ) -> Result<Vec<BatchChargeResult>, Error> {
-        Ok(Vec::new(_env))
+        Ok(Vec::new(env))
     }
 
     /// Single interval charge driven by the operator.
@@ -1213,18 +1187,25 @@ impl SubscriptionVault {
     /// # Events
     ///
     /// Emits [`FundsDepositedEvent`] with `subscription_id`, `amount`, and timestamp.
+    ///
+    /// # Idempotency
+    ///
+    /// When `idem_key` is `Some(key)` and a deposit with the same key has already been
+    /// processed for this subscription, the call is a no-op that returns `Ok(())` without
+    /// modifying state or transferring tokens.
     pub fn deposit_funds(
         env: Env,
         subscription_id: u32,
         subscriber: Address,
         amount: i128,
+        idem_key: Option<soroban_sdk::BytesN<32>>,
     ) -> Result<(), Error> {
         require_not_emergency_stop(&env)?;
 
         // Acquire reentrancy guard: prevents re-entry during token transfer
         let _guard = crate::reentrancy::ReentrancyGuard::lock(&env, "deposit_funds")?;
 
-        subscription::do_deposit_funds(&env, subscription_id, subscriber.clone(), amount)?;
+        subscription::do_deposit_funds(&env, subscription_id, subscriber.clone(), amount, idem_key)?;
 
         let sub = queries::get_subscription(&env, subscription_id)?;
         let timestamp = env.ledger().timestamp();
@@ -1708,18 +1689,25 @@ impl SubscriptionVault {
     /// This function acquires a reentrancy guard to prevent recursive calls during
     /// state mutations. The guard is automatically released (even on error) via the
     /// Drop trait, guaranteeing cleanup.
+    ///
+    /// # Idempotency
+    ///
+    /// When `idem_key` is `Some(key)` and a one-off charge with the same key has already
+    /// been processed for this subscription, the call is a no-op that returns `Ok(())`
+    /// without modifying state.
     pub fn charge_one_off(
         env: Env,
         subscription_id: u32,
         merchant: Address,
         amount: i128,
+        idem_key: Option<soroban_sdk::BytesN<32>>,
     ) -> Result<(), Error> {
         require_not_emergency_stop(&env)?;
 
         // Acquire reentrancy guard
         let _guard = crate::reentrancy::ReentrancyGuard::lock(&env, "charge_one_off")?;
 
-        subscription::do_charge_one_off(&env, subscription_id, merchant, amount)
+        subscription::do_charge_one_off(&env, subscription_id, merchant, amount, idem_key)
     }
 
     // ── Charging ──────────────────────────────────────────────────────────────
@@ -1736,9 +1724,17 @@ impl SubscriptionVault {
     /// This function acquires a reentrancy guard to prevent recursive calls during
     /// state mutations. The guard is automatically released (even on error) via the
     /// Drop trait, guaranteeing cleanup.
+    /// # Idempotency
+    ///
+    /// When `idem_key` is `Some(key)` and a charge with the same key has already been
+    /// processed for this subscription, the call returns the same `ChargeExecutionResult`
+    /// without modifying state.  The key is domain-separated (scoped to the
+    /// `charge_subscription` entrypoint) so that the same raw key cannot accidentally
+    /// replay across `deposit_funds` or `charge_one_off`.
     pub fn charge_subscription(
         env: Env,
         subscription_id: u32,
+        idem_key: Option<soroban_sdk::BytesN<32>>,
     ) -> Result<ChargeExecutionResult, Error> {
         require_not_emergency_stop(&env)?;
 
@@ -1749,7 +1745,7 @@ impl SubscriptionVault {
         let old_sub = queries::get_subscription(&env, subscription_id)?;
         let timestamp = env.ledger().timestamp();
         let result =
-            charge_core::charge_one(&env, subscription_id, timestamp, None)?;
+            charge_core::charge_one(&env, subscription_id, timestamp, idem_key)?;
         let new_sub = queries::get_subscription(&env, subscription_id)?;
 
         let period_start = old_sub.last_payment_timestamp;
@@ -2931,7 +2927,11 @@ mod test_charge_invariants;
 
 #[cfg(test)]
 mod test_billing_period_snapshots;
+#[cfg(test)]
 mod test_insufficient_balance;
+
+#[cfg(test)]
+mod test_idempotency_keys;
 
 #[cfg(test)]
 mod test {

--- a/contracts/subscription_vault/src/nonce.rs
+++ b/contracts/subscription_vault/src/nonce.rs
@@ -121,16 +121,6 @@ pub fn check_and_advance(
     Ok(())
 }
 
-/// Alias for [`consume_nonce`] — used by admin.rs.
-pub fn check_and_advance(
-    env: &Env,
-    signer: &Address,
-    domain: u32,
-    expected: u64,
-) -> Result<(), Error> {
-    consume_nonce(env, signer, domain, expected)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/contracts/subscription_vault/src/subscription.rs
+++ b/contracts/subscription_vault/src/subscription.rs
@@ -462,6 +462,7 @@ pub fn do_deposit_funds(
     subscription_id: u32,
     subscriber: Address,
     amount: i128,
+    idem_key: Option<soroban_sdk::BytesN<32>>,
 ) -> Result<(), Error> {
     subscriber.require_auth();
     crate::blocklist::require_not_blocklisted(env, &subscriber)?;
@@ -505,6 +506,18 @@ pub fn do_deposit_funds(
         return Err(Error::SubscriptionExpired);
     }
 
+    // Idempotent return: same idempotency key already processed
+    if let Some(ref k) = idem_key {
+        let hashed = crate::idempotency::hash_idem_key(
+            env,
+            crate::types::DOMAIN_DEPOSIT_FUNDS,
+            subscription_id,
+            k,
+        );
+        if crate::idempotency::check_key(env, subscription_id, &hashed) {
+            return Ok(());
+        }
+    }
 
     let token_addr = sub.token.clone();
 
@@ -566,6 +579,17 @@ pub fn do_deposit_funds(
                 timestamp: env.ledger().timestamp(),
             },
         );
+    }
+
+    // Record idempotency key after successful deposit
+    if let Some(k) = idem_key {
+        let hashed = crate::idempotency::hash_idem_key(
+            env,
+            crate::types::DOMAIN_DEPOSIT_FUNDS,
+            subscription_id,
+            &k,
+        );
+        crate::idempotency::push_key(env, subscription_id, &hashed);
     }
 
     Ok(())
@@ -776,6 +800,7 @@ pub fn do_charge_one_off(
     subscription_id: u32,
     merchant: Address,
     amount: i128,
+    idem_key: Option<soroban_sdk::BytesN<32>>,
 ) -> Result<(), Error> {
     merchant.require_auth();
 
@@ -799,6 +824,19 @@ pub fn do_charge_one_off(
             );
         }
         return Err(Error::SubscriptionExpired);
+    }
+
+    // Idempotent return: same idempotency key already processed
+    if let Some(ref k) = idem_key {
+        let hashed = crate::idempotency::hash_idem_key(
+            env,
+            crate::types::DOMAIN_CHARGE_ONEOFF,
+            subscription_id,
+            k,
+        );
+        if crate::idempotency::check_key(env, subscription_id, &hashed) {
+            return Ok(());
+        }
     }
 
     if sub.merchant != merchant {
@@ -939,6 +977,17 @@ pub fn do_charge_one_off(
             timestamp: now,
         },
     );
+
+    // Record idempotency key after successful one-off charge
+    if let Some(k) = idem_key {
+        let hashed = crate::idempotency::hash_idem_key(
+            env,
+            crate::types::DOMAIN_CHARGE_ONEOFF,
+            subscription_id,
+            &k,
+        );
+        crate::idempotency::push_key(env, subscription_id, &hashed);
+    }
 
     Ok(())
 }

--- a/contracts/subscription_vault/src/test.rs
+++ b/contracts/subscription_vault/src/test.rs
@@ -487,7 +487,7 @@ fn test_state_machine_property_lifecycle_entrypoints_follow_manual_model() {
                 {
                     let token_client = soroban_sdk::token::StellarAssetClient::new(&env, &token);
                     token_client.mint(&subscriber, &AMOUNT);
-                    client.deposit_funds(&id, &subscriber, &AMOUNT);
+                    client.deposit_funds(&id, &subscriber, &AMOUNT, &None::<soroban_sdk::BytesN<32>>);
                 }
 
                 let result = match action {
@@ -534,7 +534,7 @@ fn test_state_machine_property_charge_failures_and_recovery_paths_obey_rules() {
             };
             env.ledger().set_timestamp(charge_time + step as u64);
 
-            let result = client.try_charge_subscription(&id);
+            let result = client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
             assert_eq!(result, Ok(Ok(ChargeExecutionResult::InsufficientBalance)));
 
             let failed_status = client.get_subscription(&id).status;
@@ -547,7 +547,7 @@ fn test_state_machine_property_charge_failures_and_recovery_paths_obey_rules() {
 
             soroban_sdk::token::StellarAssetClient::new(&env, &token)
                 .mint(&subscriber, &topup_amount.max(1_000_000));
-            client.deposit_funds(&id, &subscriber, &topup_amount.max(1_000_000));
+            client.deposit_funds(&id, &subscriber, &topup_amount.max(1_000_000, &None::<soroban_sdk::BytesN<32>>));
 
             let after_deposit = client.get_subscription(&id).status;
             if topup_amount >= AMOUNT {
@@ -562,7 +562,7 @@ fn test_state_machine_property_charge_failures_and_recovery_paths_obey_rules() {
             if topup_amount >= AMOUNT {
                 env.ledger()
                     .set_timestamp(charge_time + INTERVAL + step as u64 + 1);
-                let charge_again = client.try_charge_subscription(&id);
+                let charge_again = client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
                 assert!(charge_again.is_ok());
                 assert_eq!(
                     client.get_subscription(&id).status,
@@ -741,7 +741,7 @@ fn test_pause_resume_then_charge_succeeds() {
     );
 
     test_env.jump(INTERVAL + 1);
-    let result = test_env.client.try_charge_subscription(&id);
+    let result = test_env.client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(result, Ok(Ok(ChargeExecutionResult::Charged)));
     assert_eq!(
         test_env.client.get_subscription(&id).prepaid_balance,
@@ -856,7 +856,7 @@ fn test_all_valid_transitions_coverage() {
             SubscriptionStatus::InsufficientBalance,
         );
         test_env.stellar_token_client().mint(&subscriber, &AMOUNT);
-        test_env.client.deposit_funds(&id, &subscriber, &AMOUNT);
+        test_env.client.deposit_funds(&id, &subscriber, &AMOUNT, &None::<soroban_sdk::BytesN<32>>);
         test_env.client.resume_subscription(&id, &subscriber);
         assertions::assert_status(&test_env.client, &id, SubscriptionStatus::Active);
     }
@@ -979,7 +979,7 @@ fn test_charge_subscription_basic() {
         .env
         .ledger()
         .with_mut(|li| li.timestamp = T0 + INTERVAL + 1);
-    test_env.client.charge_subscription(&id);
+    test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
 
     assert_eq!(test_env.client.get_subscription(&id).prepaid_balance, PREPAID - AMOUNT);
     let sub = test_env.client.get_subscription(&id);
@@ -1001,7 +1001,7 @@ fn test_charge_subscription_paused_fails() {
     fixtures::seed_balance(&test_env.env, &test_env.client, id, PREPAID);
     test_env.client.pause_subscription(&id, &subscriber);
     test_env.jump(INTERVAL + 1);
-    test_env.client.charge_subscription(&id);
+    test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
 }
 
 #[test]
@@ -1018,7 +1018,7 @@ fn test_charge_subscription_insufficient_balance_returns_error() {
 
     let grace_period = 7 * 24 * 60 * 60u64;
     test_env.jump(INTERVAL + grace_period + 1);
-    let result = test_env.client.try_charge_subscription(&id);
+    let result = test_env.client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(result, Ok(Ok(ChargeExecutionResult::InsufficientBalance)));
 }
 
@@ -1075,7 +1075,7 @@ fn test_withdraw_subscriber_funds() {
         &None::<i128>,
         &None::<u64>,
     );
-    test_env.client.deposit_funds(&sub_id, &subscriber, &5_000_000);
+    test_env.client.deposit_funds(&sub_id, &subscriber, &5_000_000, &None::<soroban_sdk::BytesN<32>>);
     test_env.client.cancel_subscription(&sub_id, &subscriber);
     test_env.client.withdraw_subscriber_funds(&sub_id, &subscriber);
 
@@ -1104,7 +1104,7 @@ fn test_min_topup_below_threshold() {
         &None::<i128>,
      &None::<u64>);
     test_env.client.cancel_subscription(&id, &merchant);
-    let result = test_env.client.try_deposit_funds(&id, &subscriber, &4_999_999);
+    let result = test_env.client.try_deposit_funds(&id, &subscriber, &4_999_999, &None::<soroban_sdk::BytesN<32>>);
     assert!(result.is_err());
 }
 
@@ -1135,7 +1135,7 @@ fn test_min_topup_exactly_at_threshold() {
         &None::<i128>,
      &None::<u64>);
     assert!(client
-        .try_deposit_funds(&id, &subscriber, &min_topup)
+        .try_deposit_funds(&id, &subscriber, &min_topup, &None::<soroban_sdk::BytesN<32>>)
         .is_ok());
 }
 
@@ -1169,7 +1169,7 @@ fn test_min_topup_above_threshold() {
         &None::<i128>,
      &None::<u64>);
     assert!(client
-        .try_deposit_funds(&id, &subscriber, &deposit_amount)
+        .try_deposit_funds(&id, &subscriber, &deposit_amount, &None::<soroban_sdk::BytesN<32>>)
         .is_ok());
 }
 
@@ -1195,7 +1195,7 @@ fn test_deposit_funds_basic() {
         &None::<i128>,
         &None::<u64>,
     );
-    test_env.client.deposit_funds(&id, &subscriber, &5_000_000);
+    test_env.client.deposit_funds(&id, &subscriber, &5_000_000, &None::<soroban_sdk::BytesN<32>>);
     assertions::assert_prepaid_balance(&test_env.client, &id, 5_000_000);
 }
 
@@ -1217,7 +1217,7 @@ fn test_deposit_funds_unauthorized() {
         &false,
         &None::<i128>,
      &None::<u64>);
-    let result = client.try_deposit_funds(&id, &other, &5_000_000);
+    let result = client.try_deposit_funds(&id, &other, &5_000_000, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(result, Err(Ok(Error::Unauthorized)));
 
     let sub = client.get_subscription(&id);
@@ -1243,7 +1243,7 @@ fn test_deposit_funds_event_payload() {
         &None::<u64>,
     );
     
-    client.deposit_funds(&id, &subscriber, &15_000_000);
+    client.deposit_funds(&id, &subscriber, &15_000_000, &None::<soroban_sdk::BytesN<32>>);
 
     let events = env.events().all();
     let deposit_event = events.last().expect("No events found");
@@ -1291,7 +1291,7 @@ fn test_deposit_funds_cei_compliance() {
     let initial_contract_balance = token_client.balance(&client.address);
     let deposit_amount = 20_000_000i128;
 
-    client.deposit_funds(&id, &subscriber, &deposit_amount);
+    client.deposit_funds(&id, &subscriber, &deposit_amount, &None::<soroban_sdk::BytesN<32>>);
 
     // Check effects (state)
     let sub = client.get_subscription(&id);
@@ -1322,7 +1322,7 @@ fn test_deposit_funds_below_minimum() {
         &None::<u64>,
     );
     // min_topup is 1_000_000; try to deposit 500
-    test_env.client.deposit_funds(&id, &subscriber, &500);
+    test_env.client.deposit_funds(&id, &subscriber, &500, &None::<soroban_sdk::BytesN<32>>);
 }
 
 // -- Blocklist tests ----------------------------------------------------------
@@ -1480,7 +1480,7 @@ fn test_blocklist_enforced_across_mutating_subscription_flows_and_unblock_restor
     assert_eq!(
         test_env
             .client
-            .try_deposit_funds(&plan_sub, &subscriber, &5_000_000i128),
+            .try_deposit_funds(&plan_sub, &subscriber, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>),
         Err(Ok(Error::SubscriberBlocklisted))
     );
     assert_eq!(
@@ -1511,7 +1511,7 @@ fn test_blocklist_enforced_across_mutating_subscription_flows_and_unblock_restor
     );
     test_env
         .client
-        .deposit_funds(&plan_sub, &subscriber, &5_000_000i128);
+        .deposit_funds(&plan_sub, &subscriber, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     test_env.client.resume_subscription(&direct_sub, &subscriber);
     test_env
         .client
@@ -2349,10 +2349,10 @@ fn test_next_charge_info_cross_check_status_gating() {
 
     // Cross-check gating: paused / cancelled / insufficient states fail immediately.
     // Grace period passes the status gate, but still obeys the interval gate.
-    assert_eq!(client.try_charge_subscription(&id_paused), Err(Ok(Error::NotActive)));
-    assert_eq!(client.try_charge_subscription(&id_cancelled), Err(Ok(Error::NotActive)));
-    assert_eq!(client.try_charge_subscription(&id_insufficient), Err(Ok(Error::NotActive)));
-    assert_eq!(client.try_charge_subscription(&id_grace), Err(Ok(Error::IntervalNotElapsed)));
+    assert_eq!(client.try_charge_subscription(&id_paused, &None::<soroban_sdk::BytesN<32>>), Err(Ok(Error::NotActive)));
+    assert_eq!(client.try_charge_subscription(&id_cancelled, &None::<soroban_sdk::BytesN<32>>), Err(Ok(Error::NotActive)));
+    assert_eq!(client.try_charge_subscription(&id_insufficient, &None::<soroban_sdk::BytesN<32>>), Err(Ok(Error::NotActive)));
+    assert_eq!(client.try_charge_subscription(&id_grace, &None::<soroban_sdk::BytesN<32>>), Err(Ok(Error::IntervalNotElapsed)));
 }
 
 // -- Top-up estimation (precision) --------------------------------------------
@@ -2405,7 +2405,7 @@ fn test_estimate_topup_cross_check_after_actual_charge() {
     // Execute one real charge at the exact boundary.
     env.ledger().with_mut(|li| li.timestamp = T0 + INTERVAL);
     assert_eq!(
-        client.try_charge_subscription(&id),
+        client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>),
         Ok(Ok(ChargeExecutionResult::Charged))
     );
 
@@ -2479,9 +2479,9 @@ fn test_replay_charge_same_period() {
     fixtures::seed_balance(&test_env.env, &test_env.client, id, PREPAID);
 
     test_env.jump(INTERVAL + 1);
-    test_env.client.charge_subscription(&id);
+    test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     // Second charge in same period should fail
-    test_env.client.charge_subscription(&id);
+    test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
 }
 
 // -- Recovery -----------------------------------------------------------------
@@ -2526,14 +2526,14 @@ fn test_lifetime_cap_auto_cancel() {
 
     // First charge
     test_env.jump(INTERVAL + 1);
-    test_env.client.charge_subscription(&id);
+    test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     let sub = test_env.client.get_subscription(&id);
     assert_eq!(sub.lifetime_charged, AMOUNT);
     assert_eq!(sub.status, SubscriptionStatus::Active);
 
     // Second charge -> cap reached -> auto-cancel
     test_env.jump(INTERVAL);
-    test_env.client.charge_subscription(&id);
+    test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     let sub = test_env.client.get_subscription(&id);
     assert_eq!(sub.lifetime_charged, 2 * AMOUNT);
     assert_eq!(sub.status, SubscriptionStatus::Cancelled);
@@ -2721,12 +2721,12 @@ fn test_subscriber_credit_limit_blocks_topup_when_exposure_exceeds_limit() {
     // Deposit that would keep us under the limit succeeds.
     test_env
         .client
-        .deposit_funds(&sub_id, &subscriber, &5_000_000i128);
+        .deposit_funds(&sub_id, &subscriber, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Further deposit would push exposure over the limit and must be rejected.
     let result = test_env
         .client
-        .try_deposit_funds(&sub_id, &subscriber, &1_000_000i128);
+        .try_deposit_funds(&sub_id, &subscriber, &1_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(result, Err(Ok(Error::CreditLimitExceeded)));
 }
 
@@ -2768,7 +2768,7 @@ fn test_get_subscriber_credit_limit_and_exposure_views() {
     // After topping up, exposure increases by the deposited amount.
     test_env
         .client
-        .deposit_funds(&sub_id, &subscriber, &5_000_000i128);
+        .deposit_funds(&sub_id, &subscriber, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     let exposure_after_topup = test_env
         .client
         .get_subscriber_exposure(&subscriber, &test_env.token);
@@ -2791,7 +2791,7 @@ fn test_partial_refund_debits_prepaid_and_transfers_tokens() {
         &false,
         &None::<i128>,
      &None::<u64>);
-    test_env.client.deposit_funds(&sub_id, &subscriber, &20_000_000i128);
+    test_env.client.deposit_funds(&sub_id, &subscriber, &20_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     let balance_before = test_env.token_client().balance(&subscriber);
     assertions::assert_prepaid_balance(&test_env.client, &sub_id, 20_000_000i128);
@@ -2822,7 +2822,7 @@ fn test_partial_refund_rejects_invalid_amounts_and_auth() {
         &false,
         &None::<i128>,
      &None::<u64>);
-    test_env.client.deposit_funds(&sub_id, &subscriber, &5_000_000i128);
+    test_env.client.deposit_funds(&sub_id, &subscriber, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Zero or negative refund amounts are rejected.
     let zero_res =
@@ -2888,7 +2888,7 @@ fn test_partial_refund_repeated_debits_are_cumulative() {
     );
     test_env
         .client
-        .deposit_funds(&sub_id, &subscriber, &30_000_000i128);
+        .deposit_funds(&sub_id, &subscriber, &30_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Three successive partial refunds of 5 USDC each.
     for _ in 0..3 {
@@ -2922,7 +2922,7 @@ fn test_partial_refund_cumulative_exact_drain_then_over_refund_fails() {
     );
     test_env
         .client
-        .deposit_funds(&sub_id, &subscriber, &10_000_000i128);
+        .deposit_funds(&sub_id, &subscriber, &10_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Refund the full balance as two equal halves.
     test_env
@@ -2961,7 +2961,7 @@ fn test_partial_refund_full_balance_as_partial_succeeds() {
     );
     test_env
         .client
-        .deposit_funds(&sub_id, &subscriber, &20_000_000i128);
+        .deposit_funds(&sub_id, &subscriber, &20_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Refund the entire prepaid balance in one call.
     test_env
@@ -2992,7 +2992,7 @@ fn test_partial_refund_after_cancellation_succeeds() {
     );
     test_env
         .client
-        .deposit_funds(&sub_id, &subscriber, &15_000_000i128);
+        .deposit_funds(&sub_id, &subscriber, &15_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     test_env.client.cancel_subscription(&sub_id, &subscriber);
 
     // Admin can still issue a partial refund on a cancelled subscription.
@@ -3026,7 +3026,7 @@ fn test_partial_refund_emits_event() {
     );
     test_env
         .client
-        .deposit_funds(&sub_id, &subscriber, &10_000_000i128);
+        .deposit_funds(&sub_id, &subscriber, &10_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     test_env
         .client
@@ -3199,9 +3199,9 @@ fn test_withdraw_subscriber_funds_exactly_once() {
         &None::<i128>,
         &None::<u64>,
     );
-    test_env.client.deposit_funds(&id, &subscriber, &10_000_000);
+    test_env.client.deposit_funds(&id, &subscriber, &10_000_000, &None::<soroban_sdk::BytesN<32>>);
 
-    test_env.client.deposit_funds(&id, &subscriber, &5_000_000);
+    test_env.client.deposit_funds(&id, &subscriber, &5_000_000, &None::<soroban_sdk::BytesN<32>>);
     test_env.client.cancel_subscription(&id, &subscriber);
 
     // First withdrawal: Success
@@ -3254,7 +3254,7 @@ fn test_cancel_and_withdraw_events() {
         &None::<i128>,
         &None::<u64>,
     );
-    test_env.client.deposit_funds(&id, &subscriber, &5_000_000);
+    test_env.client.deposit_funds(&id, &subscriber, &5_000_000, &None::<soroban_sdk::BytesN<32>>);
 
     test_env.client.cancel_subscription(&id, &subscriber);
 
@@ -3323,18 +3323,18 @@ fn test_cap_cancelled_subscriber_can_withdraw() {
      &None::<u64>);
 
     // Deposit exactly cap so the deposit fits within enforce_deposit_cap.
-    test_env.client.deposit_funds(&sub_id, &subscriber, &cap);
+    test_env.client.deposit_funds(&sub_id, &subscriber, &cap, &None::<soroban_sdk::BytesN<32>>);
 
     test_env
         .env
         .ledger()
         .with_mut(|li| li.timestamp = T0 + INTERVAL + 1);
-    test_env.client.charge_subscription(&sub_id); // charges AMOUNT, balance = cap - AMOUNT = 5M
+    test_env.client.charge_subscription(&sub_id, &None::<soroban_sdk::BytesN<32>>); // charges AMOUNT, balance = cap - AMOUNT = 5M
     test_env
         .env
         .ledger()
         .with_mut(|li| li.timestamp = T0 + 2 * INTERVAL + 1);
-    test_env.client.charge_subscription(&sub_id); // remaining cap < AMOUNT → cancel, balance stays 5M
+    test_env.client.charge_subscription(&sub_id, &None::<soroban_sdk::BytesN<32>>); // remaining cap < AMOUNT → cancel, balance stays 5M
 
     assertions::assert_status(&test_env.client, &sub_id, SubscriptionStatus::Cancelled);
     let sub_after = test_env.client.get_subscription(&sub_id);
@@ -3394,7 +3394,7 @@ fn test_merchant_balance_and_withdrawal() {
         .env
         .ledger()
         .with_mut(|li| li.timestamp = T0 + INTERVAL + 1);
-    test_env.client.charge_subscription(&id);
+    test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
 
     let balance = test_env.client.get_merchant_balance(&merchant);
     assert!(balance > 0);
@@ -3616,7 +3616,7 @@ fn test_billing_lifecycle_golden_path_end_to_end() {
     assert_eq!(created.last_payment_timestamp, T0);
     assert_eq!(test_env.client.get_merchant_balance(&merchant), 0);
 
-    test_env.client.deposit_funds(&id, &subscriber, &PREPAID);
+    test_env.client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
     let after_deposit = test_env.client.get_subscription(&id);
     assert_eq!(after_deposit.status, SubscriptionStatus::Active);
     assert_eq!(after_deposit.prepaid_balance, PREPAID);
@@ -3630,7 +3630,7 @@ fn test_billing_lifecycle_golden_path_end_to_end() {
     );
 
     test_env.env.ledger().set_timestamp(T0 + INTERVAL);
-    test_env.client.charge_subscription(&id);
+    test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     let after_first_charge = test_env.client.get_subscription(&id);
     assert_eq!(after_first_charge.status, SubscriptionStatus::Active);
     assert_eq!(after_first_charge.prepaid_balance, PREPAID - AMOUNT);
@@ -3639,7 +3639,7 @@ fn test_billing_lifecycle_golden_path_end_to_end() {
     assert_eq!(test_env.client.get_merchant_balance(&merchant), AMOUNT);
 
     test_env.env.ledger().set_timestamp(T0 + (2 * INTERVAL));
-    test_env.client.charge_subscription(&id);
+    test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     let after_second_charge = test_env.client.get_subscription(&id);
     assert_eq!(after_second_charge.status, SubscriptionStatus::Active);
     assert_eq!(after_second_charge.prepaid_balance, PREPAID - (2 * AMOUNT));
@@ -3739,11 +3739,11 @@ fn test_billing_lifecycle_delayed_charge_and_min_topup_progression() {
     );
     test_env
         .client
-        .deposit_funds(&id, &subscriber, &19_000_000i128);
+        .deposit_funds(&id, &subscriber, &19_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     let delayed_charge_at = T0 + (2 * INTERVAL) + 77;
     test_env.env.ledger().set_timestamp(delayed_charge_at);
-    test_env.client.charge_subscription(&id);
+    test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
 
     let after_delayed_charge = test_env.client.get_subscription(&id);
     assert_eq!(after_delayed_charge.status, SubscriptionStatus::Active);
@@ -3757,7 +3757,7 @@ fn test_billing_lifecycle_delayed_charge_and_min_topup_progression() {
 
     test_env
         .client
-        .deposit_funds(&id, &subscriber, &1_000_000i128);
+        .deposit_funds(&id, &subscriber, &1_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     let after_topup = test_env.client.get_subscription(&id);
     assert_eq!(after_topup.prepaid_balance, AMOUNT);
 
@@ -3765,7 +3765,7 @@ fn test_billing_lifecycle_delayed_charge_and_min_topup_progression() {
         .env
         .ledger()
         .set_timestamp(delayed_charge_at + INTERVAL);
-    test_env.client.charge_subscription(&id);
+    test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
 
     let after_second_charge = test_env.client.get_subscription(&id);
     assert_eq!(after_second_charge.status, SubscriptionStatus::Active);
@@ -3987,7 +3987,7 @@ fn test_withdraw_subscriber_funds_after_cancel() {
         &None::<i128>,
         &None::<u64>,
     );
-    test_env.client.deposit_funds(&id, &subscriber, &5_000_000);
+    test_env.client.deposit_funds(&id, &subscriber, &5_000_000, &None::<soroban_sdk::BytesN<32>>);
     test_env.client.cancel_subscription(&id, &subscriber);
 
     test_env.client.withdraw_subscriber_funds(&id, &subscriber);
@@ -4514,14 +4514,14 @@ fn test_billing_statements_offset_pagination_newest_first() {
         &true,
         &None::<i128>,
      &None::<u64>);
-    test_env.client.deposit_funds(&id, &subscriber, &200_000_000i128);
+    test_env.client.deposit_funds(&id, &subscriber, &200_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     for i in 1..=6 {
         test_env
             .env
             .ledger()
             .set_timestamp(T0 + (i as u64 * INTERVAL));
-        test_env.client.charge_subscription(&id);
+        test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     }
 
     let page1 = test_env
@@ -4558,14 +4558,14 @@ fn test_billing_statements_cursor_pagination_boundaries() {
         &true,
         &None::<i128>,
      &None::<u64>);
-    test_env.client.deposit_funds(&id, &subscriber, &200_000_000i128);
+    test_env.client.deposit_funds(&id, &subscriber, &200_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     for i in 1..=4 {
         test_env
             .env
             .ledger()
             .set_timestamp(T0 + (i as u64 * INTERVAL));
-        test_env.client.charge_subscription(&id);
+        test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     }
 
     let first = test_env
@@ -4609,14 +4609,14 @@ fn test_compaction_prunes_old_statements_and_keeps_recent() {
         &false,
         &None::<i128>,
      &None::<u64>);
-    test_env.client.deposit_funds(&id, &subscriber, &500_000_000i128);
+    test_env.client.deposit_funds(&id, &subscriber, &500_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     for i in 1..=8 {
         test_env
             .env
             .ledger()
             .set_timestamp(T0 + (i as u64 * INTERVAL));
-        test_env.client.charge_subscription(&id);
+        test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     }
 
     test_env.client.set_billing_retention(&test_env.admin, &3);
@@ -4683,14 +4683,14 @@ fn test_compaction_idempotent_second_run() {
     );
     test_env
         .client
-        .deposit_funds(&id, &subscriber, &500_000_000i128);
+        .deposit_funds(&id, &subscriber, &500_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     for i in 1..=8 {
         test_env
             .env
             .ledger()
             .set_timestamp(T0 + (i as u64 * INTERVAL));
-        test_env.client.charge_subscription(&id);
+        test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     }
 
     test_env.client.set_billing_retention(&test_env.admin, &3);
@@ -4732,14 +4732,14 @@ fn test_compaction_keep_recent_zero_prunes_all_detail() {
     );
     test_env
         .client
-        .deposit_funds(&id, &subscriber, &100_000_000i128);
+        .deposit_funds(&id, &subscriber, &100_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     for i in 1..=4 {
         test_env
             .env
             .ledger()
             .set_timestamp(T0 + (i as u64 * INTERVAL));
-        test_env.client.charge_subscription(&id);
+        test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     }
 
     let summary = test_env
@@ -4829,14 +4829,14 @@ fn test_compaction_override_respects_per_run_threshold() {
     );
     test_env
         .client
-        .deposit_funds(&id, &subscriber, &500_000_000i128);
+        .deposit_funds(&id, &subscriber, &500_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     for i in 1..=6 {
         test_env
             .env
             .ledger()
             .set_timestamp(T0 + (i as u64 * INTERVAL));
-        test_env.client.charge_subscription(&id);
+        test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     }
 
     test_env
@@ -4878,10 +4878,10 @@ fn test_oracle_enabled_charge_uses_quote_conversion() {
         &false,
         &None::<i128>,
      &None::<u64>);
-    test_env.client.deposit_funds(&id, &subscriber, &100_000_000i128);
+    test_env.client.deposit_funds(&id, &subscriber, &100_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     test_env.env.ledger().set_timestamp(T0 + INTERVAL);
-    test_env.client.charge_subscription(&id);
+    test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
 
     assert_eq!(test_env.client.get_merchant_balance(&merchant), 10_000_000i128);
 }
@@ -4906,9 +4906,9 @@ fn test_oracle_stale_quote_rejected() {
         &false,
         &None::<i128>,
      &None::<u64>);
-    test_env.client.deposit_funds(&id, &subscriber, &100_000_000i128);
+    test_env.client.deposit_funds(&id, &subscriber, &100_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
-    let result = test_env.client.try_charge_subscription(&id);
+    let result = test_env.client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(result, Err(Ok(Error::OraclePriceStale)));
 }
 
@@ -5933,7 +5933,7 @@ fn resume_actor_cases() {
 
         if *initial_status == SubscriptionStatus::InsufficientBalance && *expect_ok {
             test_env.stellar_token_client().mint(&subscriber, &AMOUNT);
-            test_env.client.deposit_funds(&id, &subscriber, &AMOUNT);
+            test_env.client.deposit_funds(&id, &subscriber, &AMOUNT, &None::<soroban_sdk::BytesN<32>>);
         }
 
         let result = test_env.client.try_resume_subscription(&id, &actor);
@@ -6185,7 +6185,7 @@ fn test_cancelled_to_insufficient_balance_blocked() {
     assertions::assert_status(&test_env.client, &id, SubscriptionStatus::Cancelled);
 
     test_env.jump(INTERVAL + 1);
-    let result = test_env.client.try_charge_subscription(&id);
+    let result = test_env.client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert!(result.is_err(), "charge on Cancelled must fail");
     // status must remain Cancelled  never flipped to InsufficientBalance.
     assertions::assert_status(&test_env.client, &id, SubscriptionStatus::Cancelled);
@@ -6207,7 +6207,7 @@ fn test_idempotent_pause_preserves_all_fields() {
         INTERVAL,
     );
     test_env.stellar_token_client().mint(&subscriber, &PREPAID);
-    test_env.client.deposit_funds(&id, &subscriber, &PREPAID);
+    test_env.client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
 
     let before = test_env.client.get_subscription(&id);
 
@@ -6244,7 +6244,7 @@ fn test_idempotent_cancel_preserves_all_fields() {
         INTERVAL,
     );
     test_env.stellar_token_client().mint(&subscriber, &PREPAID);
-    test_env.client.deposit_funds(&id, &subscriber, &PREPAID);
+    test_env.client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
 
     let before = test_env.client.get_subscription(&id);
 
@@ -6420,7 +6420,7 @@ fn test_balance_preserved_across_pause_resume() {
     let (id, subscriber, _) =
         fixtures::create_subscription(&test_env.env, &test_env.client, SubscriptionStatus::Active);
     test_env.stellar_token_client().mint(&subscriber, &PREPAID);
-    test_env.client.deposit_funds(&id, &subscriber, &PREPAID);
+    test_env.client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
 
     let original_balance = test_env.client.get_subscription(&id).prepaid_balance;
 
@@ -6438,7 +6438,7 @@ fn test_balance_preserved_on_cancel() {
     let (id, subscriber, _) =
         fixtures::create_subscription(&test_env.env, &test_env.client, SubscriptionStatus::Active);
     test_env.stellar_token_client().mint(&subscriber, &PREPAID);
-    test_env.client.deposit_funds(&id, &subscriber, &PREPAID);
+    test_env.client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
 
     let original_balance = test_env.client.get_subscription(&id).prepaid_balance;
 
@@ -6457,14 +6457,14 @@ fn test_charge_blocked_while_paused() {
     let (id, subscriber, _) =
         fixtures::create_subscription(&test_env.env, &test_env.client, SubscriptionStatus::Active);
     test_env.stellar_token_client().mint(&subscriber, &PREPAID);
-    test_env.client.deposit_funds(&id, &subscriber, &PREPAID);
+    test_env.client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
 
     test_env.client.pause_subscription(&id, &subscriber);
     assertions::assert_status(&test_env.client, &id, SubscriptionStatus::Paused);
 
     test_env.jump(INTERVAL + 1);
 
-    let result = test_env.client.try_charge_subscription(&id);
+    let result = test_env.client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(
         result,
         Err(Ok(Error::NotActive)),
@@ -6481,14 +6481,14 @@ fn test_charge_blocked_after_cancel() {
     let (id, subscriber, _) =
         fixtures::create_subscription(&test_env.env, &test_env.client, SubscriptionStatus::Active);
     test_env.stellar_token_client().mint(&subscriber, &PREPAID);
-    test_env.client.deposit_funds(&id, &subscriber, &PREPAID);
+    test_env.client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
 
     test_env.client.cancel_subscription(&id, &subscriber);
     assertions::assert_status(&test_env.client, &id, SubscriptionStatus::Cancelled);
 
     test_env.jump(INTERVAL + 1);
 
-    let result = test_env.client.try_charge_subscription(&id);
+    let result = test_env.client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(
         result,
         Err(Ok(Error::NotActive)),
@@ -6506,7 +6506,7 @@ fn test_resume_and_charge_immediately() {
     let (id, subscriber, _) =
         fixtures::create_subscription(&test_env.env, &test_env.client, SubscriptionStatus::Active);
     test_env.stellar_token_client().mint(&subscriber, &PREPAID);
-    test_env.client.deposit_funds(&id, &subscriber, &PREPAID);
+    test_env.client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
 
     // Pause while the interval elapses.
     test_env.client.pause_subscription(&id, &subscriber);
@@ -6516,7 +6516,7 @@ fn test_resume_and_charge_immediately() {
     test_env.client.resume_subscription(&id, &subscriber);
     assertions::assert_status(&test_env.client, &id, SubscriptionStatus::Active);
 
-    let result = test_env.client.try_charge_subscription(&id);
+    let result = test_env.client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert!(
         result.is_ok(),
         "charge after resume with elapsed interval must succeed"
@@ -6649,11 +6649,11 @@ fn test_batch_charge_with_paused_and_cancelled() {
     test_env.stellar_token_client().mint(&sub_a, &PREPAID);
     test_env.stellar_token_client().mint(&sub_b, &PREPAID);
     test_env.stellar_token_client().mint(&sub_c, &PREPAID);
-    test_env.client.deposit_funds(&id_active, &sub_a, &PREPAID);
-    test_env.client.deposit_funds(&id_paused, &sub_b, &PREPAID);
+    test_env.client.deposit_funds(&id_active, &sub_a, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
+    test_env.client.deposit_funds(&id_paused, &sub_b, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
     test_env
         .client
-        .deposit_funds(&id_cancelled, &sub_c, &PREPAID);
+        .deposit_funds(&id_cancelled, &sub_c, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
 
     test_env.client.pause_subscription(&id_paused, &sub_b);
     test_env.client.cancel_subscription(&id_cancelled, &sub_c);
@@ -6685,7 +6685,7 @@ fn test_pause_cancel_withdraw_flow() {
     let (id, subscriber, _) =
         fixtures::create_subscription(&test_env.env, &test_env.client, SubscriptionStatus::Active);
     test_env.stellar_token_client().mint(&subscriber, &PREPAID);
-    test_env.client.deposit_funds(&id, &subscriber, &PREPAID);
+    test_env.client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
 
     let original_balance = test_env.client.get_subscription(&id).prepaid_balance;
 
@@ -6734,7 +6734,7 @@ fn test_insufficient_deposit_resume_flow() {
 
     // Subscriber tops up  balance credited regardless of status.
     test_env.stellar_token_client().mint(&subscriber, &PREPAID);
-    test_env.client.deposit_funds(&id, &subscriber, &PREPAID);
+    test_env.client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
     assertions::assert_prepaid_balance(&test_env.client, &id, PREPAID);
 
     // Resume brings subscription back to Active.
@@ -6743,7 +6743,7 @@ fn test_insufficient_deposit_resume_flow() {
 
     // A charge must now succeed once the interval elapses.
     test_env.jump(INTERVAL + 1);
-    let result = test_env.client.try_charge_subscription(&id);
+    let result = test_env.client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert!(
         result.is_ok(),
         "charge after insufficient→deposit→resume must succeed"
@@ -6781,7 +6781,7 @@ fn setup_oracle_env<'a>(
         &None::<i128>,
         &None::<u64>,
     );
-    client.deposit_funds(&id, &subscriber, &200_000_000i128);
+    client.deposit_funds(&id, &subscriber, &200_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     (id, subscriber, merchant, oracle)
 }
 
@@ -6857,10 +6857,10 @@ fn test_oracle_disabled_charge_uses_subscription_amount_directly() {
     );
     test_env
         .client
-        .deposit_funds(&id, &subscriber, &50_000_000i128);
+        .deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     test_env.env.ledger().set_timestamp(T0 + INTERVAL);
-    test_env.client.charge_subscription(&id);
+    test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
 
     // Merchant receives exactly AMOUNT (no oracle conversion).
     assert_eq!(test_env.client.get_merchant_balance(&merchant), AMOUNT);
@@ -6883,7 +6883,7 @@ fn test_oracle_zero_price_rejected() {
     );
 
     test_env.env.ledger().set_timestamp(T0 + INTERVAL);
-    let result = test_env.client.try_charge_subscription(&id);
+    let result = test_env.client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(result, Err(Ok(Error::OraclePriceInvalid)));
 }
 
@@ -6904,7 +6904,7 @@ fn test_oracle_negative_price_rejected() {
     );
 
     test_env.env.ledger().set_timestamp(T0 + INTERVAL);
-    let result = test_env.client.try_charge_subscription(&id);
+    let result = test_env.client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(result, Err(Ok(Error::OraclePriceInvalid)));
 }
 
@@ -6926,7 +6926,7 @@ fn test_oracle_zero_timestamp_price_unavailable() {
     );
 
     test_env.env.ledger().set_timestamp(T0 + INTERVAL);
-    let result = test_env.client.try_charge_subscription(&id);
+    let result = test_env.client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(result, Err(Ok(Error::OraclePriceUnavailable)));
 }
 
@@ -6964,7 +6964,7 @@ fn test_oracle_price_exactly_at_max_age_boundary_accepted() {
     );
     test_env
         .client
-        .deposit_funds(&id, &subscriber, &200_000_000i128);
+        .deposit_funds(&id, &subscriber, &200_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Set last_payment_timestamp so interval has elapsed by charge_ts.
     let mut sub = test_env.client.get_subscription(&id);
@@ -6975,7 +6975,7 @@ fn test_oracle_price_exactly_at_max_age_boundary_accepted() {
 
     test_env.env.ledger().set_timestamp(charge_ts);
     // Should succeed — price age == max_age_seconds (boundary, not stale).
-    test_env.client.charge_subscription(&id);
+    test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(
         test_env.client.get_merchant_balance(&merchant),
         10_000_000i128
@@ -7013,7 +7013,7 @@ fn test_oracle_price_one_second_past_max_age_rejected() {
     );
     test_env
         .client
-        .deposit_funds(&id, &subscriber, &200_000_000i128);
+        .deposit_funds(&id, &subscriber, &200_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Set last_payment_timestamp so interval has elapsed by charge_ts.
     let mut sub = test_env.client.get_subscription(&id);
@@ -7023,7 +7023,7 @@ fn test_oracle_price_one_second_past_max_age_rejected() {
     });
 
     test_env.env.ledger().set_timestamp(charge_ts);
-    let result = test_env.client.try_charge_subscription(&id);
+    let result = test_env.client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(result, Err(Ok(Error::OraclePriceStale)));
 }
 
@@ -7061,10 +7061,10 @@ fn test_oracle_enabled_no_address_stored_returns_not_configured() {
     );
     test_env
         .client
-        .deposit_funds(&id, &subscriber, &50_000_000i128);
+        .deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     test_env.env.ledger().set_timestamp(T0 + INTERVAL);
-    let result = test_env.client.try_charge_subscription(&id);
+    let result = test_env.client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(result, Err(Ok(Error::OracleNotConfigured)));
 }
 
@@ -7089,7 +7089,7 @@ fn test_oracle_error_does_not_mutate_balances() {
     let merchant_before = test_env.client.get_merchant_balance(&merchant);
 
     test_env.env.ledger().set_timestamp(T0 + INTERVAL);
-    let _ = test_env.client.try_charge_subscription(&id);
+    let _ = test_env.client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
 
     assert_eq!(
         test_env.client.get_subscription(&id).prepaid_balance,
@@ -7603,8 +7603,8 @@ fn test_merchant_token_bucket_reconciliation() {
         &None::<u64>,
     );
 
-    client.deposit_funds(&id_a, &subscriber_a, &20_000_000i128);
-    client.deposit_funds(&id_b, &subscriber_b, &20_000_000i128);
+    client.deposit_funds(&id_a, &subscriber_a, &20_000_000i128, &None::<soroban_sdk::BytesN<32>>);
+    client.deposit_funds(&id_b, &subscriber_b, &20_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     assert_eq!(client.get_merchant_balance_by_token(&merchant, &token_a), 0);
     assert_eq!(client.get_merchant_balance_by_token(&merchant, &token_b), 0);
@@ -7612,8 +7612,8 @@ fn test_merchant_token_bucket_reconciliation() {
 
     // Charge cycle 1
     env.ledger().set_timestamp(T0 + INTERVAL);
-    client.charge_subscription(&id_a);
-    client.charge_subscription(&id_b);
+    client.charge_subscription(&id_a, &None::<soroban_sdk::BytesN<32>>);
+    client.charge_subscription(&id_b, &None::<soroban_sdk::BytesN<32>>);
 
     assert_eq!(
         client.get_merchant_balance_by_token(&merchant, &token_a),
@@ -7643,8 +7643,8 @@ fn test_merchant_token_bucket_reconciliation() {
 
     // Charge cycle 2 (interleaved sequence)
     env.ledger().set_timestamp(T0 + 2 * INTERVAL);
-    client.charge_subscription(&id_a);
-    client.charge_subscription(&id_b);
+    client.charge_subscription(&id_a, &None::<soroban_sdk::BytesN<32>>);
+    client.charge_subscription(&id_b, &None::<soroban_sdk::BytesN<32>>);
 
     assert_eq!(
         client.get_merchant_balance_by_token(&merchant, &token_a),
@@ -7888,10 +7888,10 @@ fn test_oneoff_unauthorized_merchant_rejected() {
         &None::<i128>,
         &None::<u64>,
     );
-    client.deposit_funds(&id, &subscriber, &50_000_000i128);
+    client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Imposter (different merchant) must be rejected
-    let res = client.try_charge_one_off(&id, &imposter, &5_000_000i128);
+    let res = client.try_charge_one_off(&id, &imposter, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(res, Err(Ok(Error::Unauthorized)));
 
     // Verify balance unchanged
@@ -7916,9 +7916,9 @@ fn test_oneoff_zero_amount_rejected() {
         &None::<i128>,
         &None::<u64>,
     );
-    client.deposit_funds(&id, &subscriber, &50_000_000i128);
+    client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
-    let res = client.try_charge_one_off(&id, &merchant, &0i128);
+    let res = client.try_charge_one_off(&id, &merchant, &0i128, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(res, Err(Ok(Error::InvalidAmount)));
 }
 
@@ -7939,9 +7939,9 @@ fn test_oneoff_negative_amount_rejected() {
         &None::<i128>,
         &None::<u64>,
     );
-    client.deposit_funds(&id, &subscriber, &50_000_000i128);
+    client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
-    let res = client.try_charge_one_off(&id, &merchant, &-1i128);
+    let res = client.try_charge_one_off(&id, &merchant, &-1i128, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(res, Err(Ok(Error::InvalidAmount)));
 }
 
@@ -7962,10 +7962,10 @@ fn test_oneoff_exceeds_balance_rejected() {
         &None::<i128>,
         &None::<u64>,
     );
-    client.deposit_funds(&id, &subscriber, &50_000_000i128);
+    client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Attempt to charge more than balance
-    let res = client.try_charge_one_off(&id, &merchant, &50_000_001i128);
+    let res = client.try_charge_one_off(&id, &merchant, &50_000_001i128, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(res, Err(Ok(Error::InsufficientPrepaidBalance)));
 
     // Balance unchanged
@@ -7990,10 +7990,10 @@ fn test_oneoff_exact_balance_succeeds() {
         &None::<i128>,
         &None::<u64>,
     );
-    client.deposit_funds(&id, &subscriber, &50_000_000i128);
+    client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Charge exactly the full balance
-    client.charge_one_off(&id, &merchant, &50_000_000i128);
+    client.charge_one_off(&id, &merchant, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     let sub = client.get_subscription(&id);
     assert_eq!(sub.prepaid_balance, 0);
@@ -8016,11 +8016,11 @@ fn test_oneoff_on_paused_subscription_succeeds() {
         &None::<i128>,
         &None::<u64>,
     );
-    client.deposit_funds(&id, &subscriber, &50_000_000i128);
+    client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     client.pause_subscription(&id, &subscriber);
 
     // One-off charges should work on paused subscriptions
-    client.charge_one_off(&id, &merchant, &5_000_000i128);
+    client.charge_one_off(&id, &merchant, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     let sub = client.get_subscription(&id);
     assert_eq!(sub.prepaid_balance, 45_000_000);
@@ -8044,10 +8044,10 @@ fn test_oneoff_on_cancelled_subscription_rejected() {
         &None::<i128>,
         &None::<u64>,
     );
-    client.deposit_funds(&id, &subscriber, &50_000_000i128);
+    client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     client.cancel_subscription(&id, &subscriber);
 
-    let res = client.try_charge_one_off(&id, &merchant, &5_000_000i128);
+    let res = client.try_charge_one_off(&id, &merchant, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(res, Err(Ok(Error::NotActive)));
 }
 
@@ -8068,22 +8068,22 @@ fn test_oneoff_partial_balance_boundary() {
         &None::<i128>,
         &None::<u64>,
     );
-    client.deposit_funds(&id, &subscriber, &10_000_000i128);
+    client.deposit_funds(&id, &subscriber, &10_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Charge leaving exactly 1 unit remaining
-    client.charge_one_off(&id, &merchant, &9_999_999i128);
+    client.charge_one_off(&id, &merchant, &9_999_999i128, &None::<soroban_sdk::BytesN<32>>);
 
     let sub = client.get_subscription(&id);
     assert_eq!(sub.prepaid_balance, 1);
 
     // Now charge that last unit
-    client.charge_one_off(&id, &merchant, &1i128);
+    client.charge_one_off(&id, &merchant, &1i128, &None::<soroban_sdk::BytesN<32>>);
 
     let sub = client.get_subscription(&id);
     assert_eq!(sub.prepaid_balance, 0);
 
     // Any further charge should fail
-    let res = client.try_charge_one_off(&id, &merchant, &1i128);
+    let res = client.try_charge_one_off(&id, &merchant, &1i128, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(res, Err(Ok(Error::InsufficientPrepaidBalance)));
 }
 
@@ -8104,17 +8104,17 @@ fn test_oneoff_blocked_by_emergency_stop() {
         &None::<i128>,
         &None::<u64>,
     );
-    client.deposit_funds(&id, &subscriber, &50_000_000i128);
+    client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Enable emergency stop
     client.enable_emergency_stop(&admin);
 
-    let res = client.try_charge_one_off(&id, &merchant, &5_000_000i128);
+    let res = client.try_charge_one_off(&id, &merchant, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(res, Err(Ok(Error::EmergencyStopActive)));
 
     // Disable and verify charge works again
     client.disable_emergency_stop(&admin);
-    client.charge_one_off(&id, &merchant, &5_000_000i128);
+    client.charge_one_off(&id, &merchant, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     let sub = client.get_subscription(&id);
     assert_eq!(sub.prepaid_balance, 45_000_000);
 }
@@ -8136,9 +8136,9 @@ fn test_oneoff_statement_kind_consistency() {
         &None::<i128>,
         &None::<u64>,
     );
-    client.deposit_funds(&id, &subscriber, &50_000_000i128);
+    client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
-    client.charge_one_off(&id, &merchant, &7_000_000i128);
+    client.charge_one_off(&id, &merchant, &7_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Verify statement was recorded with OneOff kind
     let page = client.get_sub_statements_offset(&id, &0, &10, &false);
@@ -8171,9 +8171,9 @@ fn test_oneoff_event_emitted() {
         &None::<i128>,
         &None::<u64>,
     );
-    client.deposit_funds(&id, &subscriber, &50_000_000i128);
+    client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
-    client.charge_one_off(&id, &merchant, &3_000_000i128);
+    client.charge_one_off(&id, &merchant, &3_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Verify oneoff_ch event was emitted (events().all() is non-empty after the call)
     let all = env.events().all();
@@ -8202,15 +8202,15 @@ fn test_oneoff_lifetime_cap_boundary() {
         &None::<u64>,
     );
     // Deposit exactly cap — enforce_deposit_cap rejects deposits over remaining cap.
-    client.deposit_funds(&id, &subscriber, &20_000_000i128);
+    client.deposit_funds(&id, &subscriber, &20_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Charge up to one unit below cap so subscription stays Active
-    client.charge_one_off(&id, &merchant, &19_999_999i128);
+    client.charge_one_off(&id, &merchant, &19_999_999i128, &None::<soroban_sdk::BytesN<32>>);
     let sub = client.get_subscription(&id);
     assert_eq!(sub.lifetime_charged, 19_999_999);
 
     // Next charge exceeds remaining balance (1 unit left) — balance check fires first.
-    let res = client.try_charge_one_off(&id, &merchant, &2i128);
+    let res = client.try_charge_one_off(&id, &merchant, &2i128, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(res, Err(Ok(Error::InsufficientPrepaidBalance)));
 }
 
@@ -8232,13 +8232,13 @@ fn test_oneoff_does_not_update_last_payment_timestamp() {
         &None::<i128>,
         &None::<u64>,
     );
-    client.deposit_funds(&id, &subscriber, &50_000_000i128);
+    client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     let sub_before = client.get_subscription(&id);
     let ts_before = sub_before.last_payment_timestamp;
 
     env.ledger().set_timestamp(T0 + 1000);
-    client.charge_one_off(&id, &merchant, &5_000_000i128);
+    client.charge_one_off(&id, &merchant, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     let sub_after = client.get_subscription(&id);
     assert_eq!(sub_after.last_payment_timestamp, ts_before);
@@ -8263,22 +8263,22 @@ fn test_compaction_aggregation_accuracy() {
         &None::<i128>,
         &None::<u64>,
     );
-    test_env.client.deposit_funds(&id, &subscriber, &500_000_000i128);
+    test_env.client.deposit_funds(&id, &subscriber, &500_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // 1. Add mixed charges
     // Interval charge
     test_env.env.ledger().set_timestamp(T0 + INTERVAL);
-    test_env.client.charge_subscription(&id); // 10 USDC
+    test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>); // 10 USDC
 
     // Usage charge
     test_env.client.charge_usage(&id, &5_000_000i128); // 5 USDC
 
     // One-off charge
-    test_env.client.charge_one_off(&id, &merchant, &2_000_000i128); // 2 USDC
+    test_env.client.charge_one_off(&id, &merchant, &2_000_000i128, &None::<soroban_sdk::BytesN<32>>); // 2 USDC
 
     // Another interval charge
     test_env.env.ledger().set_timestamp(T0 + 2 * INTERVAL);
-    test_env.client.charge_subscription(&id); // 10 USDC (sequence 3)
+    test_env.client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>); // 10 USDC (sequence 3)
     
     // Total charged so far: 10 + 5 + 2 + 10 = 27 USDC
     // Sequences: 0 (Interval), 1 (Usage), 2 (OneOff), 3 (Interval)
@@ -9153,7 +9153,7 @@ fn test_migrate_does_not_affect_subscriptions() {
         &None::<i128>,
         &None::<u64>,
     );
-    client.deposit_funds(&id, &subscriber, &PREPAID);
+    client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
     let before = client.get_subscription(&id);
 
     // Simulate a forward migration.

--- a/contracts/subscription_vault/src/test_emergency_stop_lifetime_caps.rs
+++ b/contracts/subscription_vault/src/test_emergency_stop_lifetime_caps.rs
@@ -49,7 +49,7 @@ fn test_emergency_stop_blocks_all_critical_create_deposit_charge_paths() {
         &None::<i128>,
         &None::<u64>,
     );
-    client.deposit_funds(&sub_id, &subscriber, &10_000_000i128);
+    client.deposit_funds(&sub_id, &subscriber, &10_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     let plan_id =
         client.create_plan_template(&merchant, &1_000_000i128, &INTERVAL, &false, &None::<i128>);
@@ -87,11 +87,11 @@ fn test_emergency_stop_blocks_all_critical_create_deposit_charge_paths() {
         Err(Ok(Error::EmergencyStopActive))
     );
     assert_eq!(
-        client.try_deposit_funds(&sub_id, &subscriber, &1_000_000i128),
+        client.try_deposit_funds(&sub_id, &subscriber, &1_000_000i128, &None::<soroban_sdk::BytesN<32>>),
         Err(Ok(Error::EmergencyStopActive))
     );
     assert_eq!(
-        client.try_charge_subscription(&sub_id),
+        client.try_charge_subscription(&sub_id, &None::<soroban_sdk::BytesN<32>>),
         Err(Ok(Error::EmergencyStopActive))
     );
     assert_eq!(
@@ -107,7 +107,7 @@ fn test_emergency_stop_blocks_all_critical_create_deposit_charge_paths() {
         Err(Ok(Error::EmergencyStopActive))
     );
     assert_eq!(
-        client.try_charge_one_off(&sub_id, &merchant, &100_000i128),
+        client.try_charge_one_off(&sub_id, &merchant, &100_000i128, &None::<soroban_sdk::BytesN<32>>),
         Err(Ok(Error::EmergencyStopActive))
     );
 
@@ -172,7 +172,7 @@ fn test_emergency_stop_blocks_batch_charge() {
         &None::<i128>,
         &None::<u64>,
     );
-    client.deposit_funds(&sub_id, &subscriber, &10_000_000i128);
+    client.deposit_funds(&sub_id, &subscriber, &10_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     env.ledger().set_timestamp(T0 + INTERVAL + 1);
 
     client.enable_emergency_stop(&admin);
@@ -196,7 +196,7 @@ fn test_batch_charge_resumes_normally_after_emergency_stop_disabled() {
         &None::<i128>,
         &None::<u64>,
     );
-    client.deposit_funds(&sub_id, &subscriber, &10_000_000i128);
+    client.deposit_funds(&sub_id, &subscriber, &10_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     env.ledger().set_timestamp(T0 + INTERVAL + 1);
 
     client.enable_emergency_stop(&admin);
@@ -227,11 +227,11 @@ fn test_lifetime_cap_interval_overrun_cancels_without_debiting_or_crediting() {
         &None::<u64>,
     );
     // enforce_deposit_cap caps single deposit at `cap`.
-    client.deposit_funds(&sub_id, &subscriber, &cap);
+    client.deposit_funds(&sub_id, &subscriber, &cap, &None::<soroban_sdk::BytesN<32>>);
 
     env.ledger().set_timestamp(T0 + INTERVAL + 1);
     assert_eq!(
-        client.try_charge_subscription(&sub_id),
+        client.try_charge_subscription(&sub_id, &None::<soroban_sdk::BytesN<32>>),
         Ok(Ok(ChargeExecutionResult::Charged))
     );
     let after_first = client.get_subscription(&sub_id);
@@ -239,7 +239,7 @@ fn test_lifetime_cap_interval_overrun_cancels_without_debiting_or_crediting() {
 
     env.ledger().set_timestamp(T0 + (2 * INTERVAL) + 1);
     assert_eq!(
-        client.try_charge_subscription(&sub_id),
+        client.try_charge_subscription(&sub_id, &None::<soroban_sdk::BytesN<32>>),
         Ok(Ok(ChargeExecutionResult::LifetimeCapReached))
     );
 
@@ -268,7 +268,7 @@ fn test_lifetime_cap_usage_exact_hit_charges_then_auto_cancels() {
         &None::<u64>,
     );
     // enforce_deposit_cap caps single deposit at `cap`.
-    client.deposit_funds(&sub_id, &subscriber, &cap);
+    client.deposit_funds(&sub_id, &subscriber, &cap, &None::<soroban_sdk::BytesN<32>>);
     client.charge_usage_with_reference(&sub_id, &cap, &String::from_str(&env, "cap-exact-usage"));
 
     let sub = client.get_subscription(&sub_id);
@@ -296,7 +296,7 @@ fn test_lifetime_cap_usage_overrun_cancels_without_financial_side_effects() {
         &None::<u64>,
     );
     // enforce_deposit_cap caps single deposit at `cap`.
-    client.deposit_funds(&sub_id, &subscriber, &cap);
+    client.deposit_funds(&sub_id, &subscriber, &cap, &None::<soroban_sdk::BytesN<32>>);
 
     // Simulate a nearly exhausted cap while still active.
     let mut sub = client.get_subscription(&sub_id);
@@ -337,8 +337,8 @@ fn test_lifetime_cap_oneoff_exact_hit_auto_cancels() {
         &None::<u64>,
     );
     // enforce_deposit_cap caps single deposit at `cap`.
-    client.deposit_funds(&sub_id, &subscriber, &cap);
-    client.charge_one_off(&sub_id, &merchant, &cap);
+    client.deposit_funds(&sub_id, &subscriber, &cap, &None::<soroban_sdk::BytesN<32>>);
+    client.charge_one_off(&sub_id, &merchant, &cap, &None::<soroban_sdk::BytesN<32>>);
     let events = env.events().all();
 
     // Capture events immediately after the mutating call.
@@ -352,7 +352,7 @@ fn test_lifetime_cap_oneoff_exact_hit_auto_cancels() {
     assert_eq!(client.get_merchant_balance(&merchant), cap);
 
     assert_eq!(
-        client.try_charge_one_off(&sub_id, &merchant, &1i128),
+        client.try_charge_one_off(&sub_id, &merchant, &1i128, &None::<soroban_sdk::BytesN<32>>),
         Err(Ok(Error::LifetimeCapReached))
     );
 }

--- a/contracts/subscription_vault/src/test_emergency_stop_matrix.rs
+++ b/contracts/subscription_vault/src/test_emergency_stop_matrix.rs
@@ -45,7 +45,7 @@ fn test_emergency_stop_matrix_blocks_mutations_but_allows_reads() {
         &None::<i128>,
         &None::<u64>,
     );
-    client.deposit_funds(&sub_id, &subscriber, &10_000_000i128);
+    client.deposit_funds(&sub_id, &subscriber, &10_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     let plan_id = client.create_plan_template(&merchant, &1_000_000i128, &INTERVAL, &false, &None::<i128>);
 
@@ -81,15 +81,15 @@ fn test_emergency_stop_matrix_blocks_mutations_but_allows_reads() {
         Err(Ok(Error::EmergencyStopActive))
     );
     assert_eq!(client.try_create_subscription_from_plan(&subscriber, &plan_id), Err(Ok(Error::EmergencyStopActive)));
-    assert_eq!(client.try_deposit_funds(&sub_id, &subscriber, &1_000_000i128), Err(Ok(Error::EmergencyStopActive)));
+    assert_eq!(client.try_deposit_funds(&sub_id, &subscriber, &1_000_000i128, &None::<soroban_sdk::BytesN<32>>), Err(Ok(Error::EmergencyStopActive)));
 
-    assert_eq!(client.try_charge_subscription(&sub_id), Err(Ok(Error::EmergencyStopActive)));
+    assert_eq!(client.try_charge_subscription(&sub_id, &None::<soroban_sdk::BytesN<32>>), Err(Ok(Error::EmergencyStopActive)));
     assert_eq!(client.try_charge_usage(&sub_id, &100_000i128), Err(Ok(Error::EmergencyStopActive)));
     assert_eq!(
         client.try_charge_usage_with_reference(&sub_id, &100_000i128, &String::from_str(&env, "usage-ref")),
         Err(Ok(Error::EmergencyStopActive))
     );
-    assert_eq!(client.try_charge_one_off(&sub_id, &merchant, &100_000i128), Err(Ok(Error::EmergencyStopActive)));
+    assert_eq!(client.try_charge_one_off(&sub_id, &merchant, &100_000i128, &None::<soroban_sdk::BytesN<32>>), Err(Ok(Error::EmergencyStopActive)));
 
     let ids_vec = Vec::from_array(&env, [sub_id]);
     assert_eq!(client.try_operator_batch_charge(&operator, &ids_vec, &0u64), Err(Ok(Error::EmergencyStopActive)));

--- a/contracts/subscription_vault/src/test_expiration.rs
+++ b/contracts/subscription_vault/src/test_expiration.rs
@@ -63,16 +63,16 @@ fn test_expiration_timing_and_charging() {
         &None::<i128>,
         &Some(expires_at),
     );
-    client.deposit_funds(&sub_id, &subscriber, &(amount * 5));
+    client.deposit_funds(&sub_id, &subscriber, &(amount * 5, &None::<soroban_sdk::BytesN<32>>));
 
     // Before expiry: charge succeeds
     env.ledger().with_mut(|l| l.timestamp = T0 + INTERVAL);
-    client.charge_subscription(&sub_id);
+    client.charge_subscription(&sub_id, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(client.get_subscription(&sub_id).lifetime_charged, amount);
 
     // At expiry boundary — subscription expires_at = T0 + 2*INTERVAL
     env.ledger().with_mut(|l| l.timestamp = T0 + 2 * INTERVAL);
-    let res = client.try_charge_subscription(&sub_id);
+    let res = client.try_charge_subscription(&sub_id, &None::<soroban_sdk::BytesN<32>>);
     assert!(res.is_err(), "charge at expiry should be rejected");
 
     // expires_at field is preserved on the subscription
@@ -80,7 +80,7 @@ fn test_expiration_timing_and_charging() {
 
     // After expiry — still rejects
     env.ledger().with_mut(|l| l.timestamp = T0 + 3 * INTERVAL);
-    let res2 = client.try_charge_subscription(&sub_id);
+    let res2 = client.try_charge_subscription(&sub_id, &None::<soroban_sdk::BytesN<32>>);
     assert!(res2.is_err(), "charge after expiry should be rejected");
 
     // Check withdrawal behavior after expiry
@@ -119,7 +119,7 @@ fn test_cleanup_and_archival() {
 
     // Advance past expiry and trigger it via a charge attempt
     env.ledger().with_mut(|l| l.timestamp = T0 + 2 * INTERVAL);
-    let _ = client.try_charge_subscription(&sub_id); // transitions to Expired
+    let _ = client.try_charge_subscription(&sub_id, &None::<soroban_sdk::BytesN<32>>); // transitions to Expired
 
     // Perform cleanup which archives the subscription
     client.cleanup_subscription(&sub_id, &subscriber);
@@ -227,9 +227,9 @@ fn test_deposit_rejected_when_expired() {
     // Advance past expiry
     env.ledger().with_mut(|l| l.timestamp = T0 + 100);
     // Trigger the expiration by attempting a charge
-    let _ = client.try_charge_subscription(&sub_id);
+    let _ = client.try_charge_subscription(&sub_id, &None::<soroban_sdk::BytesN<32>>);
 
     // subscription.is_expired(now) is true; deposit should be rejected
-    let res = client.try_deposit_funds(&sub_id, &subscriber, &min_topup);
+    let res = client.try_deposit_funds(&sub_id, &subscriber, &min_topup, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(res, Err(Ok(Error::SubscriptionExpired)));
 }

--- a/contracts/subscription_vault/src/test_idempotency_keys.rs
+++ b/contracts/subscription_vault/src/test_idempotency_keys.rs
@@ -1,0 +1,253 @@
+use crate::{
+    ChargeExecutionResult, SubscriptionVault, SubscriptionVaultClient,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token, Address, BytesN, Env,
+};
+
+const AMOUNT: i128 = 10_000_000;
+const INTERVAL: u64 = 86_400;
+const DEPOSIT: i128 = 50_000_000;
+const MIN_TOPUP: i128 = 1_000_000;
+
+fn setup_test_env() -> (Env, SubscriptionVaultClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let contract_id = env.register(SubscriptionVault, ());
+    let client = SubscriptionVaultClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    client.init(&token, &6, &admin, &MIN_TOPUP, &(7 * 24 * 60 * 60));
+
+    let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&contract_id, &1_000_000_000i128);
+
+    (env, client, token)
+}
+
+fn create_and_fund_sub(
+    env: &Env,
+    client: &SubscriptionVaultClient,
+    subscriber: &Address,
+    merchant: &Address,
+    token: &Address,
+) -> u32 {
+    let id = client.create_subscription(
+        subscriber,
+        merchant,
+        &AMOUNT,
+        &INTERVAL,
+        &false,
+        &None::<i128>,
+        &None::<u64>,
+    );
+
+    let token_client = token::Client::new(env, token);
+    if token_client.balance(subscriber) < DEPOSIT {
+        token::StellarAssetClient::new(env, token).mint(subscriber, &(DEPOSIT * 2));
+    }
+
+    let none_key: Option<BytesN<32>> = None;
+    client.deposit_funds(&id, subscriber, &DEPOSIT, &none_key);
+    env.ledger().set_timestamp(env.ledger().timestamp() + 1);
+
+    id
+}
+
+fn make_key(env: &Env, val: u8) -> BytesN<32> {
+    let mut arr = [0u8; 32];
+    arr[31] = val;
+    BytesN::from_array(env, &arr)
+}
+
+#[test]
+fn test_charge_subscription_idempotent_replay() {
+    let (env, client, token) = setup_test_env();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let id = create_and_fund_sub(&env, &client, &subscriber, &merchant, &token);
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + INTERVAL);
+
+    let key = make_key(&env, 1);
+    let r1 = client.charge_subscription(&id, &Some(key.clone()));
+    assert_eq!(r1, ChargeExecutionResult::Charged);
+
+    let r2 = client.charge_subscription(&id, &Some(key.clone()));
+    assert_eq!(r2, ChargeExecutionResult::Charged);
+}
+
+#[test]
+fn test_charge_subscription_different_keys_allowed() {
+    let (env, client, token) = setup_test_env();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let id = create_and_fund_sub(&env, &client, &subscriber, &merchant, &token);
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + INTERVAL);
+
+    let key1 = make_key(&env, 1);
+    let r1 = client.charge_subscription(&id, &Some(key1));
+    assert_eq!(r1, ChargeExecutionResult::Charged);
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + INTERVAL);
+
+    let key2 = make_key(&env, 2);
+    let r2 = client.charge_subscription(&id, &Some(key2));
+    assert_eq!(r2, ChargeExecutionResult::Charged);
+}
+
+#[test]
+fn test_charge_subscription_none_key_ok() {
+    let (env, client, token) = setup_test_env();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let id = create_and_fund_sub(&env, &client, &subscriber, &merchant, &token);
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + INTERVAL);
+
+    let none_key: Option<BytesN<32>> = None;
+    let r = client.charge_subscription(&id, &none_key);
+    assert_eq!(r, ChargeExecutionResult::Charged);
+}
+
+#[test]
+fn test_deposit_funds_idempotent_replay() {
+    let (env, client, token) = setup_test_env();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let id = create_and_fund_sub(&env, &client, &subscriber, &merchant, &token);
+
+    let key = make_key(&env, 10);
+    let extra = 5_000_000i128;
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&subscriber, &extra);
+
+    client.deposit_funds(&id, &subscriber, &extra, &Some(key.clone()));
+
+    let sub = client.get_subscription(&id);
+    assert_eq!(sub.prepaid_balance, DEPOSIT + extra);
+
+    client.deposit_funds(&id, &subscriber, &extra, &Some(key.clone()));
+
+    let sub2 = client.get_subscription(&id);
+    assert_eq!(sub2.prepaid_balance, DEPOSIT + extra);
+}
+
+#[test]
+fn test_deposit_funds_different_keys_allowed() {
+    let (env, client, token) = setup_test_env();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let id = create_and_fund_sub(&env, &client, &subscriber, &merchant, &token);
+
+    let key1 = make_key(&env, 20);
+    let key2 = make_key(&env, 21);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&subscriber, &20_000_000i128);
+
+    client.deposit_funds(&id, &subscriber, &10_000_000i128, &Some(key1));
+    client.deposit_funds(&id, &subscriber, &10_000_000i128, &Some(key2));
+
+    let sub = client.get_subscription(&id);
+    assert_eq!(sub.prepaid_balance, DEPOSIT + 20_000_000i128);
+}
+
+#[test]
+fn test_charge_one_off_idempotent_replay() {
+    let (env, client, token) = setup_test_env();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let id = create_and_fund_sub(&env, &client, &subscriber, &merchant, &token);
+
+    let key = make_key(&env, 30);
+    let amount: i128 = 5_000_000;
+
+    client.charge_one_off(&id, &merchant, &amount, &Some(key.clone()));
+    client.charge_one_off(&id, &merchant, &amount, &Some(key.clone()));
+
+    let sub = client.get_subscription(&id);
+    assert_eq!(sub.prepaid_balance, DEPOSIT - amount);
+}
+
+#[test]
+fn test_charge_one_off_different_keys_allowed() {
+    let (env, client, token) = setup_test_env();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let id = create_and_fund_sub(&env, &client, &subscriber, &merchant, &token);
+
+    let key1 = make_key(&env, 31);
+    let key2 = make_key(&env, 32);
+
+    client.charge_one_off(&id, &merchant, &1_000_000i128, &Some(key1));
+    client.charge_one_off(&id, &merchant, &2_000_000i128, &Some(key2));
+
+    let sub = client.get_subscription(&id);
+    assert_eq!(sub.prepaid_balance, DEPOSIT - 3_000_000i128);
+}
+
+#[test]
+fn test_same_raw_key_different_entrypoints_no_collision() {
+    let (env, client, token) = setup_test_env();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let id = create_and_fund_sub(&env, &client, &subscriber, &merchant, &token);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&subscriber, &10_000_000i128);
+
+    let key = make_key(&env, 99);
+
+    client.charge_one_off(&id, &merchant, &1_000_000i128, &Some(key.clone()));
+    client.deposit_funds(&id, &subscriber, &5_000_000i128, &Some(key.clone()));
+
+    env.ledger().set_timestamp(env.ledger().timestamp() + INTERVAL);
+    client.charge_subscription(&id, &Some(key.clone()));
+}
+
+#[test]
+fn test_ring_buffer_evicts_oldest_key() {
+    let (env, client, token) = setup_test_env();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let id = create_and_fund_sub(&env, &client, &subscriber, &merchant, &token);
+    let token_admin = token::StellarAssetClient::new(&env, &token);
+    token_admin.mint(&subscriber, &1_000_000_000i128);
+
+    // Insert 33 unique keys to fill buffer (32) + evict oldest (key 0)
+    for i in 0..33u8 {
+        let key = make_key(&env, i);
+        token_admin.mint(&subscriber, &MIN_TOPUP);
+        client.deposit_funds(&id, &subscriber, &MIN_TOPUP, &Some(key));
+    }
+
+    // Buffer now holds [32, 1, 2, 3, ..., 31], cursor = 1.
+    // Key 0 was evicted (overwritten by key 32 at index 0).
+
+    let balance_before = client.get_subscription(&id).prepaid_balance;
+
+    // Key 1 is still present → idempotent no-op (balance unchanged)
+    let key1 = make_key(&env, 1);
+    client.deposit_funds(&id, &subscriber, &MIN_TOPUP, &Some(key1));
+    assert_eq!(
+        client.get_subscription(&id).prepaid_balance,
+        balance_before,
+        "key 1 should be idempotent (no balance change)"
+    );
+
+    // Key 0 was evicted → fresh deposit (balance increases)
+    let key0 = make_key(&env, 0);
+    token_admin.mint(&subscriber, &MIN_TOPUP);
+    client.deposit_funds(&id, &subscriber, &MIN_TOPUP, &Some(key0));
+    assert_eq!(
+        client.get_subscription(&id).prepaid_balance,
+        balance_before + MIN_TOPUP,
+        "key 0 should be a fresh deposit"
+    );
+}

--- a/contracts/subscription_vault/src/test_insufficient_balance.rs
+++ b/contracts/subscription_vault/src/test_insufficient_balance.rs
@@ -69,7 +69,7 @@ fn test_deposit_insufficient_token_balance_reverts() {
     let sub_before = client.get_subscription(&id);
 
     // Subscriber has 0 tokens — the token.transfer inside deposit_funds must revert
-    let result = client.try_deposit_funds(&id, &subscriber, &5_000_000i128);
+    let result = client.try_deposit_funds(&id, &subscriber, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     assert!(result.is_err(), "deposit with zero subscriber balance must fail");
 
     // State invariant: prepaid_balance and vault balance unchanged
@@ -103,7 +103,7 @@ fn test_deposit_insufficient_partial_balance_reverts() {
     let sub_before = client.get_subscription(&id);
 
     // Try to deposit more than the subscriber holds
-    let result = client.try_deposit_funds(&id, &subscriber, &5_000_000i128);
+    let result = client.try_deposit_funds(&id, &subscriber, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     assert!(result.is_err(), "deposit exceeding subscriber balance must fail");
 
     // State invariant: nothing changed
@@ -140,7 +140,7 @@ fn test_deposit_rejected_when_credit_limit_exceeded() {
 
     // Deposit min_topup (1_000_000) should be rejected since
     // exposure (10_000_000) + 1_000_000 > limit (1_000_000)
-    let result = client.try_deposit_funds(&id, &subscriber, &1_000_000i128);
+    let result = client.try_deposit_funds(&id, &subscriber, &1_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(
         result,
         Err(Ok(Error::CreditLimitExceeded)),
@@ -174,7 +174,7 @@ fn test_deposit_allowed_within_credit_limit() {
 
     let vault_before = token_client.balance(&client.address);
 
-    let result = client.try_deposit_funds(&id, &subscriber, &PREPAID);
+    let result = client.try_deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
     assert!(result.is_ok(), "deposit within credit limit should succeed");
 
     // Verify deposit was applied
@@ -213,7 +213,7 @@ fn test_deposit_credit_limit_aggregate_two_subs() {
     let sub1_before = client.get_subscription(&id1);
     let sub2_before = client.get_subscription(&id2);
 
-    let result = client.try_deposit_funds(&id1, &subscriber, &1_000_000i128);
+    let result = client.try_deposit_funds(&id1, &subscriber, &1_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(
         result,
         Err(Ok(Error::CreditLimitExceeded)),

--- a/contracts/subscription_vault/src/test_operator.rs
+++ b/contracts/subscription_vault/src/test_operator.rs
@@ -345,7 +345,7 @@ fn operator_charge_usage_succeeds() {
         &None::<u64>,
     );
     te.stellar_token_client().mint(&subscriber, &DEPOSIT);
-    te.client.deposit_funds(&sub_id, &subscriber, &DEPOSIT);
+    te.client.deposit_funds(&sub_id, &subscriber, &DEPOSIT, &None::<soroban_sdk::BytesN<32>>);
 
     te.client.set_operator(&te.admin, &operator);
 
@@ -374,7 +374,7 @@ fn operator_charge_usage_wrong_operator_rejected() {
         &None::<u64>,
     );
     te.stellar_token_client().mint(&subscriber, &DEPOSIT);
-    te.client.deposit_funds(&sub_id, &subscriber, &DEPOSIT);
+    te.client.deposit_funds(&sub_id, &subscriber, &DEPOSIT, &None::<soroban_sdk::BytesN<32>>);
 
     te.client.set_operator(&te.admin, &operator);
 
@@ -649,7 +649,7 @@ fn get_operator_nonce_increments_per_call() {
 
         // Re-fund so the next charge can succeed.
         te.stellar_token_client().mint(&subscriber, &AMOUNT);
-        te.client.deposit_funds(&sub_id, &subscriber, &AMOUNT);
+        te.client.deposit_funds(&sub_id, &subscriber, &AMOUNT, &None::<soroban_sdk::BytesN<32>>);
     }
     assert_eq!(te.client.get_operator_nonce(&operator), 3u64);
 }
@@ -673,7 +673,7 @@ fn operator_charge_usage_with_reference_succeeds() {
         &None::<u64>,
     );
     te.stellar_token_client().mint(&subscriber, &DEPOSIT);
-    te.client.deposit_funds(&sub_id, &subscriber, &DEPOSIT);
+    te.client.deposit_funds(&sub_id, &subscriber, &DEPOSIT, &None::<soroban_sdk::BytesN<32>>);
 
     te.client.set_operator(&te.admin, &operator);
 

--- a/contracts/subscription_vault/src/test_recovery.rs
+++ b/contracts/subscription_vault/src/test_recovery.rs
@@ -174,7 +174,7 @@ fn test_state_consistency() {
     
     let sub_id = client.create_subscription(&subscriber, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>);
     
-    client.deposit_funds(&sub_id, &subscriber, &50_000_000i128);
+    client.deposit_funds(&sub_id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     
     // Total accounted should be 50M. Contract balance is 50M.
     // Try to recover 1 from accounted funds - should fail
@@ -257,7 +257,7 @@ fn test_get_token_reconciliation_with_prepaid() {
     token_client.mint(&subscriber, &50_000_000);
     let sub_id =
         client.create_subscription(&subscriber, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>);
-    client.deposit_funds(&sub_id, &subscriber, &50_000_000i128);
+    client.deposit_funds(&sub_id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Get reconciliation
     let reconciliation = client.get_token_reconciliation(&token_addr);
@@ -283,11 +283,11 @@ fn test_get_token_reconciliation_after_charge() {
     token_client.mint(&subscriber, &50_000_000);
     let sub_id =
         client.create_subscription(&subscriber, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>);
-    client.deposit_funds(&sub_id, &subscriber, &50_000_000i128);
+    client.deposit_funds(&sub_id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Charge the subscription
     env.ledger().with_mut(|l| l.timestamp = INTERVAL + 1001);
-    client.charge_subscription(&sub_id);
+    client.charge_subscription(&sub_id, &None::<soroban_sdk::BytesN<32>>);
 
     // Get reconciliation
     let reconciliation = client.get_token_reconciliation(&token_addr);
@@ -311,7 +311,7 @@ fn test_get_token_reconciliation_with_recoverable() {
     token_client.mint(&subscriber, &50_000_000);
     let sub_id =
         client.create_subscription(&subscriber, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>);
-    client.deposit_funds(&sub_id, &subscriber, &50_000_000i128);
+    client.deposit_funds(&sub_id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Mint directly to contract (stranded funds)
     token_client.mint(&client.address, &25_000_000);
@@ -374,7 +374,7 @@ fn test_generate_reconciliation_proof() {
     token_client.mint(&subscriber, &50_000_000);
     let sub_id =
         client.create_subscription(&subscriber, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>);
-    client.deposit_funds(&sub_id, &subscriber, &50_000_000i128);
+    client.deposit_funds(&sub_id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Mint stranded funds
     token_client.mint(&client.address, &10_000_000);
@@ -425,8 +425,8 @@ fn test_query_prepaid_balances_paginated() {
     let sub2 =
         client.create_subscription(&subscriber2, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>);
 
-    client.deposit_funds(&sub1, &subscriber1, &30_000_000i128);
-    client.deposit_funds(&sub2, &subscriber2, &20_000_000i128);
+    client.deposit_funds(&sub1, &subscriber1, &30_000_000i128, &None::<soroban_sdk::BytesN<32>>);
+    client.deposit_funds(&sub2, &subscriber2, &20_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Query first page
     let request = PrepaidQueryRequest {
@@ -486,7 +486,7 @@ fn test_query_prepaid_balances_paginated_wrong_token() {
     token_client.mint(&subscriber, &50_000_000);
     let sub_id =
         client.create_subscription(&subscriber, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>);
-    client.deposit_funds(&sub_id, &subscriber, &50_000_000i128);
+    client.deposit_funds(&sub_id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Query with a different token
     let token2 = env
@@ -544,15 +544,15 @@ fn test_full_reconciliation_workflow() {
     let sub2 =
         client.create_subscription(&subscriber2, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>);
 
-    client.deposit_funds(&sub1, &subscriber1, &100_000_000i128);
-    client.deposit_funds(&sub2, &subscriber2, &50_000_000i128);
+    client.deposit_funds(&sub1, &subscriber1, &100_000_000i128, &None::<soroban_sdk::BytesN<32>>);
+    client.deposit_funds(&sub2, &subscriber2, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // 2. Add stranded funds
     token_client.mint(&client.address, &25_000_000);
 
     // 3. Charge one subscription
     env.ledger().with_mut(|l| l.timestamp = INTERVAL + 1001);
-    client.charge_subscription(&sub1);
+    client.charge_subscription(&sub1, &None::<soroban_sdk::BytesN<32>>);
 
     // 4. Verify reconciliation
     let reconciliation = client.get_token_reconciliation(&token_addr);

--- a/contracts/subscription_vault/src/test_reentrancy_invariants.rs
+++ b/contracts/subscription_vault/src/test_reentrancy_invariants.rs
@@ -102,7 +102,7 @@ fn test_deposit_state_committed_before_transfer() {
     let vault_before = token_client.balance(&client.address);
     let deposit = 5_000_000i128;
 
-    client.deposit_funds(&id, &subscriber, &deposit);
+    client.deposit_funds(&id, &subscriber, &deposit, &None::<soroban_sdk::BytesN<32>>);
 
     // Effects: storage reflects the deposit
     let sub = client.get_subscription(&id);
@@ -121,7 +121,7 @@ fn test_deposit_multiple_sequential_consistent_state() {
 
     let deposit = 5_000_000i128;
     for i in 1..=5 {
-        client.deposit_funds(&id, &subscriber, &deposit);
+        client.deposit_funds(&id, &subscriber, &deposit, &None::<soroban_sdk::BytesN<32>>);
         let sub = client.get_subscription(&id);
         assert_eq!(sub.prepaid_balance, deposit * i as i128);
     }
@@ -138,7 +138,7 @@ fn test_deposit_failure_leaves_state_unchanged() {
     let sub_before = client.get_subscription(&id);
 
     // below min_topup of 1_000_000
-    let result = client.try_deposit_funds(&id, &subscriber, &500);
+    let result = client.try_deposit_funds(&id, &subscriber, &500, &None::<soroban_sdk::BytesN<32>>);
     assert!(result.is_err());
 
     let sub_after = client.get_subscription(&id);
@@ -154,7 +154,7 @@ fn test_deposit_on_cancelled_subscription_rejected_cleanly() {
     let (id, subscriber, _) = create_sub(&env, &client, &token);
 
     client.cancel_subscription(&id, &subscriber);
-    let result = client.try_deposit_funds(&id, &subscriber, &5_000_000i128);
+    let result = client.try_deposit_funds(&id, &subscriber, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     // Cancelled subs are blocklisted from deposit
     assert!(result.is_err());
     let sub = client.get_subscription(&id);
@@ -181,7 +181,7 @@ fn test_charge_token_conservation_invariant() {
     env.ledger().set_timestamp(T0 + INTERVAL + 1);
     let vault_before = token_client.balance(&client.address);
 
-    client.charge_subscription(&id);
+    client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
 
     let sub_after = client.get_subscription(&id);
     let merchant_balance = client.get_merchant_balance(&merchant);
@@ -206,7 +206,7 @@ fn test_charge_insufficient_balance_no_partial_debit() {
     let grace = 7 * 24 * 60 * 60u64;
     env.ledger().set_timestamp(T0 + INTERVAL + grace + 1);
 
-    let result = client.try_charge_subscription(&id);
+    let result = client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert!(result.is_ok()); // returns InsufficientBalance result, not Err
 
     let sub = client.get_subscription(&id);
@@ -226,13 +226,13 @@ fn test_charge_replay_rejected_no_state_mutation() {
         .mint(&client.address, &PREPAID);
 
     env.ledger().set_timestamp(T0 + INTERVAL + 1);
-    client.charge_subscription(&id);
+    client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
 
     let sub_after_first = client.get_subscription(&id);
     let merchant_after_first = client.get_merchant_balance(&merchant);
 
     // Replay attempt in same interval
-    let result = client.try_charge_subscription(&id);
+    let result = client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(result, Err(Ok(Error::Replay)));
 
     let sub_after_replay = client.get_subscription(&id);
@@ -250,7 +250,7 @@ fn test_charge_on_paused_no_state_change() {
     client.pause_subscription(&id, &subscriber);
 
     env.ledger().set_timestamp(T0 + INTERVAL + 1);
-    let result = client.try_charge_subscription(&id);
+    let result = client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(result, Err(Ok(Error::NotActive)));
 
     assert_eq!(client.get_subscription(&id).prepaid_balance, PREPAID);
@@ -270,7 +270,7 @@ fn test_charge_lifetime_charged_monotonically_increases() {
     let mut prev_lifetime = 0i128;
     for i in 1..=4 {
         env.ledger().set_timestamp(T0 + (i as u64 * INTERVAL) + 1);
-        client.charge_subscription(&id);
+        client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
         let sub = client.get_subscription(&id);
         assert!(sub.lifetime_charged > prev_lifetime);
         prev_lifetime = sub.lifetime_charged;
@@ -289,7 +289,7 @@ fn test_withdraw_subscriber_state_committed_before_transfer() {
     let (id, subscriber, _) = create_sub(&env, &client, &token);
     let token_client = soroban_sdk::token::Client::new(&env, &token);
 
-    client.deposit_funds(&id, &subscriber, &PREPAID);
+    client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
     client.cancel_subscription(&id, &subscriber);
 
     let vault_before = token_client.balance(&client.address);
@@ -311,7 +311,7 @@ fn test_withdraw_subscriber_double_withdrawal_rejected() {
     let (env, client, token, _) = setup();
     let (id, subscriber, _) = create_sub(&env, &client, &token);
 
-    client.deposit_funds(&id, &subscriber, &PREPAID);
+    client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
     client.cancel_subscription(&id, &subscriber);
     client.withdraw_subscriber_funds(&id, &subscriber);
 
@@ -327,7 +327,7 @@ fn test_withdraw_subscriber_requires_cancelled_status() {
     let (env, client, token, _) = setup();
     let (id, subscriber, _) = create_sub(&env, &client, &token);
 
-    client.deposit_funds(&id, &subscriber, &PREPAID);
+    client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
     // Not cancelled — Active status
     let result = client.try_withdraw_subscriber_funds(&id, &subscriber);
     assert!(result.is_err());
@@ -343,7 +343,7 @@ fn test_withdraw_subscriber_exact_amount_transferred() {
     let token_client = soroban_sdk::token::Client::new(&env, &token);
 
     let deposit = 7_777_777i128;
-    client.deposit_funds(&id, &subscriber, &deposit);
+    client.deposit_funds(&id, &subscriber, &deposit, &None::<soroban_sdk::BytesN<32>>);
     client.cancel_subscription(&id, &subscriber);
 
     let subscriber_before = token_client.balance(&subscriber);
@@ -453,7 +453,7 @@ fn test_refund_state_committed_before_transfer() {
     let (id, subscriber, _) = create_sub(&env, &client, &token);
     let token_client = soroban_sdk::token::Client::new(&env, &token);
 
-    client.deposit_funds(&id, &subscriber, &PREPAID);
+    client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
 
     let vault_before = token_client.balance(&client.address);
     let subscriber_before = token_client.balance(&subscriber);
@@ -476,7 +476,7 @@ fn test_refund_exceeds_balance_rejected_no_state_change() {
     let token_client = soroban_sdk::token::Client::new(&env, &token);
 
     let deposit = 5_000_000i128;
-    client.deposit_funds(&id, &subscriber, &deposit);
+    client.deposit_funds(&id, &subscriber, &deposit, &None::<soroban_sdk::BytesN<32>>);
 
     let vault_before = token_client.balance(&client.address);
 
@@ -494,7 +494,7 @@ fn test_refund_cumulative_cannot_exceed_deposit() {
     let (id, subscriber, _) = create_sub(&env, &client, &token);
 
     let deposit = 10_000_000i128;
-    client.deposit_funds(&id, &subscriber, &deposit);
+    client.deposit_funds(&id, &subscriber, &deposit, &None::<soroban_sdk::BytesN<32>>);
 
     // Drain in two steps
     client.partial_refund(&admin, &id, &subscriber, &5_000_000i128);
@@ -517,12 +517,12 @@ fn test_reentrancy_guard_lock_is_released_after_operation() {
     let (env, client, token, _) = setup();
     let (id, subscriber, _) = create_sub(&env, &client, &token);
 
-    client.deposit_funds(&id, &subscriber, &5_000_000i128);
+    client.deposit_funds(&id, &subscriber, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // After a successful deposit, no lock key should remain in storage.
     // We verify this by running a second deposit — if the lock were stuck,
     // it would return Reentrancy error.
-    let result = client.try_deposit_funds(&id, &subscriber, &5_000_000i128);
+    let result = client.try_deposit_funds(&id, &subscriber, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     assert!(result.is_ok(), "second deposit must succeed — lock must be released");
 }
 
@@ -550,7 +550,7 @@ fn test_reentrancy_guard_not_stuck_after_rejection() {
     let (env, client, token, admin) = setup();
     let (id, subscriber, _) = create_sub(&env, &client, &token);
 
-    client.deposit_funds(&id, &subscriber, &5_000_000i128);
+    client.deposit_funds(&id, &subscriber, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Rejected refund (wrong admin)
     let stranger = Address::generate(&env);
@@ -570,7 +570,7 @@ fn test_reentrancy_guard_not_stuck_after_rejection() {
 fn test_charge_nonexistent_subscription_errors_cleanly() {
     let (env, client, _, _) = setup();
     env.ledger().set_timestamp(T0 + INTERVAL + 1);
-    let result = client.try_charge_subscription(&9999u32);
+    let result = client.try_charge_subscription(&9999u32, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(result, Err(Ok(Error::NotFound)));
 }
 
@@ -580,7 +580,7 @@ fn test_deposit_nonexistent_subscription_errors_cleanly() {
     let (env, client, token, _) = setup();
     let subscriber = Address::generate(&env);
     mint(&env, &token, &subscriber, PREPAID);
-    let result = client.try_deposit_funds(&9999u32, &subscriber, &5_000_000i128);
+    let result = client.try_deposit_funds(&9999u32, &subscriber, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(result, Err(Ok(Error::NotFound)));
 }
 
@@ -594,7 +594,7 @@ fn test_charge_blocked_by_emergency_stop_no_mutation() {
     client.enable_emergency_stop(&admin);
     env.ledger().set_timestamp(T0 + INTERVAL + 1);
 
-    let result = client.try_charge_subscription(&id);
+    let result = client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(result, Err(Ok(Error::EmergencyStopActive)));
 
     assert_eq!(client.get_subscription(&id).prepaid_balance, PREPAID);
@@ -609,7 +609,7 @@ fn test_deposit_blocked_by_emergency_stop_no_mutation() {
 
     client.enable_emergency_stop(&admin);
 
-    let result = client.try_deposit_funds(&id, &subscriber, &5_000_000i128);
+    let result = client.try_deposit_funds(&id, &subscriber, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(result, Err(Ok(Error::EmergencyStopActive)));
     assert_eq!(client.get_subscription(&id).prepaid_balance, 0);
 }
@@ -637,7 +637,7 @@ fn test_withdraw_subscriber_blocked_by_emergency_stop_no_mutation() {
     let (env, client, token, admin) = setup();
     let (id, subscriber, _) = create_sub(&env, &client, &token);
 
-    client.deposit_funds(&id, &subscriber, &PREPAID);
+    client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
     client.cancel_subscription(&id, &subscriber);
 
     client.enable_emergency_stop(&admin);
@@ -662,7 +662,7 @@ fn test_charge_failure_then_topup_then_charge_succeeds() {
     seed_balance(&env, &client, id, 0);
     let grace = 7 * 24 * 60 * 60u64;
     env.ledger().set_timestamp(T0 + INTERVAL + grace + 1);
-    let _ = client.try_charge_subscription(&id);
+    let _ = client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(
         client.get_subscription(&id).status,
         SubscriptionStatus::InsufficientBalance
@@ -670,7 +670,7 @@ fn test_charge_failure_then_topup_then_charge_succeeds() {
 
     // Top up and resume
     mint(&env, &token, &subscriber, PREPAID);
-    client.deposit_funds(&id, &subscriber, &PREPAID);
+    client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
     client.resume_subscription(&id, &subscriber);
     assert_eq!(
         client.get_subscription(&id).status,
@@ -679,7 +679,7 @@ fn test_charge_failure_then_topup_then_charge_succeeds() {
 
     // Next interval — charge must succeed cleanly
     env.ledger().set_timestamp(T0 + INTERVAL + grace + 1 + INTERVAL);
-    let result = client.try_charge_subscription(&id);
+    let result = client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert!(result.is_ok());
     assert_eq!(
         client.get_subscription(&id).prepaid_balance,

--- a/contracts/subscription_vault/src/test_require_auth.rs
+++ b/contracts/subscription_vault/src/test_require_auth.rs
@@ -135,7 +135,7 @@ fn deposit_funds_missing_auth() {
     let contract_id = env.register(SubscriptionVault, ());
     let client = SubscriptionVaultClient::new(&env, &contract_id);
     let subscriber = Address::generate(&env);
-    let _ = client.deposit_funds(&0u32, &subscriber, &DEPOSIT);
+    let _ = client.deposit_funds(&0u32, &subscriber, &DEPOSIT, &None::<soroban_sdk::BytesN<32>>, &None::<soroban_sdk::BytesN<32>>);
 }
 
 #[test]
@@ -149,7 +149,7 @@ fn deposit_funds_wrong_subscriber() {
     soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&attacker, &DEPOSIT);
     // mock_all_auths satisfies require_auth(), but the contract rejects because
     // attacker != sub.subscriber.
-    let _ = client.deposit_funds(&id, &attacker, &DEPOSIT);
+    let _ = client.deposit_funds(&id, &attacker, &DEPOSIT, &None::<soroban_sdk::BytesN<32>>, &None::<soroban_sdk::BytesN<32>>);
 }
 
 #[test]
@@ -157,7 +157,7 @@ fn deposit_funds_correct_auth() {
     let (env, client, token, _) = setup();
     let (id, subscriber, _) = make_subscription(&env, &client);
     soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&subscriber, &DEPOSIT);
-    client.deposit_funds(&id, &subscriber, &DEPOSIT);
+    client.deposit_funds(&id, &subscriber, &DEPOSIT, &None::<soroban_sdk::BytesN<32>>, &None::<soroban_sdk::BytesN<32>>);
     let sub = client.get_subscription(&id);
     assert_eq!(sub.prepaid_balance, DEPOSIT);
 }
@@ -315,7 +315,7 @@ fn withdraw_merchant_funds_correct_auth() {
 
     // Deposit so the vault holds real tokens.
     soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&subscriber, &DEPOSIT);
-    client.deposit_funds(&id, &subscriber, &DEPOSIT);
+    client.deposit_funds(&id, &subscriber, &DEPOSIT, &None::<soroban_sdk::BytesN<32>>, &None::<soroban_sdk::BytesN<32>>);
 
     // Directly credit the merchant's ledger balance and mint matching vault tokens
     // so the withdrawal transfer can complete.  (A real charge flow would do this

--- a/contracts/subscription_vault/src/test_security.rs
+++ b/contracts/subscription_vault/src/test_security.rs
@@ -61,7 +61,7 @@ fn test_reentrancy_lock_prevents_recursive_calls() {
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&subscriber, &1_000_000);
 
-    client.deposit_funds(&id, &subscriber, &1_000_000);
+    client.deposit_funds(&id, &subscriber, &1_000_000, &None::<soroban_sdk::BytesN<32>>);
 
     // If it didn't crash, the guard worked (it locked and unlocked correctly).
     assert!(true);
@@ -75,7 +75,7 @@ fn test_deposit_funds_state_committed_before_transfer() {
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&subscriber, &PREPAID);
 
-    client.deposit_funds(&id, &subscriber, &PREPAID);
+    client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
 
     let sub = client.get_subscription(&id);
     assert_eq!(sub.prepaid_balance, PREPAID);
@@ -128,10 +128,10 @@ fn test_replay_protection_same_timestamp_rejected() {
     env.ledger().set_timestamp(T0 + INTERVAL + 1);
 
     // First charge succeeds
-    client.charge_subscription(&id);
+    client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
 
     // Immediate second charge at same timestamp should fail with Replay (1006)
-    let result = client.try_charge_subscription(&id);
+    let result = client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert!(result.is_err());
     // Error code 1006 is Replay
 }
@@ -185,7 +185,7 @@ fn test_charge_amount_greater_than_balance_fails() {
     // insufficient — the contract handles underfunding as a recoverable outcome, not a panic.
     env.ledger().set_timestamp(T0 + INTERVAL + 1);
 
-    let result = client.try_charge_subscription(&id);
+    let result = client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(
         result,
         Ok(Ok(crate::ChargeExecutionResult::InsufficientBalance))
@@ -197,7 +197,7 @@ fn test_deposit_negative_amount_fails() {
     let (env, client, _, _) = setup_security_env();
     let (id, subscriber, _) = create_security_subscription(&env, &client);
 
-    let result = client.try_deposit_funds(&id, &subscriber, &-1);
+    let result = client.try_deposit_funds(&id, &subscriber, &-1, &None::<soroban_sdk::BytesN<32>>);
     assert!(result.is_err());
     // Error code 5004 is Underflow (used for negative amount check)
 }
@@ -227,7 +227,7 @@ fn test_chained_charge_and_cancel_preserves_balance() {
 
     // 2. Charge
     env.ledger().set_timestamp(T0 + INTERVAL + 1);
-    client.charge_subscription(&id);
+    client.charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
 
     // 3. Cancel
     client.cancel_subscription(&id, &subscriber);

--- a/contracts/subscription_vault/src/test_subscription_status_transitions.rs
+++ b/contracts/subscription_vault/src/test_subscription_status_transitions.rs
@@ -99,7 +99,7 @@ fn test_active_to_paused_to_active() {
     // Fund the subscription so the balance check in resume is satisfied.
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&subscriber, &PREPAID);
-    client.deposit_funds(&id, &subscriber, &PREPAID);
+    client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
 
     let initial_balance = client.get_subscription(&id).prepaid_balance;
 
@@ -130,7 +130,7 @@ fn test_active_to_cancelled() {
 
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&subscriber, &PREPAID);
-    client.deposit_funds(&id, &subscriber, &PREPAID);
+    client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
 
     let balance_before = client.get_subscription(&id).prepaid_balance;
     assert_eq!(client.get_subscription(&id).status, SubscriptionStatus::Active);
@@ -176,7 +176,7 @@ fn test_active_to_insufficient_balance_via_underfunded_charge() {
     assert_eq!(sub_before.status, SubscriptionStatus::Active);
     assert_eq!(sub_before.lifetime_charged, 0);
 
-    let result = client.try_charge_subscription(&id);
+    let result = client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
 
     // charge_subscription returns Ok(InsufficientBalance) — not a hard error —
     // because the insufficient-balance path is a recoverable lifecycle event.
@@ -202,7 +202,7 @@ fn test_charge_cancelled_subscription_rejected() {
     client.cancel_subscription(&id, &subscriber);
     assert_eq!(client.get_subscription(&id).status, SubscriptionStatus::Cancelled);
 
-    let result = client.try_charge_subscription(&id);
+    let result = client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(result, Err(Ok(Error::NotActive)));
 
     // Status did not change.
@@ -224,7 +224,7 @@ fn test_charge_paused_subscription_rejected() {
     // Fund the subscription so balance isn't the limiting factor.
     let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token);
     token_admin.mint(&subscriber, &PREPAID);
-    client.deposit_funds(&id, &subscriber, &PREPAID);
+    client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
 
     client.pause_subscription(&id, &subscriber);
     assert_eq!(client.get_subscription(&id).status, SubscriptionStatus::Paused);
@@ -232,7 +232,7 @@ fn test_charge_paused_subscription_rejected() {
     // Advance past the billing interval — the charge would succeed if Active.
     env.ledger().with_mut(|l| l.timestamp = T0 + INTERVAL + 1);
 
-    let result = client.try_charge_subscription(&id);
+    let result = client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(result, Err(Ok(Error::NotActive)));
 
     // Status and balance must be unchanged after the rejected charge.

--- a/contracts/subscription_vault/src/types.rs
+++ b/contracts/subscription_vault/src/types.rs
@@ -3,7 +3,7 @@
 //! Kept in a separate module to reduce merge conflicts when editing state machine
 //! or contract entrypoints.
 
-use soroban_sdk::{contracterror, contracttype, Address, String, Vec};
+use soroban_sdk::{contracterror, contracttype, Address, BytesN, String, Vec};
 
 /// Maximum number of metadata keys per subscription.
 pub const MAX_METADATA_KEYS: u32 = 10;
@@ -1562,5 +1562,36 @@ pub struct PrepaidQueryResult {
     pub next_start_id: Option<u32>,
     /// Whether more subscriptions may exist beyond this scan window.
     pub has_more: bool,
+}
+
+// ── Idempotency Key Ring Buffer ─────────────────────────────────────────────
+
+/// Maximum number of idempotency keys retained per subscription.
+pub const IDEM_HISTORY: u32 = 32;
+
+/// Entrypoint domains for idempotency key scoping.
+///
+/// Each entrypoint type uses a unique domain so that the same raw key supplied
+/// to `charge_subscription` vs `deposit_funds` produces a different on-chain
+/// fingerprint and cannot accidentally replay across operations.
+pub const DOMAIN_CHARGE_INTERVAL: u32 = 0;
+pub const DOMAIN_DEPOSIT_FUNDS: u32 = 1;
+pub const DOMAIN_CHARGE_ONEOFF: u32 = 2;
+
+/// Ring buffer of recently-seen idempotency key hashes for one subscription.
+///
+/// `DataKey::IdemKey(subscription_id)` stores this structure so that the same
+/// caller-supplied key is recognised within `IDEM_HISTORY` consecutive charges
+/// and rejected with `Error::Replay`.
+///
+/// # Eviction
+/// When the buffer is full the next push overwrites the oldest entry (cursor
+/// wraps around). The caller must therefore ensure their retry window does not
+/// exceed `IDEM_HISTORY` operations for a single subscription.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IdemRingBuffer {
+    pub entries: Vec<BytesN<32>>,
+    pub cursor: u32,
 }
 

--- a/docs/replay_protection.md
+++ b/docs/replay_protection.md
@@ -9,7 +9,7 @@ Charge operations (`charge_subscription` and, internally, each item in `batch_ch
 1. **Replay**: Charging the same billing period more than once.
 2. **Idempotent retries**: Allowing the same logical charge to be submitted multiple times (e.g. network retry) without double-debiting.
 
-Storage usage is kept bounded: one period index and optionally one idempotency key per subscription.
+Storage usage is kept bounded: one period index and one ring buffer of up to 32 idempotency key hashes per subscription.
 
 ## Mechanisms
 
@@ -18,14 +18,41 @@ Storage usage is kept bounded: one period index and optionally one idempotency k
 - For each subscription we record the **last charged billing period** as `period_index = now / interval_seconds` (integer division).
 - Before charging we require that the current period has not already been charged. If it has, the contract returns `Error::Replay`.
 - After a successful charge we store the current `period_index` for that subscription.
-- **Storage**: One `u64` per subscription (key: `("cp", subscription_id)`).
+- **Storage**: One `u64` per subscription (key: `DataKey::ChargedPeriod(subscription_id)`).
 
 ### Optional idempotency key (caller-provided)
 
-- `charge_subscription(subscription_id, idempotency_key)` accepts an optional `Option<BytesN<32>>`.
-- If the caller supplies a key and we have already processed a charge for this subscription with the **same** key, we return `Ok(())` without changing state (idempotent success).
-- If the caller supplies a key and we have not seen it for this subscription, we perform the normal checks (period replay, interval, balance), then charge and store the key.
-- **Storage**: At most one idempotency key per subscription (key: `("idem", subscription_id)`). Supplying a new key for a new period overwrites the previous one.
+Three entrypoints accept an optional idempotency key:
+
+| Entrypoint | Domain constant |
+|---|---|
+| `charge_subscription` | `DOMAIN_CHARGE_INTERVAL = 0` |
+| `deposit_funds` | `DOMAIN_DEPOSIT_FUNDS = 1` |
+| `charge_one_off` | `DOMAIN_CHARGE_ONEOFF = 2` |
+
+- Each entrypoint accepts an `idem_key: Option<BytesN<32>>`.
+- If the caller supplies a key and we have already recorded the **hash** of `(domain, subscription_id, key)` for this subscription, we return the success variant without modifying state (idempotent no-op).
+- If the key is new, the normal checks run, the operation executes, and the hashed key is appended to the ring buffer.
+
+#### Key hashing
+
+The raw caller-supplied key is **never stored directly**. Instead, the contract computes:
+
+```
+hash = SHA256(domain || subscription_id || raw_key)
+```
+
+where `domain` is a 4-byte big-endian `u32`, `subscription_id` is a 4-byte big-endian `u32`, and `raw_key` is the 32-byte caller-supplied value. This ensures:
+
+- The same raw key used on two different entrypoints produces different on-chain fingerprints.
+- The same raw key used on two different subscriptions produces different fingerprints.
+- No raw key material is visible in storage to indexers.
+
+#### Ring buffer
+
+- Hashes are stored in an `IdemRingBuffer` struct capped at `IDEM_HISTORY = 32` entries per subscription.
+- A `cursor` field tracks where the next entry will be written. When the buffer is full, the oldest entry is silently overwritten (cursor wraps around).
+- **Storage**: One `IdemRingBuffer` per subscription (key: `DataKey::IdemKey(subscription_id)`).
 
 ### Batch charge
 
@@ -35,25 +62,125 @@ Storage usage is kept bounded: one period index and optionally one idempotency k
 
 1. **Use one idempotency key per billing event.** For a given subscription and billing period, use a single stable key (e.g. derived from `subscription_id` + period start or from your job id). Retries with the same key are safe; using a new key for the same period will be rejected as `Replay` once the period was already charged.
 
-2. **Do not reuse keys across periods.** Use a new key for each new billing period so that the next charge is not mistaken for a replay of the previous period.
+2. **Do not reuse keys across periods or entrypoints.** Use a new key for each new billing period so that the next charge is not mistaken for a replay of the previous period. The domain-separated hashing scheme prevents cross-entrypoint collisions, but best practice is still to use unique keys per event.
 
 3. **Handle `Error::Replay`.** If you receive `Replay`, the charge for that period was already applied (by this or a previous request). Treat as success for reporting; do not retry with a different key for the same period.
 
-4. **Optional but recommended:** Persist idempotency keys in your billing engine (e.g. per subscription and period) so that retries use the same key.
+4. **Handle idempotent no-op.** If you receive `Ok` but did not observe the corresponding on-chain event (e.g. your indexer missed it), the operation still succeeded. The contract does not re-emit events on idempotent matches; verify against the ring buffer off-chain if needed.
+
+5. **Optional but recommended:** Persist idempotency keys in your billing engine (e.g. per subscription and period) so that retries use the same key.
+
+6. **Retry window.** Because the ring buffer holds only the 32 most recent hashes, retries must complete within 32 operations for the same subscription. After 32 newer operations, the oldest hash is evicted and a retry with that key would be processed as a fresh operation.
 
 ## Required parameters and behavior (Rustdoc summary)
 
-- **`charge_subscription(env, subscription_id, idempotency_key)`**
-  - `idempotency_key`: `Option<BytesN<32>>`. Use `Some(key)` for safe retries; use `None` for period-only protection.
-  - Returns `Ok(())` on success or idempotent match (same key already processed).
+- **`charge_subscription(env, subscription_id, idem_key)`**
+  - `idem_key`: `Option<BytesN<32>>`. Use `Some(key)` for safe retries; use `None` for period-only protection.
+  - Returns `Ok(ChargeExecutionResult::Charged)` on success or idempotent match (same key already processed).
   - Returns `Err(Error::Replay)` if this billing period was already charged (and the call did not match a stored idempotency key).
+
+- **`deposit_funds(env, subscription_id, subscriber, amount, idem_key)`**
+  - `idem_key`: `Option<BytesN<32>>`. Use `Some(key)` for safe retries.
+  - Returns `Ok(())` on success or idempotent match.
+
+- **`charge_one_off(env, subscription_id, merchant, amount, idem_key)`**
+  - `idem_key`: `Option<BytesN<32>>`. Use `Some(key)` for safe retries.
+  - Returns `Ok(())` on success or idempotent match.
 
 ## Residual risks and mitigations
 
-- **Clock skew / timestamp manipulation:** Period is derived from ledger timestamp. Validators set ledger time; contract does not rely on caller-provided time. Mitigation: trust the network’s ledger timestamp.
-- **Unbounded growth:** Only one period index and one idempotency key per subscription are stored. No unbounded growth from replay protection.
-- **Key collision:** If an integrator reuses the same 32-byte key for two different billing periods, the second period’s charge would be treated as idempotent (return Ok without charging). Mitigation: derive keys from period (e.g. include period start or index in the key).
+- **Clock skew / timestamp manipulation:** Period is derived from ledger timestamp. Validators set ledger time; contract does not rely on caller-provided time. Mitigation: trust the network's ledger timestamp.
+- **Unbounded growth:** Only one period index and one `IdemRingBuffer` (≤ 32 entries × 32 bytes = 1,024 bytes per subscription) are stored. No unbounded growth from replay protection.
+- **Key collision:** If an integrator reuses the same 32-byte key for two different billing periods on the same entrypoint, the second period's charge would be treated as idempotent (return Ok without charging). Mitigation: derive keys from period (e.g. include period start or index in the key).
+- **Ring buffer eviction:** A retry delayed by more than 32 operations will miss the ring buffer and execute as a fresh charge. Use `None` or choose a short retry window.
+- **Cross-entrypoint safety:** Domain separation in the hash prevents the same raw key from replaying across `charge_subscription`, `deposit_funds`, and `charge_one_off`.
+
 ---
+
+## Admin-operation nonce scheme
+
+Privileged admin operations (`batch_charge` and `rotate_admin`) carry an additional layer of replay protection through an explicit, domain-separated, monotonic nonce scheme.
+
+### Design
+
+| Property | Value |
+|---|---|
+| Nonce type | `u64` (unsigned, monotonic) |
+| Per-signer | One counter per `(signer: Address, domain: u32)` pair |
+| Storage | Persistent storage, key `DataKey::AdminNonce(Address, u32)` |
+| Initial value | `0` (absent key treated as `0`) |
+| Enforcement | Caller provides the *current* stored value; contract checks equality, then atomically increments |
+| Error on mismatch | `Error::NonceAlreadyUsed` (code `1038`) |
+
+### Domain constants
+
+```rust
+pub const DOMAIN_BATCH_CHARGE: u32 = 0;   // label: "batch"
+pub const DOMAIN_ADMIN_ROTATION: u32 = 1;  // label: "adm_rot"
+```
+
+Domain separation ensures that a nonce consumed in one operation cannot interfere with another. The labels appear in the emitted event topic so indexers can filter by domain.
+
+### Nonce consumption flow
+
+```
+caller → batch_charge(ids, nonce)
+  1. require_stored_admin_auth()   // auth check first – fails fast on wrong signer
+  2. check_and_advance(admin, DOMAIN_BATCH_CHARGE, nonce)
+        a. read stored nonce (default 0)
+        b. assert provided == stored  → Error::NonceAlreadyUsed if not
+        c. write stored + 1
+        d. emit NonceConsumedEvent
+  3. … rest of charge logic
+```
+
+### Emitted event
+
+Every successful nonce consumption emits a `NonceConsumedEvent`:
+
+```rust
+pub struct NonceConsumedEvent {
+    pub signer:    Address,  // the admin address that consumed the nonce
+    pub domain:    u32,      // DOMAIN_BATCH_CHARGE or DOMAIN_ADMIN_ROTATION
+    pub nonce:     u64,      // the consumed (previous) nonce value
+    pub timestamp: u64,      // ledger timestamp at consumption
+}
+```
+
+Event topic: `("nonce_consumed", signer, domain_label)` where `domain_label` is the human-readable symbol (`"batch"` or `"adm_rot"`).
+
+### Off-chain integration
+
+Use `get_admin_nonce(signer, domain) -> u64` to read the expected nonce before submitting a transaction:
+
+```rust
+// Pseudocode
+let next_nonce = client.get_admin_nonce(&admin, DOMAIN_BATCH_CHARGE);
+client.batch_charge(&subscription_ids, &next_nonce);
+```
+
+To prevent races, integrate this with a serialised job queue or use optimistic concurrency: if `NonceAlreadyUsed` is returned, re-read the nonce and retry.
+
+### Security properties
+
+| Threat | Mitigation |
+|---|---|
+| Cross-ledger replay | Nonce is monotonic; replaying any past transaction fails with `NonceAlreadyUsed` |
+| Out-of-order submission | Only the exact stored value is accepted; skipping nonce values is rejected |
+| Cross-domain replay | Domain tag is part of storage key; batch_charge nonce and rotate_admin nonce are fully independent |
+| Cross-signer replay | Signer address is part of storage key; each admin has its own counter |
+| Nonce overflow | `checked_add(1)` panics (transaction aborted) rather than wrapping to 0 |
+| Auth bypass via nonce manipulation | Auth check (`require_admin_auth`) runs *before* nonce check; invalid signers are rejected without advancing any counter |
+
+### Storage layout
+
+```
+Persistent storage:
+  DataKey::AdminNonce(Address, 0) → u64   (batch_charge nonce for address)
+  DataKey::AdminNonce(Address, 1) → u64   (rotate_admin nonce for address)
+```
+
+Nonce entries are stored in **persistent** storage so they survive ledger TTL extension and contract upgrades. Growth is bounded: one `u64` entry per `(signer, domain)` pair. In practice this means at most two entries per admin address (one per domain).
 
 ## Admin-operation nonce scheme
 


### PR DESCRIPTION
Add an optional idempotency key (idem_key: Option<BytesN<32>>) to charge_subscription, deposit_funds, and charge_one_off so that off-chain callers can safely retry without double-execution.

- IdemRingBuffer type with cursor-based ring buffer (max 32 entries) stored under DataKey::IdemKey(subscription_id)
- New idempotency.rs module: hash_idem_key (SHA256 of domain || sub_id || raw_key), check_key (linear scan), push_key (overwrite at cursor when full)
- Three domain constants (DOMAIN_CHARGE_INTERVAL=0, DOMAIN_DEPOSIT_FUNDS=1, DOMAIN_CHARGE_ONEOFF=2) to prevent cross-entrypoint key collisions
- Pre-existing compilation fixes: duplicate imports in charge_core, duplicate check_and_advance in nonce, stale period_snapshots module in lib, _env typo in do_operator_batch_charge
- Updated docs/replay_protection.md with ring buffer and hashing documentation
- 9 comprehensive idempotency tests (replay, different keys, domain separation, ring buffer eviction, None-key passthrough)
- All existing test callers updated with &None::<BytesN<32>>

closes: #508 