### PR TITLE
feat: implement rotate_merchant_address admin entrypoint

### DIFF
--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -663,6 +663,28 @@ impl SubscriptionVault {
         admin::do_rotate_admin(&env, current_admin, new_admin, nonce)
     }
 
+    /// Rotate a merchant's on-chain address from `old_merchant` to `new_merchant`.
+    ///
+    /// Migrates every per-merchant storage key (balances, earnings, config, pause
+    /// state, subscription index) and rewrites `Subscription.merchant` for all
+    /// subscriptions previously indexed under the old address.
+    ///
+    /// Admin only. `nonce` is consumed in `DOMAIN_MERCHANT_ROTATION` to prevent replay.
+    ///
+    /// # Errors
+    /// - `Unauthorized`     if caller is not the stored admin
+    /// - `NonceAlreadyUsed` if the nonce has already been used
+    /// - `SelfRotation`     if `old_merchant == new_merchant`
+    pub fn rotate_merchant_address(
+        env: Env,
+        admin: Address,
+        old_merchant: Address,
+        new_merchant: Address,
+        nonce: u64,
+    ) -> Result<(), Error> {
+        merchant::do_rotate_merchant_address(&env, admin, old_merchant, new_merchant, nonce)
+    }
+
     /// Configure oracle pricing parameters. Admin only.
     ///
     /// Enables/disables oracle, sets the oracle address, and defines staleness bounds.

--- a/contracts/subscription_vault/src/merchant.rs
+++ b/contracts/subscription_vault/src/merchant.rs
@@ -535,3 +535,154 @@ pub fn update_merchant_config(
 
     Ok(config)
 }
