### PR TITLE
feat: add scheduled future-dated cancellation

### DIFF
--- a/contracts/subscription_vault/src/admin.rs
+++ b/contracts/subscription_vault/src/admin.rs
@@ -216,6 +216,10 @@ pub(crate) fn execute_batch_charge(env: &Env, subscription_ids: &Vec<u32>) -> Ve
                 success: false,
                 error_code: Error::LifetimeCapReached.to_code(),
             },
+            Ok(ChargeExecutionResult::ScheduledCancellation) => BatchChargeResult {
+                success: true,
+                error_code: 0,
+            },
             Err(e) => BatchChargeResult {
                 success: false,
                 error_code: e.to_code(),

--- a/contracts/subscription_vault/src/charge_core.rs
+++ b/contracts/subscription_vault/src/charge_core.rs
@@ -37,13 +37,10 @@ use crate::subscription::{next_charge_time, write_subscription};
 use crate::statements::append_statement;
 use crate::types::{
     BillingChargeKind, BillingPeriodSnapshot, ChargeExecutionResult, DataKey, Error,
-    LifetimeCapReachedEvent, SubscriptionChargeFailedEvent, SubscriptionChargedEvent,
+    SubscriptionCancelledEvent,
+    GracePeriodEnteredEvent, LifetimeCapReachedEvent, SubscriptionChargeFailedEvent, SubscriptionChargedEvent,
     SubscriptionStatus, UsageChargeRejectedEvent, UsageChargeResult, UsageLimits, UsageState,
     UsageStatementEvent, SNAPSHOT_FLAG_CLOSED, SNAPSHOT_FLAG_INTERVAL_CHARGED, SNAPSHOT_FLAG_USAGE_CHARGED,
-    GracePeriodEnteredEvent, LifetimeCapReachedEvent, SubscriptionChargeFailedEvent,
-    SubscriptionChargedEvent, SubscriptionStatus, UsageChargeRejectedEvent, UsageChargeResult,
-    UsageLimits, UsageState, UsageStatementEvent, SNAPSHOT_FLAG_CLOSED,
-    SNAPSHOT_FLAG_INTERVAL_CHARGED,
 };
 use soroban_sdk::{symbol_short, Env, String, Symbol};
 
@@ -98,6 +95,42 @@ pub fn charge_one(
                 );
             }
             return Ok(ChargeExecutionResult::LifetimeCapReached);
+        }
+    }
+
+    // Scheduled cancellation: fire when cancel_at has arrived.
+    if let Some(cancel_at) = sub.cancel_at {
+        if now >= cancel_at {
+            if sub.status != SubscriptionStatus::Cancelled {
+                transition_to(&mut sub.status, SubscriptionStatus::Cancelled)?;
+                let refund_amount = sub.prepaid_balance;
+                sub.prepaid_balance = 0;
+                sub.cancel_at = None;
+                let token_addr = sub.token.clone();
+                write_subscription(env, subscription_id, &sub);
+                if refund_amount > 0 {
+                    let token_client = soroban_sdk::token::Client::new(env, &token_addr);
+                    token_client.transfer(
+                        &env.current_contract_address(),
+                        &sub.subscriber,
+                        &refund_amount,
+                    );
+                    crate::accounting::sub_total_accounted(env, &token_addr, refund_amount)?;
+                }
+                env.events().publish(
+                    (soroban_sdk::Symbol::new(env, "subscription_cancelled"), subscription_id),
+                    SubscriptionCancelledEvent {
+                        subscription_id,
+                        subscriber: sub.subscriber.clone(),
+                        merchant: sub.merchant.clone(),
+                        token: sub.token.clone(),
+                        authorizer: sub.subscriber.clone(),
+                        refund_amount,
+                        timestamp: now,
+                    },
+                );
+            }
+            return Ok(ChargeExecutionResult::ScheduledCancellation);
         }
     }
 

