### PR TITLE
Refactor: replace panics with typed Result errors (#490)

### DIFF
--- a/contracts/subscription_vault/src/charge_core.rs
+++ b/contracts/subscription_vault/src/charge_core.rs
@@ -40,10 +40,7 @@ use crate::types::{
     LifetimeCapReachedEvent, SubscriptionChargeFailedEvent, SubscriptionChargedEvent,
     SubscriptionStatus, UsageChargeRejectedEvent, UsageChargeResult, UsageLimits, UsageState,
     UsageStatementEvent, SNAPSHOT_FLAG_CLOSED, SNAPSHOT_FLAG_INTERVAL_CHARGED, SNAPSHOT_FLAG_USAGE_CHARGED,
-    GracePeriodEnteredEvent, LifetimeCapReachedEvent, SubscriptionChargeFailedEvent,
-    SubscriptionChargedEvent, SubscriptionStatus, UsageChargeRejectedEvent, UsageChargeResult,
-    UsageLimits, UsageState, UsageStatementEvent, SNAPSHOT_FLAG_CLOSED,
-    SNAPSHOT_FLAG_INTERVAL_CHARGED,
+    GracePeriodEnteredEvent,
 };
 use soroban_sdk::{symbol_short, Env, String, Symbol};
 

--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -2901,7 +2901,10 @@ mod test_charge_invariants;
 
 #[cfg(test)]
 mod test_billing_period_snapshots;
+#[cfg(test)]
 mod test_insufficient_balance;
+#[cfg(test)]
+mod test_governance;
 
 #[cfg(test)]
 mod test {

--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -113,36 +113,6 @@ pub mod statements {
     }
 }
 
-/// Period snapshots: write billing-period summaries for reconciliation.
-pub mod period_snapshots {
-    #![allow(unused_variables, dead_code)]
-    use crate::types::{
-        BillingPeriodSnapshot, DataKey, Error, BILLING_PERIOD_SNAPSHOT_TTL_EXTEND_TO,
-        BILLING_PERIOD_SNAPSHOT_TTL_THRESHOLD,
-    };
-    use soroban_sdk::Env;
-
-    pub fn write_period_snapshot(
-        _env: &Env,
-        _snapshot: BillingPeriodSnapshot,
-    ) -> Result<(), Error> {
-        Ok(())
-    }
-    pub fn get_period_snapshot(
-        _env: &Env,
-        _subscription_id: u32,
-        _period_index: u64,
-    ) -> Option<BillingPeriodSnapshot> {
-        None
-    }
-    pub fn list_period_snapshots(
-        _env: &Env,
-        _subscription_id: u32,
-        _limit: u32,
-    ) -> soroban_sdk::Vec<BillingPeriodSnapshot> {
-        soroban_sdk::Vec::new(_env)
-    }
-}
 
 /// Accounting: tracks total tokens accounted for across all subscriptions.
 ///
@@ -246,7 +216,7 @@ pub mod operator {
         ids: &Vec<u32>,
         nonce: u64,
     ) -> Result<Vec<BatchChargeResult>, Error> {
-        Ok(Vec::new(_env))
+        Ok(Vec::new(env))
     }
 
     /// Single interval charge driven by the operator.

--- a/contracts/subscription_vault/src/merchant.rs
+++ b/contracts/subscription_vault/src/merchant.rs
@@ -362,6 +362,9 @@ pub fn withdraw_merchant_funds_for_token(
         return Err(Error::InvalidInput);
     }
 
+    // Verify merchant config is initialized
+    let _config = get_merchant_config(env, merchant.clone()).ok_or(Error::NotFound)?;
+
     let current = get_merchant_balance_by_token(env, &merchant, &token_addr);
     if current == 0 {
         return Err(Error::NotFound);
@@ -426,6 +429,9 @@ pub fn merchant_refund(
     if amount <= 0 {
         return Err(Error::InvalidAmount);
     }
+
+    // Verify merchant config is initialized
+    let _config = get_merchant_config(env, merchant.clone()).ok_or(Error::NotFound)?;
 
     let current = get_merchant_balance_by_token(env, &merchant, &token_addr);
     if current == 0 {

--- a/contracts/subscription_vault/src/metadata.rs
+++ b/contracts/subscription_vault/src/metadata.rs
@@ -112,7 +112,8 @@ pub fn delete_metadata(
         .unwrap_or(Vec::new(env));
 
     if let Some(idx) = keys.iter().position(|k| k == key) {
-        keys.remove(idx.try_into().unwrap());
+        let idx_u32 = idx.try_into().map_err(|_| Error::Overflow)?;
+        keys.remove(idx_u32);
         env.storage()
             .persistent()
             .set(&DataKey::MetadataKeys(subscription_id), &keys);

--- a/contracts/subscription_vault/src/nonce.rs
+++ b/contracts/subscription_vault/src/nonce.rs
@@ -121,15 +121,6 @@ pub fn check_and_advance(
     Ok(())
 }
 
-/// Alias for [`consume_nonce`] — used by admin.rs.
-pub fn check_and_advance(
-    env: &Env,
-    signer: &Address,
-    domain: u32,
-    expected: u64,
-) -> Result<(), Error> {
-    consume_nonce(env, signer, domain, expected)
-}
 
 #[cfg(test)]
 mod tests {

--- a/contracts/subscription_vault/src/nonce.rs
+++ b/contracts/subscription_vault/src/nonce.rs
@@ -99,10 +99,10 @@ pub fn check_and_advance(
         return Err(Error::NonceAlreadyUsed);
     }
 
-    // Increment the counter atomically. Panics on overflow (u64::MAX).
+    // Increment the counter atomically. Returns Error::Overflow on overflow (u64::MAX).
     let next = stored
         .checked_add(1)
-        .expect("nonce overflow: u64::MAX reached");
+        .ok_or(Error::Overflow)?;
 
     // Persist the incremented nonce before emitting event (effects-before-interactions).
     env.storage().persistent().set(&key, &next);
@@ -125,6 +125,7 @@ pub fn check_and_advance(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use soroban_sdk::testutils::Address as _;
 
     /// Mock test to verify constant values are correct.
     #[test]
@@ -132,5 +133,23 @@ mod tests {
         assert_eq!(DOMAIN_BATCH_CHARGE, 0);
         assert_eq!(DOMAIN_ADMIN_ROTATION, 1);
         assert_eq!(DOMAIN_OPERATOR_BATCH_CHARGE, 2);
+    }
+
+    #[test]
+    fn test_check_and_advance_overflow() {
+        let env = Env::default();
+        let signer = Address::generate(&env);
+        let domain = DOMAIN_BATCH_CHARGE;
+        let contract_id = env.register(crate::SubscriptionVault, ());
+
+        let res = env.as_contract(&contract_id, || {
+            let key = DataKey::AdminNonce(signer.clone(), domain);
+            // Seed with u64::MAX
+            env.storage().persistent().set(&key, &u64::MAX);
+
+            // Try to advance it, it should return Err(Error::Overflow)
+            check_and_advance(&env, &signer, domain, u64::MAX)
+        });
+        assert_eq!(res, Err(Error::Overflow));
     }
 }

--- a/contracts/subscription_vault/src/subscription.rs
+++ b/contracts/subscription_vault/src/subscription.rs
@@ -616,7 +616,8 @@ pub fn do_cancel_subscription(
     let merchant_key = DataKey::MerchantSubs(sub.merchant.clone());
     if let Some(mut ids) = env.storage().instance().get::<_, Vec<u32>>(&merchant_key) {
         if let Some(idx) = ids.iter().position(|x| x == subscription_id) {
-            ids.remove(idx.try_into().unwrap());
+            let idx_u32 = idx.try_into().map_err(|_| Error::Overflow)?;
+            ids.remove(idx_u32);
             env.storage().instance().set(&merchant_key, &ids);
         }
     }
@@ -624,7 +625,8 @@ pub fn do_cancel_subscription(
     let token_key = DataKey::TokenSubs(sub.token.clone());
     if let Some(mut ids) = env.storage().instance().get::<_, Vec<u32>>(&token_key) {
         if let Some(idx) = ids.iter().position(|x| x == subscription_id) {
-            ids.remove(idx.try_into().unwrap());
+            let idx_u32 = idx.try_into().map_err(|_| Error::Overflow)?;
+            ids.remove(idx_u32);
             env.storage().instance().set(&token_key, &ids);
         }
     }
@@ -633,7 +635,8 @@ pub fn do_cancel_subscription(
     let subscriber_key = DataKey::SubscriberSubs(sub.subscriber.clone());
     if let Some(mut ids) = env.storage().instance().get::<_, Vec<u32>>(&subscriber_key) {
         if let Some(idx) = ids.iter().position(|x| x == subscription_id) {
-            ids.remove(idx.try_into().unwrap());
+            let idx_u32 = idx.try_into().map_err(|_| Error::Overflow)?;
+            ids.remove(idx_u32);
             env.storage().instance().set(&subscriber_key, &ids);
         }
     }

--- a/contracts/subscription_vault/src/test_billing_period_snapshots.rs
+++ b/contracts/subscription_vault/src/test_billing_period_snapshots.rs
@@ -4,18 +4,20 @@ use crate::{
         BillingPeriodSnapshot, Error, SNAPSHOT_FLAG_CLOSED, SNAPSHOT_FLAG_EMPTY,
         SNAPSHOT_FLAG_INTERVAL_CHARGED, SNAPSHOT_FLAG_USAGE_CHARGED,
     },
+    SubscriptionVault,
 };
-use soroban_sdk::{testutils::Ledger, Env};
+use soroban_sdk::{testutils::Ledger, Env, Address};
 
-fn setup() -> Env {
+fn setup() -> (Env, Address) {
     let env = Env::default();
     env.ledger().set_timestamp(1_000_000);
-    env
+    let contract_id = env.register(SubscriptionVault, ());
+    (env, contract_id) 
 }
 
 #[test]
 fn test_write_and_get_snapshot() {
-    let env = setup();
+    let (env, contract_id) = setup();
     let sub_id = 1;
     let period_index = 0;
 
@@ -30,15 +32,15 @@ fn test_write_and_get_snapshot() {
         finalized_at: 200,
     };
 
-    assert!(write_period_snapshot(&env, snapshot.clone()).is_ok());
+    assert!(env.as_contract(&contract_id, || write_period_snapshot(&env, snapshot.clone())).is_ok());
 
-    let fetched = get_period_snapshot(&env, sub_id, period_index).unwrap();
+    let fetched = env.as_contract(&contract_id, || get_period_snapshot(&env, sub_id, period_index)).unwrap();
     assert_eq!(fetched, snapshot);
 }
 
 #[test]
 fn test_list_period_snapshots_returns_latest_n() {
-    let env = setup();
+    let (env, contract_id) = setup();
     let sub_id = 2;
 
     for i in 0..5 {
@@ -52,11 +54,11 @@ fn test_list_period_snapshots_returns_latest_n() {
             status_flags: SNAPSHOT_FLAG_INTERVAL_CHARGED | SNAPSHOT_FLAG_CLOSED,
             finalized_at: 200 + i * 100,
         };
-        assert!(write_period_snapshot(&env, snapshot).is_ok());
+        assert!(env.as_contract(&contract_id, || write_period_snapshot(&env, snapshot)).is_ok());
     }
 
     // Get latest 3
-    let latest = list_period_snapshots(&env, sub_id, 3);
+    let latest = env.as_contract(&contract_id, || list_period_snapshots(&env, sub_id, 3));
     assert_eq!(latest.len(), 3);
     
     // Should return newest first
@@ -67,7 +69,7 @@ fn test_list_period_snapshots_returns_latest_n() {
 
 #[test]
 fn test_overwrite_closed_snapshot_rejected() {
-    let env = setup();
+    let (env, contract_id) = setup();
     let sub_id = 3;
     let period_index = 0;
 
@@ -82,17 +84,17 @@ fn test_overwrite_closed_snapshot_rejected() {
         finalized_at: 200,
     };
 
-    assert!(write_period_snapshot(&env, snapshot.clone()).is_ok());
+    assert!(env.as_contract(&contract_id, || write_period_snapshot(&env, snapshot.clone())).is_ok());
 
     // Try to update closed snapshot
     snapshot.total_charged = 1000;
-    let result = write_period_snapshot(&env, snapshot);
+    let result = env.as_contract(&contract_id, || write_period_snapshot(&env, snapshot));
     assert_eq!(result, Err(Error::InvalidStatusTransition));
 }
 
 #[test]
 fn test_empty_period_sets_empty_flag() {
-    let env = setup();
+    let (env, contract_id) = setup();
     let sub_id = 4;
     let period_index = 0;
 
@@ -107,15 +109,15 @@ fn test_empty_period_sets_empty_flag() {
         finalized_at: 200,
     };
 
-    assert!(write_period_snapshot(&env, snapshot).is_ok());
+    assert!(env.as_contract(&contract_id, || write_period_snapshot(&env, snapshot)).is_ok());
 
-    let fetched = get_period_snapshot(&env, sub_id, period_index).unwrap();
+    let fetched = env.as_contract(&contract_id, || get_period_snapshot(&env, sub_id, period_index)).unwrap();
     assert_eq!(fetched.status_flags, SNAPSHOT_FLAG_CLOSED | SNAPSHOT_FLAG_EMPTY);
 }
 
 #[test]
 fn test_mixed_interval_and_usage_sets_both_flags() {
-    let env = setup();
+    let (env, contract_id) = setup();
     let sub_id = 5;
     let period_index = 0;
 
@@ -130,7 +132,7 @@ fn test_mixed_interval_and_usage_sets_both_flags() {
         status_flags: SNAPSHOT_FLAG_USAGE_CHARGED,
         finalized_at: 150,
     };
-    assert!(write_period_snapshot(&env, usage_snapshot).is_ok());
+    assert!(env.as_contract(&contract_id, || write_period_snapshot(&env, usage_snapshot)).is_ok());
 
     // 2. Write interval charge closing the period
     let interval_snapshot = BillingPeriodSnapshot {
@@ -143,9 +145,9 @@ fn test_mixed_interval_and_usage_sets_both_flags() {
         status_flags: SNAPSHOT_FLAG_CLOSED | SNAPSHOT_FLAG_INTERVAL_CHARGED,
         finalized_at: 200,
     };
-    assert!(write_period_snapshot(&env, interval_snapshot).is_ok());
+    assert!(env.as_contract(&contract_id, || write_period_snapshot(&env, interval_snapshot)).is_ok());
 
-    let fetched = get_period_snapshot(&env, sub_id, period_index).unwrap();
+    let fetched = env.as_contract(&contract_id, || get_period_snapshot(&env, sub_id, period_index)).unwrap();
     
     // Assert merged state
     assert_eq!(fetched.total_charged, 1200);
@@ -161,7 +163,7 @@ fn test_mixed_interval_and_usage_sets_both_flags() {
 
 #[test]
 fn test_integrity_checks() {
-    let env = setup();
+    let (env, contract_id) = setup();
     
     // Invalid boundaries
     let bad_bounds = BillingPeriodSnapshot {
@@ -174,7 +176,7 @@ fn test_integrity_checks() {
         status_flags: SNAPSHOT_FLAG_USAGE_CHARGED,
         finalized_at: 150,
     };
-    assert_eq!(write_period_snapshot(&env, bad_bounds), Err(Error::InvalidInput));
+    assert_eq!(env.as_contract(&contract_id, || write_period_snapshot(&env, bad_bounds)), Err(Error::InvalidInput));
 
     // Interval charge requires period_start < period_end
     let bad_interval = BillingPeriodSnapshot {
@@ -187,5 +189,5 @@ fn test_integrity_checks() {
         status_flags: SNAPSHOT_FLAG_INTERVAL_CHARGED,
         finalized_at: 100,
     };
-    assert_eq!(write_period_snapshot(&env, bad_interval), Err(Error::InvalidInput));
+    assert_eq!(env.as_contract(&contract_id, || write_period_snapshot(&env, bad_interval)), Err(Error::InvalidInput));
 }

--- a/contracts/subscription_vault/src/test_governance.rs
+++ b/contracts/subscription_vault/src/test_governance.rs
@@ -324,6 +324,74 @@ fn test_update_deactivate_merchant() {
     assert_eq!(updated.is_active, false);
 }
 
+#[test]
+fn test_withdraw_uninitialized_merchant_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(SubscriptionVault, ());
+    let client = SubscriptionVaultClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+
+    client.init(&token, &6, &admin, &1_000_000i128, &(7 * 24 * 60 * 60));
+
+    let merchant = Address::generate(&env);
+    let amount = 1_000_000i128;
+
+    // Call try_withdraw_merchant_funds for an uninitialized merchant config
+    let res = client.try_withdraw_merchant_funds(&merchant, &amount);
+    assert_eq!(res, Err(Ok(crate::types::Error::NotFound)));
+}
+
+#[test]
+fn test_withdraw_token_uninitialized_merchant_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(SubscriptionVault, ());
+    let client = SubscriptionVaultClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+
+    client.init(&token, &6, &admin, &1_000_000i128, &(7 * 24 * 60 * 60));
+
+    let merchant = Address::generate(&env);
+    let amount = 1_000_000i128;
+
+    let res = client.try_withdraw_merchant_token_funds(&merchant, &token, &amount);
+    assert_eq!(res, Err(Ok(crate::types::Error::NotFound)));
+}
+
+#[test]
+fn test_merchant_refund_uninitialized_merchant_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(SubscriptionVault, ());
+    let client = SubscriptionVaultClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+
+    client.init(&token, &6, &admin, &1_000_000i128, &(7 * 24 * 60 * 60));
+
+    let merchant = Address::generate(&env);
+    let subscriber = Address::generate(&env);
+    let amount = 1_000_000i128;
+
+    let res = client.try_merchant_refund(&merchant, &subscriber, &token, &amount);
+    assert_eq!(res, Err(Ok(crate::types::Error::NotFound)));
+}
+
 // ══════════════════════════════════════════════════════════════════════════════
 // Admin rotation invariant tests
 //

--- a/contracts/subscription_vault/tests/multi_actor_e2e_test.rs
+++ b/contracts/subscription_vault/tests/multi_actor_e2e_test.rs
@@ -54,6 +54,17 @@ fn test_multi_actor_e2e_flow() {
         &grace_period,
     );
 
+    // Initialize merchant config
+    let redirect_url = soroban_sdk::String::from_str(&env, "https://example.com");
+    vault.initialize_merchant_config(
+        &merchant,
+        &merchant,
+        &0,
+        &0x1F,
+        &None,
+        &redirect_url,
+    );
+
     // Pre-assertions
     assert_eq!(token.balance(&subscriber), initial_mint);
     assert_eq!(token.balance(&vault_id), 0);


### PR DESCRIPTION
# Refactor: replace panics with typed Result errors (#490)

## Description

Migrate remaining panic-inducing paths (`unwrap()`, `expect()`, and unsafe `try_into()` index casts) across the subscription vault contract components to propagate typed `Result<_, Error>` returns. This allows the Soroban SDK-generated client to surface explicit contract errors (e.g., `Error::NotFound` or `Error::Overflow`) downstream cleanly, avoiding opaque `HostError` panics.

Additionally, this PR explicitly registers the `test_governance` test suite so that its comprehensive governance and merchant configuration tests are active, and adds specific test coverage for the new error conditions.

## Key Changes

### Nonce Counters (`nonce.rs`)
- Replaced `expect("nonce overflow...")` inside `check_and_advance` with a checked addition that propagates `Error::Overflow` (5005) if the `u64` nonce counter overflows.
- Added a dedicated unit test `test_check_and_advance_overflow` using `env.as_contract()` to assert that overflows return the expected overflow error.

### Metadata Key Management (`metadata.rs`)
- Replaced `idx.try_into().unwrap()` inside `delete_metadata` with safe cast propagation returning `Error::Overflow` (5005) on failure.

### Subscription Operations (`subscription.rs`)
- Replaced three instances of `idx.try_into().unwrap()` index casts inside `do_cancel_subscription` with `try_into().map_err(|_| Error::Overflow)?`.

### Merchant Operations & Verification (`merchant.rs`)
- Added validation checks in both `withdraw_merchant_funds_for_token` and `merchant_refund` to verify the merchant configuration is initialized before modifying balances. If uninitialized, the call propagates `Error::NotFound` (2001) instead of returning default fallbacks.
- Updated `tests/multi_actor_e2e_test.rs` to initialize the merchant configuration prior to withdrawals.

### Test Suite Activation & Coverage (`lib.rs`, `test_governance.rs`)
- Registered `test_governance` as a test module (`#[cfg(test)] mod test_governance;`) in the contract's `lib.rs` to ensure it is compiled and executed.
- Appended three new unit tests to `test_governance.rs` targeting the uninitialized merchant config validations to verify they cleanly return `Error::NotFound`.

---

## Verification Plan

### Automated Test Runs
All unit and integration tests build and pass successfully (with the long invariant test skipped):
```bash
cargo test -- --skip test_merchant_earnings_invariant
```

Closes https://github.com/Stellabill/stellabill-contracts/issues/490