+
+/// Migrate every per-merchant storage key from `old_merchant` to `new_merchant`
+/// and rewrite every `Subscription.merchant` field that points at the old address.
+///
+/// # Migrated keys
+/// * `MerchantBalance(old, token)` → `MerchantBalance(new, token)` for every token
+/// * `MerchantTokens(old)`         → `MerchantTokens(new)`
+/// * `MerchantEarnings(old, token)`→ `MerchantEarnings(new, token)` for every token
+/// * `MerchantConfig(old)`         → `MerchantConfig(new)`
+/// * `MerchantPaused(old)`         → `MerchantPaused(new)`
+/// * `MerchantSubs(old)`           → `MerchantSubs(new)` (index list)
+/// * Every `Sub(id).merchant` where `merchant == old` is rewritten to `new`
+///
+/// # Auth
+/// Admin-only. The `admin` argument must match the stored admin address.
+/// Nonce `nonce` is consumed in domain `DOMAIN_MERCHANT_ROTATION` to prevent replay.
+///
+/// # Errors
+/// * `Unauthorized`       — caller is not the stored admin
+/// * `NonceAlreadyUsed`   — nonce was already consumed
+/// * `SelfRotation`       — `old == new`
+pub fn do_rotate_merchant_address(
+    env: &Env,
+    admin: Address,
+    old_merchant: Address,
+    new_merchant: Address,
+    nonce: u64,
+) -> Result<(), crate::types::Error> {
+    crate::admin::require_admin_auth(env, &admin)?;
+
+    crate::nonce::check_and_advance(
+        env,
+        &admin,
+        crate::nonce::DOMAIN_MERCHANT_ROTATION,
+        nonce,
+    )?;
+
+    if old_merchant == new_merchant {
+        return Err(crate::types::Error::SelfRotation);
+    }
+
+    let storage = env.storage().instance();
+
+    // ── 1. Migrate MerchantTokens list ────────────────────────────────────────
+    let tokens_key_old = DataKey::MerchantTokens(old_merchant.clone());
+    let tokens_key_new = DataKey::MerchantTokens(new_merchant.clone());
+    let tokens: soroban_sdk::Vec<Address> = storage
+        .get(&tokens_key_old)
+        .unwrap_or(soroban_sdk::Vec::new(env));
+
+    // ── 2. Migrate per-token balances and earnings ────────────────────────────
+    for token in tokens.iter() {
+        // MerchantBalance
+        let bal_key_old = DataKey::MerchantBalance(old_merchant.clone(), token.clone());
+        let bal: i128 = storage.get(&bal_key_old).unwrap_or(0i128);
+        if bal != 0 {
+            let bal_key_new = DataKey::MerchantBalance(new_merchant.clone(), token.clone());
+            let existing: i128 = storage.get(&bal_key_new).unwrap_or(0i128);
+            storage.set(&bal_key_new, &(existing + bal));
+        }
+        storage.remove(&bal_key_old);
+
+        // MerchantEarnings
+        let earn_key_old = DataKey::MerchantEarnings(old_merchant.clone(), token.clone());
+        if let Some(earnings) = storage.get::<_, crate::types::TokenEarnings>(&earn_key_old) {
+            let earn_key_new = DataKey::MerchantEarnings(new_merchant.clone(), token.clone());
+            storage.set(&earn_key_new, &earnings);
+            storage.remove(&earn_key_old);
+        }
+    }
+
+    // Write merged token list to new address (merge with any existing list)
+    if !tokens.is_empty() {
+        let mut new_tokens: soroban_sdk::Vec<Address> = storage
+            .get(&tokens_key_new)
+            .unwrap_or(soroban_sdk::Vec::new(env));
+        for token in tokens.iter() {
+            if !new_tokens.contains(&token) {
+                new_tokens.push_back(token);
+            }
+        }
+        storage.set(&tokens_key_new, &new_tokens);
+    }
+    storage.remove(&tokens_key_old);
+
+    // ── 3. Migrate MerchantConfig ─────────────────────────────────────────────
+    let cfg_key_old = DataKey::MerchantConfig(old_merchant.clone());
+    if let Some(config) = storage.get::<_, crate::types::MerchantConfig>(&cfg_key_old) {
+        let cfg_key_new = DataKey::MerchantConfig(new_merchant.clone());
+        storage.set(&cfg_key_new, &config);
+        storage.remove(&cfg_key_old);
+    }
+
+    // ── 4. Migrate MerchantPaused ─────────────────────────────────────────────
+    let pause_key_old = DataKey::MerchantPaused(old_merchant.clone());
+    if let Some(paused) = storage.get::<_, bool>(&pause_key_old) {
+        let pause_key_new = DataKey::MerchantPaused(new_merchant.clone());
+        storage.set(&pause_key_new, &paused);
+        storage.remove(&pause_key_old);
+    }
+
+    // ── 5. Migrate MerchantSubs index and rewrite Subscription.merchant ───────
+    let subs_key_old = DataKey::MerchantSubs(old_merchant.clone());
+    let sub_ids: soroban_sdk::Vec<u32> = storage
+        .get(&subs_key_old)
+        .unwrap_or(soroban_sdk::Vec::new(env));
+
+    let mut subscriptions_updated: u32 = 0;
+    for sub_id in sub_ids.iter() {
+        let sub_key = DataKey::Sub(sub_id);
+        if let Some(mut sub) = env
+            .storage()
+            .persistent()
+            .get::<_, crate::types::Subscription>(&sub_key)
+        {
+            if sub.merchant == old_merchant {
+                sub.merchant = new_merchant.clone();
+                env.storage().persistent().set(&sub_key, &sub);
+                subscriptions_updated += 1;
+            }
+        }
+    }
+
+    if !sub_ids.is_empty() {
+        let subs_key_new = DataKey::MerchantSubs(new_merchant.clone());
+        let mut new_sub_ids: soroban_sdk::Vec<u32> = storage
+            .get(&subs_key_new)
+            .unwrap_or(soroban_sdk::Vec::new(env));
+        for id in sub_ids.iter() {
+            if !new_sub_ids.contains(&id) {
+                new_sub_ids.push_back(id);
+            }
+        }
+        storage.set(&subs_key_new, &new_sub_ids);
+    }
+    storage.remove(&subs_key_old);
+
+    // ── 6. Emit audit event ───────────────────────────────────────────────────
+    env.events().publish(
+        (soroban_sdk::Symbol::new(env, "merchant_addr_rotated"),),
+        crate::types::MerchantAddressRotatedEvent {
+            admin,
+            old_merchant,
+            new_merchant,
+            subscriptions_updated,
+            timestamp: env.ledger().timestamp(),
+        },
+    );
+
+    Ok(())
+}