--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -1617,6 +1617,50 @@ impl SubscriptionVault {
     /// - `NotFound` if subscription doesn’t exist
     /// - `Unauthorized` if caller is not subscriber or merchant
     /// - `InvalidStatusTransition` if not active
+
+        /// Schedule a future cancellation for a subscription.
+        ///
+        /// On the next `charge_subscription` call where `now >= cancel_at`, the
+        /// subscription is transitioned to `Cancelled` and any remaining prepaid
+        /// balance is refunded instead of being charged.
+        ///
+        /// # Authorization
+        /// Only the subscription's `subscriber` or `merchant` may call this.
+        ///
+        /// # Errors
+        /// - `InvalidInput` if `cancel_at` is not strictly in the future
+        /// - `Forbidden` if caller is not subscriber or merchant
+        /// - `InvalidStatusTransition` if subscription is already `Cancelled`
+        /// - `SubscriptionExpired` if subscription has expired
+        pub fn schedule_cancel(
+            env: Env,
+            subscription_id: u32,
+            authorizer: Address,
+            cancel_at: u64,
+        ) -> Result<(), Error> {
+            let _guard = crate::reentrancy::ReentrancyGuard::lock(&env, "schedule_cancel")?;
+            subscription::do_schedule_cancel(&env, subscription_id, authorizer, cancel_at)
+        }
+
+        /// Clear a previously scheduled future cancellation.
+        ///
+        /// Idempotent: safe to call even when no cancellation was scheduled.
+        ///
+        /// # Authorization
+        /// Only the subscription's `subscriber` or `merchant` may call this.
+        ///
+        /// # Errors
+        /// - `Forbidden` if caller is not subscriber or merchant
+        /// - `InvalidStatusTransition` if subscription is already `Cancelled`
+        pub fn unschedule_cancel(
+            env: Env,
+            subscription_id: u32,
+            authorizer: Address,
+        ) -> Result<(), Error> {
+            let _guard = crate::reentrancy::ReentrancyGuard::lock(&env, "unschedule_cancel")?;
+            subscription::do_unschedule_cancel(&env, subscription_id, authorizer)
+        }
+
     pub fn pause_subscription(
         env: Env,
         subscription_id: u32,
@@ -2928,6 +2972,9 @@ mod test_utils;
 
 #[cfg(test)]
 mod test_charge_invariants;
+
+#[cfg(test)]
+mod test_scheduled_cancel;
 
 #[cfg(test)]
 mod test_billing_period_snapshots;

--- a/contracts/subscription_vault/src/subscription.rs
+++ b/contracts/subscription_vault/src/subscription.rs
@@ -46,7 +46,8 @@ use crate::types::{
     GlobalCapDefaultUpdatedEvent, LifetimeCapReachedEvent, LifetimeCapUpdatedEvent,
     MerchantCapDefaultUpdatedEvent, PartialRefundEvent, PlanMaxActiveUpdatedEvent,
     PlanTemplate, PlanTemplateUpdatedEvent, SubscriberWithdrawalEvent,
-    Subscription, SubscriptionCancelledEvent, SubscriptionCreatedEvent, SubscriptionMigratedEvent,
+    Subscription, SubscriptionCancelledEvent, SubscriptionCancelScheduledEvent, SubscriptionCancelUnscheduledEvent,
+    SubscriptionCreatedEvent, SubscriptionMigratedEvent,
     SubscriptionRecoveryReadyEvent, SubscriptionResumedEvent, SubscriptionPausedEvent,
     SubscriptionStatus, UsageLimits, UsageLimitsConfiguredEvent,
     SUB_TTL_EXTEND_TO, SUB_TTL_THRESHOLD,
@@ -407,6 +408,7 @@ pub fn do_create_subscription_with_token(
         start_time: env.ledger().timestamp(),
         expires_at,
         grace_start_timestamp: None,
+        cancel_at: None,
     };
 
     // Allocate ID with overflow / limit guard.
@@ -652,6 +654,102 @@ pub fn do_cancel_subscription(
     );
     Ok(())
 }
+
+/// Schedule a future cancellation for a subscription.
+///
+/// When `now >= cancel_at` on the next `charge_one` call, the subscription is
+/// automatically transitioned to `Cancelled` instead of being charged.
+///
+/// # Authorization
+/// Only the subscription's `subscriber` or `merchant` may schedule.
+///
+/// # Validation
+/// - `cancel_at` must be strictly greater than the current ledger timestamp.
+/// - Subscription must not already be `Cancelled` or `Expired`.
+///
+/// # Events
+/// Emits [`SubscriptionCancelScheduledEvent`].
+pub fn do_schedule_cancel(
+    env: &Env,
+    subscription_id: u32,
+    authorizer: Address,
+    cancel_at: u64,
+) -> Result<(), Error> {
+    authorizer.require_auth();
+
+    let now = env.ledger().timestamp();
+    if cancel_at <= now {
+        return Err(Error::InvalidInput);
+    }
+
+    let mut sub = get_subscription(env, subscription_id)?;
+
+    if authorizer != sub.subscriber && authorizer != sub.merchant {
+        return Err(Error::Forbidden);
+    }
+
+    if sub.status == SubscriptionStatus::Cancelled {
+        return Err(Error::InvalidStatusTransition);
+    }
+    if sub.is_expired(now) {
+        return Err(Error::SubscriptionExpired);
+    }
+
+    sub.cancel_at = Some(cancel_at);
+    write_subscription(env, subscription_id, &sub);
+
+    env.events().publish(
+        (Symbol::new(env, "cancel_scheduled"), subscription_id),
+        SubscriptionCancelScheduledEvent {
+            subscription_id,
+            cancel_at,
+            scheduled_by: authorizer,
+            timestamp: now,
+        },
+    );
+    Ok(())
+}
+
+/// Clear a previously scheduled future cancellation.
+///
+/// Safe to call even when no cancellation was scheduled (idempotent).
+///
+/// # Authorization
+/// Only the subscription's `subscriber` or `merchant` may unschedule.
+///
+/// # Events
+/// Emits [`SubscriptionCancelUnscheduledEvent`].
+pub fn do_unschedule_cancel(
+    env: &Env,
+    subscription_id: u32,
+    authorizer: Address,
+) -> Result<(), Error> {
+    authorizer.require_auth();
+
+    let mut sub = get_subscription(env, subscription_id)?;
+
+    if authorizer != sub.subscriber && authorizer != sub.merchant {
+        return Err(Error::Forbidden);
+    }
+
+    if sub.status == SubscriptionStatus::Cancelled {
+        return Err(Error::InvalidStatusTransition);
+    }
+
+    sub.cancel_at = None;
+    write_subscription(env, subscription_id, &sub);
+
+    env.events().publish(
+        (Symbol::new(env, "cancel_unscheduled"), subscription_id),
+        SubscriptionCancelUnscheduledEvent {
+            subscription_id,
+            unscheduled_by: authorizer,
+            timestamp: env.ledger().timestamp(),
+        },
+    );
+    Ok(())
+}
+
 
 /// Pause a subscription (no charges until resumed).
 ///
@@ -1392,6 +1490,7 @@ pub fn do_create_subscription_from_plan(
         start_time: env.ledger().timestamp(),
         expires_at: None,
         grace_start_timestamp: None,
+        cancel_at: None,
     };
 
     write_subscription(env, id, &sub);

--- a/contracts/subscription_vault/src/test_scheduled_cancel.rs
+++ b/contracts/subscription_vault/src/test_scheduled_cancel.rs
@@ -1,0 +1,166 @@
+use crate::{
+    Error, SubscriptionVault, SubscriptionVaultClient,
+};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{Address, Env};
+
+fn setup() -> (Env, Address, SubscriptionVaultClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(SubscriptionVault, ());
+    let client = SubscriptionVaultClient::new(&env, &contract_id);
+    (env, contract_id, client)
+}
+
+const T0: u64 = 1_000_000;
+const INTERVAL: u64 = 30 * 24 * 3600;
+const AMOUNT: i128 = 10_000_000;
+const PREPAID: i128 = 50_000_000;
+
+fn create_active_sub(env: &Env, client: &SubscriptionVaultClient) -> (u32, Address, Address, Address) {
+    use crate::test_utils::fixtures;
+    fixtures::create_active_subscription(env, client, T0, INTERVAL, AMOUNT, PREPAID)
+}
+
+// --- schedule_cancel ---
+
+#[test]
+fn test_schedule_cancel_happy_path() {
+    let (env, _, client) = setup();
+    env.ledger().set_timestamp(T0);
+    let (sub_id, subscriber, _merchant, _token) = create_active_sub(&env, &client);
+
+    let cancel_at = T0 + INTERVAL;
+    client.schedule_cancel(&sub_id, &subscriber, &cancel_at);
+
+    // subscription is still Active — cancel_at hasn't fired yet
+    let sub = client.get_subscription(&sub_id);
+    assert_eq!(sub.cancel_at, Some(cancel_at));
+}
+
+#[test]
+fn test_schedule_cancel_past_timestamp_rejected() {
+    let (env, _, client) = setup();
+    env.ledger().set_timestamp(T0);
+    let (sub_id, subscriber, _merchant, _token) = create_active_sub(&env, &client);
+
+    let result = client.try_schedule_cancel(&sub_id, &subscriber, &(T0 - 1));
+    assert_eq!(result, Err(Ok(Error::InvalidInput)));
+}
+
+#[test]
+fn test_schedule_cancel_now_rejected() {
+    let (env, _, client) = setup();
+    env.ledger().set_timestamp(T0);
+    let (sub_id, subscriber, _merchant, _token) = create_active_sub(&env, &client);
+
+    let result = client.try_schedule_cancel(&sub_id, &subscriber, &T0);
+    assert_eq!(result, Err(Ok(Error::InvalidInput)));
+}
+
+#[test]
+fn test_schedule_cancel_forbidden_for_stranger() {
+    let (env, _, client) = setup();
+    env.ledger().set_timestamp(T0);
+    let (sub_id, _subscriber, _merchant, _token) = create_active_sub(&env, &client);
+    let stranger = Address::generate(&env);
+
+    let result = client.try_schedule_cancel(&sub_id, &stranger, &(T0 + INTERVAL));
+    assert_eq!(result, Err(Ok(Error::Forbidden)));
+}
+
+#[test]
+fn test_schedule_cancel_merchant_allowed() {
+    let (env, _, client) = setup();
+    env.ledger().set_timestamp(T0);
+    let (sub_id, _subscriber, merchant, _token) = create_active_sub(&env, &client);
+
+    // merchant can also schedule
+    client.schedule_cancel(&sub_id, &merchant, &(T0 + INTERVAL));
+    let sub = client.get_subscription(&sub_id);
+    assert!(sub.cancel_at.is_some());
+}
+
+// --- unschedule_cancel ---
+
+#[test]
+fn test_unschedule_cancel_clears_schedule() {
+    let (env, _, client) = setup();
+    env.ledger().set_timestamp(T0);
+    let (sub_id, subscriber, _merchant, _token) = create_active_sub(&env, &client);
+
+    client.schedule_cancel(&sub_id, &subscriber, &(T0 + INTERVAL));
+    client.unschedule_cancel(&sub_id, &subscriber);
+
+    let sub = client.get_subscription(&sub_id);
+    assert_eq!(sub.cancel_at, None);
+}
+
+#[test]
+fn test_unschedule_cancel_idempotent() {
+    let (env, _, client) = setup();
+    env.ledger().set_timestamp(T0);
+    let (sub_id, subscriber, _merchant, _token) = create_active_sub(&env, &client);
+
+    // No prior schedule — should not error
+    client.unschedule_cancel(&sub_id, &subscriber);
+    let sub = client.get_subscription(&sub_id);
+    assert_eq!(sub.cancel_at, None);
+}
+
+// --- charge_one fires scheduled cancellation ---
+
+#[test]
+fn test_charge_one_fires_scheduled_cancellation_when_due() {
+    let (env, _, client) = setup();
+    env.ledger().set_timestamp(T0);
+    let (sub_id, subscriber, _merchant, _token) = create_active_sub(&env, &client);
+
+    // Schedule cancel for exactly one interval from now
+    let cancel_at = T0 + INTERVAL;
+    client.schedule_cancel(&sub_id, &subscriber, &cancel_at);
+
+    // Advance time to cancel_at
+    env.ledger().set_timestamp(cancel_at);
+    client.charge_subscription(&sub_id, &None::<soroban_sdk::BytesN<32>>);
+
+    let sub = client.get_subscription(&sub_id);
+    assert_eq!(sub.status, crate::SubscriptionStatus::Cancelled);
+    assert_eq!(sub.cancel_at, None);
+}
+
+#[test]
+fn test_charge_one_does_not_fire_when_cancel_at_in_future() {
+    let (env, _, client) = setup();
+    env.ledger().set_timestamp(T0);
+    let (sub_id, subscriber, _merchant, _token) = create_active_sub(&env, &client);
+
+    // Schedule cancel well in the future
+    client.schedule_cancel(&sub_id, &subscriber, &(T0 + INTERVAL * 10));
+
+    // Advance one interval — should charge normally, NOT cancel
+    env.ledger().set_timestamp(T0 + INTERVAL);
+    client.charge_subscription(&sub_id, &None::<soroban_sdk::BytesN<32>>);
+
+    let sub = client.get_subscription(&sub_id);
+    assert_eq!(sub.status, crate::SubscriptionStatus::Active);
+}
+
+#[test]
+fn test_unschedule_before_fire_prevents_cancellation() {
+    let (env, _, client) = setup();
+    env.ledger().set_timestamp(T0);
+    let (sub_id, subscriber, _merchant, _token) = create_active_sub(&env, &client);
+
+    let cancel_at = T0 + INTERVAL;
+    client.schedule_cancel(&sub_id, &subscriber, &cancel_at);
+    client.unschedule_cancel(&sub_id, &subscriber);
+
+    // Advance to what would have been the fire time
+    env.ledger().set_timestamp(cancel_at);
+    client.charge_subscription(&sub_id, &None::<soroban_sdk::BytesN<32>>);
+
+    let sub = client.get_subscription(&sub_id);
+    // Should have charged normally, not cancelled
+    assert_eq!(sub.status, crate::SubscriptionStatus::Active);
+}

--- a/contracts/subscription_vault/src/types.rs
+++ b/contracts/subscription_vault/src/types.rs
@@ -253,6 +253,9 @@ pub struct Subscription {
     pub expires_at: Option<u64>,
     /// Timestamp when a grace-period started. `None` means not in grace period.
     pub grace_start_timestamp: Option<u64>,
+    /// Scheduled future cancellation timestamp. When `Some(t)` and `now >= t`,
+    /// `charge_one` transitions the subscription to `Cancelled` instead of charging.
+    pub cancel_at: Option<u64>,
 }
 
 impl Subscription {
@@ -1025,6 +1028,25 @@ pub struct SubscriptionCancelledEvent {
     pub timestamp: u64,
 }
 
+/// Event emitted when a future cancellation is scheduled.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct SubscriptionCancelScheduledEvent {
+    pub subscription_id: u32,
+    pub cancel_at: u64,
+    pub scheduled_by: Address,
+    pub timestamp: u64,
+}
+
+/// Event emitted when a scheduled cancellation is cleared.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct SubscriptionCancelUnscheduledEvent {
+    pub subscription_id: u32,
+    pub unscheduled_by: Address,
+    pub timestamp: u64,
+}
+
 /// Event emitted when a subscription is paused.
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -1265,6 +1287,7 @@ pub enum ChargeExecutionResult {
     Charged = 0,
     InsufficientBalance = 1,
     LifetimeCapReached = 2,
+    ScheduledCancellation = 3,
 }
 
 #[contracttype]


### PR DESCRIPTION
Closes #510

## Summary

Adds `schedule_cancel` / `unschedule_cancel` entry points so a subscriber or merchant can cancel a subscription at the end of the current billing period rather than immediately.

## Changes

**`types.rs`**
- `Subscription` gains `cancel_at: Option<u64>`
- `ChargeExecutionResult` gains `ScheduledCancellation = 3`
- New events: `SubscriptionCancelScheduledEvent`, `SubscriptionCancelUnscheduledEvent`

**`subscription.rs`**
- `do_schedule_cancel`: stores `cancel_at`, validates strictly-future timestamp, checks subscriber/merchant auth, rejects Cancelled/Expired subscriptions, emits event
- `do_unschedule_cancel`: clears `cancel_at` (idempotent), checks subscriber/merchant auth, emits event

**`charge_core.rs`** (`charge_one`)
- Before the status guard, checks `cancel_at <= now`
- If due: runs full cancellation flow following CEI pattern (zero balance in storage, then token transfer), emits `subscription_cancelled`, returns `ScheduledCancellation`

**`admin.rs`**
- `execute_batch_charge` match handles new `ScheduledCancellation` arm (`success: true`)

**`lib.rs`**
- `schedule_cancel(env, subscription_id, authorizer, cancel_at)` — gated by `ReentrancyGuard`
- `unschedule_cancel(env, subscription_id, authorizer)` — gated by `ReentrancyGuard`

## Tests (`test_scheduled_cancel.rs`)

9 tests:
- happy path schedule
- past timestamp rejected
- now timestamp rejected
- forbidden for stranger
- merchant allowed
- unschedule clears schedule
- idempotent unschedule
- charge fires cancellation when due
- future cancel_at does not fire early
- unschedule-before-fire prevents cancellation

## Security

- Caller must be `subscriber` or `merchant` — any other address gets `Error::Forbidden`
- `cancel_at` must be strictly `> now` — equal or past returns `Error::InvalidInput`
- Cancellation in `charge_one` follows CEI: state zeroed before token transfer