--- a/contracts/subscription_vault/src/nonce.rs
+++ b/contracts/subscription_vault/src/nonce.rs
@@ -35,6 +35,9 @@ pub const DOMAIN_ADMIN_ROTATION: u32 = 1;
 /// Domain constant for operator batch charge operations.
 pub const DOMAIN_OPERATOR_BATCH_CHARGE: u32 = 2;
 
+/// Domain constant for merchant address rotation operations.
+pub const DOMAIN_MERCHANT_ROTATION: u32 = 3;
+
 
 /// Retrieve the current (next-expected) nonce for a `(signer, domain)` pair.
 ///
@@ -121,16 +124,6 @@ pub fn check_and_advance(
     Ok(())
 }
 
-/// Alias for [`consume_nonce`] — used by admin.rs.
-pub fn check_and_advance(
-    env: &Env,
-    signer: &Address,
-    domain: u32,
-    expected: u64,
-) -> Result<(), Error> {
-    consume_nonce(env, signer, domain, expected)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -141,5 +134,6 @@ mod tests {
         assert_eq!(DOMAIN_BATCH_CHARGE, 0);
         assert_eq!(DOMAIN_ADMIN_ROTATION, 1);
         assert_eq!(DOMAIN_OPERATOR_BATCH_CHARGE, 2);
+        assert_eq!(DOMAIN_MERCHANT_ROTATION, 3);
     }
 }

--- a/contracts/subscription_vault/src/test.rs
+++ b/contracts/subscription_vault/src/test.rs
@@ -3588,6 +3588,91 @@ fn test_withdraw_merchant_token_funds_checks_vault_balance_before_transfer() {
     );
 }
 
+// -- rotate_merchant_address tests -------------------------------------------
+
+#[test]
+fn test_rotate_merchant_address_migrates_balance_and_subscriptions() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, token, admin) = setup_contract(&env);
+
+    let old_merchant = Address::generate(&env);
+    let new_merchant = Address::generate(&env);
+
+    seed_merchant_balance(&env, &client.address, &old_merchant, &token, 5_000_000i128);
+
+    let subscriber = Address::generate(&env);
+    let id = client.create_subscription(
+        &subscriber,
+        &old_merchant,
+        &AMOUNT,
+        &INTERVAL,
+        &false,
+        &None::<i128>,
+        &None::<u64>,
+    );
+
+    client.rotate_merchant_address(&admin, &old_merchant, &new_merchant, &0u64);
+
+    assert_eq!(client.get_merchant_balance_by_token(&old_merchant, &token), 0);
+    assert_eq!(client.get_merchant_balance_by_token(&new_merchant, &token), 5_000_000i128);
+
+    let sub = client.get_subscription(&id);
+    assert_eq!(sub.merchant, new_merchant);
+}
+
+#[test]
+fn test_rotate_merchant_address_rejects_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _token, _admin) = setup_contract(&env);
+
+    let impostor = Address::generate(&env);
+    let old_merchant = Address::generate(&env);
+    let new_merchant = Address::generate(&env);
+
+    let result = client.try_rotate_merchant_address(&impostor, &old_merchant, &new_merchant, &0u64);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_rotate_merchant_address_rejects_self_rotation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _token, admin) = setup_contract(&env);
+
+    let merchant = Address::generate(&env);
+    let result = client.try_rotate_merchant_address(&admin, &merchant, &merchant, &0u64);
+    assert_eq!(result, Err(Ok(Error::SelfRotation)));
+}
+
+#[test]
+fn test_rotate_merchant_address_rejects_nonce_replay() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _token, admin) = setup_contract(&env);
+
+    let old_merchant = Address::generate(&env);
+    let new_merchant = Address::generate(&env);
+    let newer_merchant = Address::generate(&env);
+
+    client.rotate_merchant_address(&admin, &old_merchant, &new_merchant, &0u64);
+    let result = client.try_rotate_merchant_address(&admin, &new_merchant, &newer_merchant, &0u64);
+    assert_eq!(result, Err(Ok(Error::NonceAlreadyUsed)));
+}
+
+#[test]
+fn test_rotate_merchant_address_unknown_merchant_is_noop() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _token, admin) = setup_contract(&env);
+
+    let ghost = Address::generate(&env);
+    let new_merchant = Address::generate(&env);
+    client.rotate_merchant_address(&admin, &ghost, &new_merchant, &0u64);
+    assert_eq!(client.get_merchant_balance(&new_merchant), 0);
+}
+
 // -- End-to-end billing lifecycle tests --------------------------------------
 
 #[test]

--- a/contracts/subscription_vault/src/types.rs
+++ b/contracts/subscription_vault/src/types.rs
@@ -1403,6 +1403,26 @@ pub struct MerchantConfigUpdatedEvent {
     pub timestamp: u64,
 }
 
+/// Event emitted when admin rotates a merchant's address.
+///
+/// Emitted by [`SubscriptionVault::rotate_merchant_address`] after all per-merchant
+/// storage keys have been migrated from `old_merchant` to `new_merchant` and every
+/// `Subscription.merchant` field referencing the old address has been rewritten.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct MerchantAddressRotatedEvent {
+    /// Admin address that authorised the rotation.
+    pub admin: Address,
+    /// The compromised / old merchant address.
+    pub old_merchant: Address,
+    /// The new merchant address that now owns all balances and subscriptions.
+    pub new_merchant: Address,
+    /// Number of active subscription records whose `.merchant` field was rewritten.
+    pub subscriptions_updated: u32,
+    /// Ledger timestamp when the rotation was executed.
+    pub timestamp: u64,
+}
+
 /// Event emitted when a protocol fee is charged.
 #[contracttype]
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Summary

Implements `rotate_merchant_address(env, admin, old_merchant, new_merchant, nonce)` — an admin entrypoint that rescues merchant funds when a private key is compromised, by atomically migrating all per-merchant state to a new address.

## What changes

**`src/merchant.rs`** — `do_rotate_merchant_address`
- Migrates `MerchantBalance`, `MerchantTokens`, `MerchantEarnings`, `MerchantConfig`, `MerchantPaused`, and `MerchantSubs` instance keys from `old_merchant` → `new_merchant`
- Rewrites `Subscription.merchant` for every subscription ID in the old merchant's index
- Removes old keys after migration (no dangling state)
- Emits `MerchantAddressRotatedEvent` with `subscriptions_updated` count for off-chain indexers

**`src/lib.rs`** — thin `rotate_merchant_address` entrypoint delegating to `merchant::`

**`src/nonce.rs`** — adds `DOMAIN_MERCHANT_ROTATION = 3`; also removes the duplicate `check_and_advance` function that was causing a compile error on `main`

**`src/types.rs`** — adds `MerchantAddressRotatedEvent` struct

**`src/test.rs`** — 5 unit tests:
1. Happy path: balance migrated, `Subscription.merchant` rewritten
2. Non-admin caller rejected (`Unauthorized`)
3. Self-rotation rejected (`SelfRotation`)
4. Nonce replay rejected (`NonceAlreadyUsed`)
5. Unknown merchant → silent no-op (no panic, no error)

## Verification

```
cargo test
```

Note: pre-existing compile errors on `main` (duplicate `period_snapshots`, duplicate type imports) prevent the full test suite from running; this PR does not introduce any new errors and fixes the duplicate `check_and_advance` error.

Closes #509