### PR TITLE
add bulk pause/cancel admin tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,6 +1612,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 name = "subscription_vault"
 version = "0.1.0"
 dependencies = [
+ "hex",
  "proptest",
  "soroban-sdk",
 ]

--- a/contracts/subscription_vault/src/admin.rs
+++ b/contracts/subscription_vault/src/admin.rs
@@ -139,6 +139,32 @@ pub fn require_stored_admin_auth(env: &Env) -> Result<Address, Error> {
     Ok(stored_admin)
 }
 
+/// Authorize `caller` as **either** the stored admin **or** the stored operator.
+///
+/// Used by the bulk pause/cancel operational tooling, which both privileged roles
+/// may invoke. `caller.require_auth()` runs first (so an unauthenticated caller is
+/// rejected before any identity comparison), then the address must match the
+/// stored admin or operator; anything else returns [`Error::Unauthorized`].
+///
+/// This deliberately does **not** widen any other surface: the operator still has
+/// no access to fund withdrawal, admin rotation, or governance.
+pub fn require_admin_or_operator_auth(env: &Env, caller: &Address) -> Result<(), Error> {
+    caller.require_auth();
+
+    let stored_admin = require_admin(env)?;
+    if caller == &stored_admin {
+        return Ok(());
+    }
+
+    if let Some(stored_op) = crate::operator::get_operator(env) {
+        if caller == &stored_op {
+            return Ok(());
+        }
+    }
+
+    Err(Error::Unauthorized)
+}
+
 pub fn do_set_min_topup(env: &Env, admin: Address, min_topup: i128) -> Result<(), Error> {
     require_admin_auth(env, &admin)?;
     if min_topup <= 0 {

--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -299,6 +299,7 @@ pub use queries::{
 pub use state_machine::{can_transition, get_allowed_transitions, validate_status_transition};
 pub use types::{
     AcceptedToken, AccruedTotals, AdminRotatedEvent, BatchChargeResult, BatchWithdrawResult,
+    BulkCancelEvent, BulkPauseEvent, BulkSubscriptionResult, BATCH_MAX_SIZE,
     BillingChargeKind, BillingCompactedEvent, BillingCompactionSummary, BillingPeriodSnapshot,
     BillingRetentionConfig, BillingStatement, BillingStatementAggregate, BillingStatementsPage,
     CapInfo, ChargeExecutionResult, ContractSnapshot, DataKey, EmergencyStopDisabledEvent,
@@ -728,6 +729,96 @@ impl SubscriptionVault {
     ) -> Result<Vec<BatchChargeResult>, Error> {
         require_not_emergency_stop(&env)?;
         admin::do_batch_charge(&env, &subscription_ids, nonce)
+    }
+
+    // ── Bulk pause / cancel (operational hygiene) ─────────────────────────────
+
+    /// Pause many subscriptions in one transaction. Admin **or** operator.
+    ///
+    /// Operational tooling for offboarding or containing a compromised merchant
+    /// without calling [`pause_subscription`](Self::pause_subscription) one id at
+    /// a time. The batch is **partial-failure tolerant**: ids that are missing,
+    /// expired, or already paused never abort the batch — each id's fate is
+    /// reported in the returned vector (one [`BulkSubscriptionResult`] per
+    /// requested id, in request order). Already-paused ids are skipped as
+    /// idempotent no-ops (`changed = false`).
+    ///
+    /// Unlike [`batch_charge`](Self::batch_charge), this is intentionally **not**
+    /// gated by the emergency stop — pausing must remain available precisely when
+    /// the circuit breaker is engaged. This mirrors the single-id
+    /// [`pause_subscription`](Self::pause_subscription).
+    ///
+    /// # Arguments
+    ///
+    /// * `caller` — Must match the stored admin or the stored operator.
+    /// * `subscription_ids` — Ids to pause. At most [`BATCH_MAX_SIZE`]; a larger
+    ///   batch is rejected wholesale with [`Error::BatchTooLarge`]. An empty list
+    ///   is a no-op (no nonce consumed, no event).
+    /// * `nonce` — Per-batch replay protection on the `DOMAIN_OPERATOR_BATCH_CHARGE`
+    ///   counter, keyed per caller. Read the current value with
+    ///   [`get_admin_nonce`](Self::get_admin_nonce) (admin) or
+    ///   [`get_operator_nonce`](Self::get_operator_nonce) (operator), passing
+    ///   domain `2`.
+    ///
+    /// # Errors
+    ///
+    /// * [`Error::Unauthorized`] — `caller` is neither the stored admin nor operator.
+    /// * [`Error::BatchTooLarge`] — More than [`BATCH_MAX_SIZE`] ids supplied.
+    /// * [`Error::NonceAlreadyUsed`] — Provided nonce does not match expected.
+    ///
+    /// # Events
+    ///
+    /// Emits one [`SubscriptionPausedEvent`] per actually-paused id, plus a single
+    /// [`BulkPauseEvent`] envelope summarising the batch.
+    pub fn bulk_pause_subscriptions(
+        env: Env,
+        caller: Address,
+        subscription_ids: Vec<u32>,
+        nonce: u64,
+    ) -> Result<Vec<BulkSubscriptionResult>, Error> {
+        subscription::do_bulk_pause_subscriptions(&env, caller, &subscription_ids, nonce)
+    }
+
+    /// Cancel many subscriptions in one transaction. Admin **or** operator.
+    ///
+    /// Operational tooling for offboarding or containing a compromised merchant.
+    /// Like [`bulk_pause_subscriptions`](Self::bulk_pause_subscriptions) it is
+    /// **partial-failure tolerant** and returns one [`BulkSubscriptionResult`] per
+    /// requested id, in request order. Already-cancelled ids are skipped as
+    /// idempotent no-ops, so a duplicated id can never be refunded twice.
+    ///
+    /// Each cancelled id refunds its remaining prepaid balance to the subscriber,
+    /// exactly as [`cancel_subscription`](Self::cancel_subscription) does. Because
+    /// the loop performs external token transfers, the call is wrapped in a
+    /// `ReentrancyGuard` for defense in depth.
+    ///
+    /// # Arguments
+    ///
+    /// * `caller` — Must match the stored admin or the stored operator.
+    /// * `subscription_ids` — Ids to cancel. At most [`BATCH_MAX_SIZE`]; a larger
+    ///   batch is rejected wholesale with [`Error::BatchTooLarge`]. An empty list
+    ///   is a no-op (no nonce consumed, no event).
+    /// * `nonce` — Per-batch replay protection on the `DOMAIN_OPERATOR_BATCH_CHARGE`
+    ///   counter, keyed per caller (domain `2`).
+    ///
+    /// # Errors
+    ///
+    /// * [`Error::Unauthorized`] — `caller` is neither the stored admin nor operator.
+    /// * [`Error::BatchTooLarge`] — More than [`BATCH_MAX_SIZE`] ids supplied.
+    /// * [`Error::NonceAlreadyUsed`] — Provided nonce does not match expected.
+    ///
+    /// # Events
+    ///
+    /// Emits one [`SubscriptionCancelledEvent`] per actually-cancelled id, plus a
+    /// single [`BulkCancelEvent`] envelope summarising the batch.
+    pub fn bulk_cancel_subscriptions(
+        env: Env,
+        caller: Address,
+        subscription_ids: Vec<u32>,
+        nonce: u64,
+    ) -> Result<Vec<BulkSubscriptionResult>, Error> {
+        let _guard = crate::reentrancy::ReentrancyGuard::lock(&env, "bulk_cancel_subscriptions")?;
+        subscription::do_bulk_cancel_subscriptions(&env, caller, &subscription_ids, nonce)
     }
 
     // ── Emergency Stop ────────────────────────────────────────────────────────
@@ -3284,6 +3375,9 @@ mod test_validation;
 
 #[cfg(test)]
 mod test_abi_validators_integration;
+
+#[cfg(test)]
+mod test_bulk_admin_ops;
 
 #[cfg(test)]
 mod test {

--- a/contracts/subscription_vault/src/subscription.rs
+++ b/contracts/subscription_vault/src/subscription.rs
@@ -42,7 +42,8 @@ use crate::safe_math::{safe_add, safe_add_balance, safe_sub};
 use crate::state_machine::transition_to;
 use crate::statements::append_statement;
 use crate::types::{
-    BillingChargeKind, ChargeFailureEvent, DataKey, Error, FundsDepositedEvent,
+    BillingChargeKind, BulkCancelEvent, BulkPauseEvent, BulkSubscriptionResult, ChargeFailureEvent,
+    DataKey, Error, FundsDepositedEvent,
     GlobalCapDefaultUpdatedEvent, LifetimeCapReachedEvent, LifetimeCapUpdatedEvent,
     MerchantCapDefaultUpdatedEvent, PartialRefundEvent, PlanMaxActiveUpdatedEvent,
     PlanTemplate, PlanTemplateUpdatedEvent, SubscriberWithdrawalEvent,
@@ -50,7 +51,7 @@ use crate::types::{
     SubscriptionCreatedEvent, SubscriptionMigratedEvent,
     SubscriptionRecoveryReadyEvent, SubscriptionResumedEvent, SubscriptionPausedEvent,
     SubscriptionStatus, UsageLimits, UsageLimitsConfiguredEvent,
-    SUB_TTL_EXTEND_TO, SUB_TTL_THRESHOLD,
+    BATCH_MAX_SIZE, SUB_TTL_EXTEND_TO, SUB_TTL_THRESHOLD,
 };
 use soroban_sdk::{symbol_short, Address, Env, Symbol, Vec};
 
@@ -615,7 +616,7 @@ pub fn do_cancel_subscription(
 ) -> Result<(), Error> {
     authorizer.require_auth();
 
-    let mut sub = get_subscription(env, subscription_id)?;
+    let sub = get_subscription(env, subscription_id)?;
 
     if sub.is_expired(env.ledger().timestamp()) {
         return Err(Error::SubscriptionExpired);
@@ -630,6 +631,26 @@ pub fn do_cancel_subscription(
         return Err(Error::InvalidStatusTransition);
     }
 
+    apply_cancellation(env, subscription_id, sub, authorizer)
+}
+
+/// Mutation tail shared by single ([`do_cancel_subscription`]) and bulk
+/// ([`do_bulk_cancel_subscriptions`]) cancellation paths.
+///
+/// The caller is responsible for **all** authorization and for verifying that
+/// `sub` is neither expired nor already `Cancelled`. This helper transitions to
+/// `Cancelled`, refunds any remaining prepaid balance to the subscriber using
+/// the Checks-Effects-Interactions order, removes the id from the merchant,
+/// token, and subscriber indexes, and emits [`SubscriptionCancelledEvent`].
+///
+/// `authorizer` is recorded verbatim in the emitted event (the admin/operator on
+/// the bulk path, or the subscriber/merchant on the single path).
+fn apply_cancellation(
+    env: &Env,
+    subscription_id: u32,
+    mut sub: Subscription,
+    authorizer: Address,
+) -> Result<(), Error> {
     transition_to(&mut sub.status, SubscriptionStatus::Cancelled)?;
     let refund_amount = sub.prepaid_balance;
 
@@ -810,7 +831,7 @@ pub fn do_pause_subscription(
 ) -> Result<(), Error> {
     authorizer.require_auth();
 
-    let mut sub = get_subscription(env, subscription_id)?;
+    let sub = get_subscription(env, subscription_id)?;
 
     if sub.is_expired(env.ledger().timestamp()) {
         return Err(Error::SubscriptionExpired);
@@ -825,13 +846,29 @@ pub fn do_pause_subscription(
         return Ok(());
     }
 
+    apply_pause(env, subscription_id, sub, authorizer)
+}
+
+/// Mutation tail shared by single ([`do_pause_subscription`]) and bulk
+/// ([`do_bulk_pause_subscriptions`]) pause paths.
+///
+/// The caller is responsible for **all** authorization and for verifying that
+/// `sub` is neither expired nor already `Paused`. This helper performs the
+/// `Active -> Paused` transition, persists it, and emits [`SubscriptionPausedEvent`].
+/// `authorizer` is recorded verbatim in the emitted event.
+fn apply_pause(
+    env: &Env,
+    subscription_id: u32,
+    mut sub: Subscription,
+    authorizer: Address,
+) -> Result<(), Error> {
     transition_to(&mut sub.status, SubscriptionStatus::Paused)?;
 
     write_subscription(env, subscription_id, &sub);
 
     env.events().publish(
         (Symbol::new(env, "sub_paused"), subscription_id),
-        crate::types::SubscriptionPausedEvent {
+        SubscriptionPausedEvent {
             subscription_id,
             subscriber: sub.subscriber.clone(),
             merchant: sub.merchant.clone(),
@@ -905,6 +942,250 @@ pub fn do_resume_subscription(
     );
 
     Ok(())
+}
+
+// ── Bulk admin/operator pause & cancel ──────────────────────────────────────
+//
+// Operational-hygiene tooling for offboarding or containing a compromised
+// merchant. Both endpoints are authorized by the stored admin *or* operator,
+// guarded by a per-batch nonce, and are *partial-failure tolerant*: a bad id
+// (missing, expired, already in the target state, non-transitionable) is
+// recorded in the returned per-id outcome vector and the batch continues.
+//
+// Reuse note: each id is driven through the same `apply_pause` /
+// `apply_cancellation` helpers as the single-subscription endpoints, so refund,
+// index-removal, state-machine, and event semantics are identical — only the
+// authorization surface differs (admin/operator instead of subscriber/merchant).
+
+/// Build the per-id outcome for a hard failure (no state change).
+fn bulk_failed(subscription_id: u32, err: Error) -> BulkSubscriptionResult {
+    BulkSubscriptionResult {
+        subscription_id,
+        success: false,
+        changed: false,
+        error_code: err.to_code(),
+    }
+}
+
+/// Build the per-id outcome for an id that already sat in the target state
+/// (idempotent no-op — counted as a success but with `changed = false`).
+fn bulk_skipped(subscription_id: u32) -> BulkSubscriptionResult {
+    BulkSubscriptionResult {
+        subscription_id,
+        success: true,
+        changed: false,
+        error_code: 0,
+    }
+}
+
+/// Build the per-id outcome for an id that was transitioned by this call.
+fn bulk_changed(subscription_id: u32) -> BulkSubscriptionResult {
+    BulkSubscriptionResult {
+        subscription_id,
+        success: true,
+        changed: true,
+        error_code: 0,
+    }
+}
+
+/// Pause a single id on behalf of an already-authorized admin/operator batch.
+///
+/// Never aborts: returns a [`BulkSubscriptionResult`] describing the outcome.
+/// Already-`Paused` ids are skipped as no-ops; missing/expired/non-transitionable
+/// ids are reported as failures.
+fn bulk_pause_one(env: &Env, subscription_id: u32, caller: &Address) -> BulkSubscriptionResult {
+    let sub = match get_subscription(env, subscription_id) {
+        Ok(s) => s,
+        Err(e) => return bulk_failed(subscription_id, e),
+    };
+
+    if sub.is_expired(env.ledger().timestamp()) {
+        return bulk_failed(subscription_id, Error::SubscriptionExpired);
+    }
+
+    // Idempotent: already paused — skip without aborting the batch.
+    if sub.status == SubscriptionStatus::Paused {
+        return bulk_skipped(subscription_id);
+    }
+
+    match apply_pause(env, subscription_id, sub, caller.clone()) {
+        Ok(()) => bulk_changed(subscription_id),
+        Err(e) => bulk_failed(subscription_id, e),
+    }
+}
+
+/// Cancel a single id on behalf of an already-authorized admin/operator batch.
+///
+/// Never aborts: returns a [`BulkSubscriptionResult`] describing the outcome.
+/// Already-`Cancelled` ids are skipped as no-ops; missing/expired/non-transitionable
+/// ids are reported as failures.
+fn bulk_cancel_one(env: &Env, subscription_id: u32, caller: &Address) -> BulkSubscriptionResult {
+    let sub = match get_subscription(env, subscription_id) {
+        Ok(s) => s,
+        Err(e) => return bulk_failed(subscription_id, e),
+    };
+
+    if sub.is_expired(env.ledger().timestamp()) {
+        return bulk_failed(subscription_id, Error::SubscriptionExpired);
+    }
+
+    // Idempotent: already cancelled — skip without aborting the batch.
+    if sub.status == SubscriptionStatus::Cancelled {
+        return bulk_skipped(subscription_id);
+    }
+
+    match apply_cancellation(env, subscription_id, sub, caller.clone()) {
+        Ok(()) => bulk_changed(subscription_id),
+        Err(e) => bulk_failed(subscription_id, e),
+    }
+}
+
+/// Validate the shared preconditions for a bulk batch and consume its nonce.
+///
+/// Order is security-critical:
+/// 1. Authorize `caller` as admin or operator (auth runs before any state touch).
+/// 2. Reject oversized batches *before* the nonce is consumed, so a rejected
+///    batch never burns a nonce.
+/// 3. Treat an empty list as an explicit no-op: it consumes no nonce and emits
+///    no envelope event (`Ok(false)` — "do not proceed").
+/// 4. Otherwise consume the per-batch nonce and return `Ok(true)` — "proceed".
+///
+/// The nonce shares the `DOMAIN_OPERATOR_BATCH_CHARGE` counter, keyed per caller
+/// address, so admin and operator each maintain an independent monotonic sequence.
+fn bulk_precheck(
+    env: &Env,
+    caller: &Address,
+    ids: &Vec<u32>,
+    nonce: u64,
+) -> Result<bool, Error> {
+    crate::admin::require_admin_or_operator_auth(env, caller)?;
+
+    if ids.len() > BATCH_MAX_SIZE {
+        return Err(Error::BatchTooLarge);
+    }
+
+    // Empty list: explicit no-op. No nonce burned, no envelope event.
+    if ids.is_empty() {
+        return Ok(false);
+    }
+
+    crate::nonce::check_and_advance(
+        env,
+        caller,
+        crate::nonce::DOMAIN_OPERATOR_BATCH_CHARGE,
+        nonce,
+    )?;
+
+    Ok(true)
+}
+
+/// Bulk-pause a list of subscriptions. Admin or operator only.
+///
+/// See [`bulk_precheck`] for the auth/size/nonce contract. Each id is processed
+/// independently; the returned vector has exactly one [`BulkSubscriptionResult`]
+/// per requested id, in request order. Duplicate ids are handled naturally: the
+/// first occurrence transitions the subscription, later occurrences observe it
+/// already `Paused` and are skipped.
+///
+/// On a non-empty batch, emits a single [`BulkPauseEvent`] envelope summarising
+/// the counts. The per-id `SubscriptionPausedEvent`s are emitted by `apply_pause`.
+pub fn do_bulk_pause_subscriptions(
+    env: &Env,
+    caller: Address,
+    ids: &Vec<u32>,
+    nonce: u64,
+) -> Result<Vec<BulkSubscriptionResult>, Error> {
+    if !bulk_precheck(env, &caller, ids, nonce)? {
+        return Ok(Vec::new(env));
+    }
+
+    let mut results = Vec::new(env);
+    let mut paused = 0u32;
+    let mut skipped = 0u32;
+    let mut failed = 0u32;
+
+    for id in ids.iter() {
+        let r = bulk_pause_one(env, id, &caller);
+        if !r.success {
+            failed += 1;
+        } else if r.changed {
+            paused += 1;
+        } else {
+            skipped += 1;
+        }
+        results.push_back(r);
+    }
+
+    env.events().publish(
+        (Symbol::new(env, "bulk_paused"), caller.clone()),
+        BulkPauseEvent {
+            caller,
+            requested: ids.len(),
+            paused,
+            skipped,
+            failed,
+            nonce,
+            timestamp: env.ledger().timestamp(),
+            schema_version: crate::types::EVENT_SCHEMA_VERSION,
+        },
+    );
+
+    Ok(results)
+}
+
+/// Bulk-cancel a list of subscriptions. Admin or operator only.
+///
+/// See [`bulk_precheck`] for the auth/size/nonce contract. Each id is processed
+/// independently; the returned vector has exactly one [`BulkSubscriptionResult`]
+/// per requested id, in request order. Duplicate ids are handled naturally: the
+/// first occurrence cancels (and refunds) the subscription, later occurrences
+/// observe it already `Cancelled` and are skipped — so no double-refund can occur.
+///
+/// On a non-empty batch, emits a single [`BulkCancelEvent`] envelope summarising
+/// the counts. The per-id `SubscriptionCancelledEvent`s are emitted by
+/// `apply_cancellation`.
+pub fn do_bulk_cancel_subscriptions(
+    env: &Env,
+    caller: Address,
+    ids: &Vec<u32>,
+    nonce: u64,
+) -> Result<Vec<BulkSubscriptionResult>, Error> {
+    if !bulk_precheck(env, &caller, ids, nonce)? {
+        return Ok(Vec::new(env));
+    }
+
+    let mut results = Vec::new(env);
+    let mut cancelled = 0u32;
+    let mut skipped = 0u32;
+    let mut failed = 0u32;
+
+    for id in ids.iter() {
+        let r = bulk_cancel_one(env, id, &caller);
+        if !r.success {
+            failed += 1;
+        } else if r.changed {
+            cancelled += 1;
+        } else {
+            skipped += 1;
+        }
+        results.push_back(r);
+    }
+
+    env.events().publish(
+        (Symbol::new(env, "bulk_cancelled"), caller.clone()),
+        BulkCancelEvent {
+            caller,
+            requested: ids.len(),
+            cancelled,
+            skipped,
+            failed,
+            nonce,
+            timestamp: env.ledger().timestamp(),
+            schema_version: crate::types::EVENT_SCHEMA_VERSION,
+        },
+    );
+
+    Ok(results)
 }
 
 /// Merchant-initiated one-off charge: debits `amount` from the subscription's prepaid balance.

--- a/contracts/subscription_vault/src/test_bulk_admin_ops.rs
+++ b/contracts/subscription_vault/src/test_bulk_admin_ops.rs
@@ -1,0 +1,453 @@
+//! Tests for the bulk admin/operator pause & cancel tooling (issue #497).
+//!
+//! Coverage targets the operational-hygiene requirements:
+//! - admin **and** operator are both accepted authorizers; anyone else is rejected;
+//! - the batch is partial-failure tolerant (already-paused/cancelled/missing ids
+//!   are skipped or reported, never aborting the batch);
+//! - empty list is a no-op that consumes no nonce and emits no envelope event;
+//! - duplicate ids inside one batch are safe (no double pause / double refund);
+//! - batches larger than `BATCH_MAX_SIZE` are rejected wholesale;
+//! - the per-batch nonce advances and rejects wrong/replayed values.
+
+use crate::test_utils::setup::TestEnv;
+use crate::types::{BulkSubscriptionResult, Error, SubscriptionStatus, BATCH_MAX_SIZE};
+use crate::nonce::DOMAIN_OPERATOR_BATCH_CHARGE;
+use soroban_sdk::{testutils::Address as _, vec, Address, Vec};
+
+const AMOUNT: i128 = 1_000;
+const INTERVAL: u64 = 24 * 60 * 60;
+const DEPOSIT: i128 = 5_000_000; // >= init min_topup (1_000_000)
+
+/// Create an `Active`, fully-funded subscription and return its id.
+fn funded_sub(te: &TestEnv, subscriber: &Address, merchant: &Address) -> u32 {
+    let sub_id = te.client.create_subscription(
+        subscriber,
+        merchant,
+        &AMOUNT,
+        &INTERVAL,
+        &false,
+        &None,
+        &None,
+    );
+    te.stellar_token_client().mint(subscriber, &DEPOSIT);
+    te.client.deposit_funds(&sub_id, subscriber, &DEPOSIT, &None);
+    sub_id
+}
+
+fn token_balance(te: &TestEnv, who: &Address) -> i128 {
+    soroban_sdk::token::Client::new(&te.env, &te.token).balance(who)
+}
+
+fn status(te: &TestEnv, sub_id: u32) -> SubscriptionStatus {
+    te.client.get_subscription(&sub_id).status
+}
+
+// ── Bulk pause: happy paths ─────────────────────────────────────────────────
+
+#[test]
+fn admin_bulk_pause_pauses_all_active_subscriptions() {
+    let te = TestEnv::default();
+    let subscriber = Address::generate(&te.env);
+    let merchant = Address::generate(&te.env);
+
+    let a = funded_sub(&te, &subscriber, &merchant);
+    let b = funded_sub(&te, &subscriber, &merchant);
+
+    let results = te
+        .client
+        .bulk_pause_subscriptions(&te.admin, &vec![&te.env, a, b], &0u64);
+
+    assert_eq!(results.len(), 2);
+    assert!(results.get(0).unwrap().success && results.get(0).unwrap().changed);
+    assert!(results.get(1).unwrap().success && results.get(1).unwrap().changed);
+    assert_eq!(status(&te, a), SubscriptionStatus::Paused);
+    assert_eq!(status(&te, b), SubscriptionStatus::Paused);
+}
+
+#[test]
+fn operator_is_authorized_for_bulk_pause() {
+    let te = TestEnv::default();
+    let subscriber = Address::generate(&te.env);
+    let merchant = Address::generate(&te.env);
+    let operator = Address::generate(&te.env);
+    te.client.set_operator(&te.admin, &operator);
+
+    let a = funded_sub(&te, &subscriber, &merchant);
+
+    let results = te
+        .client
+        .bulk_pause_subscriptions(&operator, &vec![&te.env, a], &0u64);
+
+    assert!(results.get(0).unwrap().changed);
+    assert_eq!(status(&te, a), SubscriptionStatus::Paused);
+}
+
+#[test]
+fn unauthorized_caller_rejected_for_bulk_pause() {
+    let te = TestEnv::default();
+    let subscriber = Address::generate(&te.env);
+    let merchant = Address::generate(&te.env);
+    let stranger = Address::generate(&te.env);
+
+    let a = funded_sub(&te, &subscriber, &merchant);
+
+    let res = te
+        .client
+        .try_bulk_pause_subscriptions(&stranger, &vec![&te.env, a], &0u64);
+    assert_eq!(res, Err(Ok(Error::Unauthorized)));
+    // State untouched.
+    assert_eq!(status(&te, a), SubscriptionStatus::Active);
+}
+
+// ── Bulk pause: edge cases ──────────────────────────────────────────────────
+
+#[test]
+fn empty_bulk_pause_is_a_noop_and_consumes_no_nonce() {
+    let te = TestEnv::default();
+
+    let empty: Vec<u32> = Vec::new(&te.env);
+    let results = te.client.bulk_pause_subscriptions(&te.admin, &empty, &0u64);
+    assert_eq!(results.len(), 0);
+
+    // Nonce was NOT consumed — a real batch can still use nonce 0.
+    assert_eq!(
+        te.client.get_admin_nonce(&te.admin, &DOMAIN_OPERATOR_BATCH_CHARGE),
+        0u64
+    );
+}
+
+#[test]
+fn bulk_pause_skips_already_paused_without_aborting() {
+    let te = TestEnv::default();
+    let subscriber = Address::generate(&te.env);
+    let merchant = Address::generate(&te.env);
+
+    let active = funded_sub(&te, &subscriber, &merchant);
+    let already = funded_sub(&te, &subscriber, &merchant);
+    // Pre-pause `already` via the merchant (single-id path).
+    te.client.pause_subscription(&already, &merchant);
+
+    let missing = 9_999u32; // never created
+
+    let results = te.client.bulk_pause_subscriptions(
+        &te.admin,
+        &vec![&te.env, active, already, missing],
+        &0u64,
+    );
+
+    // active -> changed
+    assert_eq!(results.get(0).unwrap(), BulkSubscriptionResult {
+        subscription_id: active, success: true, changed: true, error_code: 0,
+    });
+    // already paused -> skipped (success, not changed)
+    assert_eq!(results.get(1).unwrap(), BulkSubscriptionResult {
+        subscription_id: already, success: true, changed: false, error_code: 0,
+    });
+    // missing -> failed with NotFound
+    assert_eq!(results.get(2).unwrap(), BulkSubscriptionResult {
+        subscription_id: missing, success: false, changed: false,
+        error_code: Error::NotFound.to_code(),
+    });
+
+    assert_eq!(status(&te, active), SubscriptionStatus::Paused);
+}
+
+#[test]
+fn bulk_pause_with_duplicate_ids_pauses_once_then_skips() {
+    let te = TestEnv::default();
+    let subscriber = Address::generate(&te.env);
+    let merchant = Address::generate(&te.env);
+    let a = funded_sub(&te, &subscriber, &merchant);
+
+    let results = te
+        .client
+        .bulk_pause_subscriptions(&te.admin, &vec![&te.env, a, a, a], &0u64);
+
+    assert!(results.get(0).unwrap().changed);
+    assert!(!results.get(1).unwrap().changed && results.get(1).unwrap().success);
+    assert!(!results.get(2).unwrap().changed && results.get(2).unwrap().success);
+    assert_eq!(status(&te, a), SubscriptionStatus::Paused);
+}
+
+#[test]
+fn bulk_pause_reports_expired_as_failure() {
+    let te = TestEnv::default();
+    let subscriber = Address::generate(&te.env);
+    let merchant = Address::generate(&te.env);
+
+    let now = te.env.ledger().timestamp();
+    let sub_id = te.client.create_subscription(
+        &subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None, &Some(now + 1_000),
+    );
+    te.stellar_token_client().mint(&subscriber, &DEPOSIT);
+    te.client.deposit_funds(&sub_id, &subscriber, &DEPOSIT, &None);
+
+    te.jump(2_000); // past expires_at
+
+    let results = te
+        .client
+        .bulk_pause_subscriptions(&te.admin, &vec![&te.env, sub_id], &0u64);
+    assert_eq!(results.get(0).unwrap().error_code, Error::SubscriptionExpired.to_code());
+    assert!(!results.get(0).unwrap().success);
+}
+
+#[test]
+fn bulk_pause_rejects_oversized_batch() {
+    let te = TestEnv::default();
+
+    let mut ids: Vec<u32> = Vec::new(&te.env);
+    for i in 0..(BATCH_MAX_SIZE + 1) {
+        ids.push_back(i);
+    }
+
+    let res = te.client.try_bulk_pause_subscriptions(&te.admin, &ids, &0u64);
+    assert_eq!(res, Err(Ok(Error::BatchTooLarge)));
+    // Oversized batch must not burn the nonce.
+    assert_eq!(
+        te.client.get_admin_nonce(&te.admin, &DOMAIN_OPERATOR_BATCH_CHARGE),
+        0u64
+    );
+}
+
+#[test]
+fn bulk_pause_at_max_batch_size_is_accepted() {
+    let te = TestEnv::default();
+
+    let mut ids: Vec<u32> = Vec::new(&te.env);
+    for i in 0..BATCH_MAX_SIZE {
+        ids.push_back(i); // ids don't need to exist; they report NotFound
+    }
+
+    // Exactly BATCH_MAX_SIZE is allowed (does not return BatchTooLarge).
+    let results = te.client.bulk_pause_subscriptions(&te.admin, &ids, &0u64);
+    assert_eq!(results.len(), BATCH_MAX_SIZE);
+}
+
+// ── Bulk pause: nonce semantics ─────────────────────────────────────────────
+
+#[test]
+fn bulk_pause_advances_nonce() {
+    let te = TestEnv::default();
+    let subscriber = Address::generate(&te.env);
+    let merchant = Address::generate(&te.env);
+    let a = funded_sub(&te, &subscriber, &merchant);
+
+    te.client.bulk_pause_subscriptions(&te.admin, &vec![&te.env, a], &0u64);
+    assert_eq!(
+        te.client.get_admin_nonce(&te.admin, &DOMAIN_OPERATOR_BATCH_CHARGE),
+        1u64
+    );
+}
+
+#[test]
+fn bulk_pause_wrong_nonce_rejected() {
+    let te = TestEnv::default();
+    let subscriber = Address::generate(&te.env);
+    let merchant = Address::generate(&te.env);
+    let a = funded_sub(&te, &subscriber, &merchant);
+
+    let res = te
+        .client
+        .try_bulk_pause_subscriptions(&te.admin, &vec![&te.env, a], &1u64);
+    assert_eq!(res, Err(Ok(Error::NonceAlreadyUsed)));
+}
+
+#[test]
+fn bulk_pause_replay_rejected() {
+    let te = TestEnv::default();
+    let subscriber = Address::generate(&te.env);
+    let merchant = Address::generate(&te.env);
+    let a = funded_sub(&te, &subscriber, &merchant);
+    let b = funded_sub(&te, &subscriber, &merchant);
+
+    te.client.bulk_pause_subscriptions(&te.admin, &vec![&te.env, a], &0u64);
+    // Replaying nonce 0 must fail.
+    let res = te
+        .client
+        .try_bulk_pause_subscriptions(&te.admin, &vec![&te.env, b], &0u64);
+    assert_eq!(res, Err(Ok(Error::NonceAlreadyUsed)));
+}
+
+#[test]
+fn admin_and_operator_have_independent_nonce_sequences() {
+    let te = TestEnv::default();
+    let subscriber = Address::generate(&te.env);
+    let merchant = Address::generate(&te.env);
+    let operator = Address::generate(&te.env);
+    te.client.set_operator(&te.admin, &operator);
+
+    let a = funded_sub(&te, &subscriber, &merchant);
+    let b = funded_sub(&te, &subscriber, &merchant);
+
+    // Both start at nonce 0 independently (keyed per signer address).
+    te.client.bulk_pause_subscriptions(&te.admin, &vec![&te.env, a], &0u64);
+    te.client.bulk_pause_subscriptions(&operator, &vec![&te.env, b], &0u64);
+
+    assert_eq!(te.client.get_admin_nonce(&te.admin, &DOMAIN_OPERATOR_BATCH_CHARGE), 1u64);
+    assert_eq!(te.client.get_operator_nonce(&operator), 1u64);
+}
+
+// ── Bulk cancel: happy paths & refunds ──────────────────────────────────────
+
+#[test]
+fn admin_bulk_cancel_cancels_and_refunds() {
+    let te = TestEnv::default();
+    let subscriber = Address::generate(&te.env);
+    let merchant = Address::generate(&te.env);
+
+    let a = funded_sub(&te, &subscriber, &merchant);
+    let b = funded_sub(&te, &subscriber, &merchant);
+    // Both deposits are in the contract; subscriber holds nothing right now.
+    assert_eq!(token_balance(&te, &subscriber), 0);
+
+    let results = te
+        .client
+        .bulk_cancel_subscriptions(&te.admin, &vec![&te.env, a, b], &0u64);
+
+    assert!(results.get(0).unwrap().changed && results.get(1).unwrap().changed);
+    assert_eq!(status(&te, a), SubscriptionStatus::Cancelled);
+    assert_eq!(status(&te, b), SubscriptionStatus::Cancelled);
+    // Full prepaid balance of both subscriptions refunded.
+    assert_eq!(token_balance(&te, &subscriber), DEPOSIT * 2);
+}
+
+#[test]
+fn operator_is_authorized_for_bulk_cancel() {
+    let te = TestEnv::default();
+    let subscriber = Address::generate(&te.env);
+    let merchant = Address::generate(&te.env);
+    let operator = Address::generate(&te.env);
+    te.client.set_operator(&te.admin, &operator);
+
+    let a = funded_sub(&te, &subscriber, &merchant);
+    te.client.bulk_cancel_subscriptions(&operator, &vec![&te.env, a], &0u64);
+    assert_eq!(status(&te, a), SubscriptionStatus::Cancelled);
+}
+
+#[test]
+fn unauthorized_caller_rejected_for_bulk_cancel() {
+    let te = TestEnv::default();
+    let subscriber = Address::generate(&te.env);
+    let merchant = Address::generate(&te.env);
+    let stranger = Address::generate(&te.env);
+    let a = funded_sub(&te, &subscriber, &merchant);
+
+    let res = te
+        .client
+        .try_bulk_cancel_subscriptions(&stranger, &vec![&te.env, a], &0u64);
+    assert_eq!(res, Err(Ok(Error::Unauthorized)));
+    assert_eq!(status(&te, a), SubscriptionStatus::Active);
+}
+
+// ── Bulk cancel: edge cases ─────────────────────────────────────────────────
+
+#[test]
+fn bulk_cancel_skips_already_cancelled_no_double_refund() {
+    let te = TestEnv::default();
+    let subscriber = Address::generate(&te.env);
+    let merchant = Address::generate(&te.env);
+
+    // `funded_sub` is net-zero on the subscriber's wallet (mint DEPOSIT, then
+    // deposit DEPOSIT into the contract).
+    let already = funded_sub(&te, &subscriber, &merchant);
+    // Cancel once via the merchant single-id path — refunds DEPOSIT already.
+    te.client.cancel_subscription(&already, &merchant);
+    assert_eq!(token_balance(&te, &subscriber), DEPOSIT);
+
+    // Creating a second funded sub is net-zero, so the refund above is untouched.
+    let active = funded_sub(&te, &subscriber, &merchant);
+    assert_eq!(token_balance(&te, &subscriber), DEPOSIT);
+
+    let results = te.client.bulk_cancel_subscriptions(
+        &te.admin,
+        &vec![&te.env, already, active],
+        &0u64,
+    );
+
+    // already-cancelled -> skipped, no second refund
+    assert_eq!(results.get(0).unwrap(), BulkSubscriptionResult {
+        subscription_id: already, success: true, changed: false, error_code: 0,
+    });
+    assert!(results.get(1).unwrap().changed);
+    // Only `active`'s DEPOSIT is refunded here, on top of the earlier refund.
+    assert_eq!(token_balance(&te, &subscriber), DEPOSIT * 2);
+}
+
+#[test]
+fn bulk_cancel_duplicate_ids_refunds_once() {
+    let te = TestEnv::default();
+    let subscriber = Address::generate(&te.env);
+    let merchant = Address::generate(&te.env);
+    let a = funded_sub(&te, &subscriber, &merchant);
+    assert_eq!(token_balance(&te, &subscriber), 0);
+
+    let results = te
+        .client
+        .bulk_cancel_subscriptions(&te.admin, &vec![&te.env, a, a], &0u64);
+
+    assert!(results.get(0).unwrap().changed);
+    assert!(!results.get(1).unwrap().changed && results.get(1).unwrap().success);
+    // Refund happened exactly once.
+    assert_eq!(token_balance(&te, &subscriber), DEPOSIT);
+}
+
+#[test]
+fn bulk_cancel_mixed_valid_cancelled_missing() {
+    let te = TestEnv::default();
+    let subscriber = Address::generate(&te.env);
+    let merchant = Address::generate(&te.env);
+
+    let valid = funded_sub(&te, &subscriber, &merchant);
+    let cancelled = funded_sub(&te, &subscriber, &merchant);
+    te.client.cancel_subscription(&cancelled, &merchant);
+    let missing = 4_242u32;
+
+    let results = te.client.bulk_cancel_subscriptions(
+        &te.admin,
+        &vec![&te.env, valid, cancelled, missing],
+        &0u64,
+    );
+
+    assert!(results.get(0).unwrap().changed);
+    assert!(!results.get(1).unwrap().changed && results.get(1).unwrap().success);
+    assert_eq!(results.get(2).unwrap().error_code, Error::NotFound.to_code());
+    assert!(!results.get(2).unwrap().success);
+}
+
+#[test]
+fn empty_bulk_cancel_is_a_noop_and_consumes_no_nonce() {
+    let te = TestEnv::default();
+    let empty: Vec<u32> = Vec::new(&te.env);
+    let results = te.client.bulk_cancel_subscriptions(&te.admin, &empty, &0u64);
+    assert_eq!(results.len(), 0);
+    assert_eq!(
+        te.client.get_admin_nonce(&te.admin, &DOMAIN_OPERATOR_BATCH_CHARGE),
+        0u64
+    );
+}
+
+#[test]
+fn bulk_cancel_rejects_oversized_batch() {
+    let te = TestEnv::default();
+    let mut ids: Vec<u32> = Vec::new(&te.env);
+    for i in 0..(BATCH_MAX_SIZE + 1) {
+        ids.push_back(i);
+    }
+    let res = te.client.try_bulk_cancel_subscriptions(&te.admin, &ids, &0u64);
+    assert_eq!(res, Err(Ok(Error::BatchTooLarge)));
+}
+
+#[test]
+fn bulk_cancel_replay_rejected() {
+    let te = TestEnv::default();
+    let subscriber = Address::generate(&te.env);
+    let merchant = Address::generate(&te.env);
+    let a = funded_sub(&te, &subscriber, &merchant);
+    let b = funded_sub(&te, &subscriber, &merchant);
+
+    te.client.bulk_cancel_subscriptions(&te.admin, &vec![&te.env, a], &0u64);
+    let res = te
+        .client
+        .try_bulk_cancel_subscriptions(&te.admin, &vec![&te.env, b], &0u64);
+    assert_eq!(res, Err(Ok(Error::NonceAlreadyUsed)));
+}

--- a/contracts/subscription_vault/src/types.rs
+++ b/contracts/subscription_vault/src/types.rs
@@ -585,6 +585,8 @@ pub enum Error {
     UsageCapExceeded = 6009,
     /// Usage charge attempted too soon after previous charge (burst protection).
     BurstLimitExceeded = 6010,
+    /// A bulk admin/operator batch exceeded [`BATCH_MAX_SIZE`] entries.
+    BatchTooLarge = 6011,
 
     // --- Merchant Config (7000-7099) ---
     /// Fee basis points exceed maximum allowed value.
@@ -651,6 +653,82 @@ pub struct BatchChargeResult {
 pub struct BatchWithdrawResult {
     pub success: bool,
     pub error_code: u32,
+}
+
+/// Maximum number of ids accepted by a single bulk admin/operator call
+/// ([`bulk_pause_subscriptions`](crate::SubscriptionVault::bulk_pause_subscriptions),
+/// [`bulk_cancel_subscriptions`](crate::SubscriptionVault::bulk_cancel_subscriptions)).
+///
+/// Batches larger than this are rejected wholesale with [`Error::BatchTooLarge`]
+/// before any state is touched, bounding per-transaction CPU/storage so a single
+/// oversized batch cannot exceed Soroban resource limits mid-loop.
+pub const BATCH_MAX_SIZE: u32 = 100;
+
+/// Per-id outcome of a bulk pause/cancel operation.
+///
+/// One entry is returned for every id in the request, in request order, so an
+/// operator can reconcile exactly what happened to each subscription without the
+/// batch aborting on the first problem.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BulkSubscriptionResult {
+    /// The subscription id this outcome refers to.
+    pub subscription_id: u32,
+    /// `true` when the id ended in the desired state (either it was transitioned
+    /// now, or it was already there — see `changed`). `false` on a hard error.
+    pub success: bool,
+    /// `true` when this call actually transitioned the subscription; `false` when
+    /// it was skipped as a no-op because it was already paused/cancelled.
+    pub changed: bool,
+    /// `0` on success; otherwise the [`Error`] code explaining why this id failed
+    /// (e.g. `NotFound`, `SubscriptionExpired`, `InvalidStatusTransition`).
+    pub error_code: u32,
+}
+
+/// Single envelope event emitted once per successful `bulk_pause_subscriptions`
+/// batch, summarising the per-id outcomes for off-chain indexers.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct BulkPauseEvent {
+    /// Admin or operator address that authorized the batch.
+    pub caller: Address,
+    /// Number of ids submitted in the request.
+    pub requested: u32,
+    /// Number of subscriptions actually transitioned Active -> Paused.
+    pub paused: u32,
+    /// Number of ids skipped as already-paused no-ops.
+    pub skipped: u32,
+    /// Number of ids that failed (not found, expired, invalid transition, ...).
+    pub failed: u32,
+    /// The per-batch nonce consumed for replay protection.
+    pub nonce: u64,
+    /// Ledger timestamp when the batch was processed.
+    pub timestamp: u64,
+    /// Event schema version for backwards-compatible indexer decoding.
+    pub schema_version: u32,
+}
+
+/// Single envelope event emitted once per successful `bulk_cancel_subscriptions`
+/// batch, summarising the per-id outcomes for off-chain indexers.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct BulkCancelEvent {
+    /// Admin or operator address that authorized the batch.
+    pub caller: Address,
+    /// Number of ids submitted in the request.
+    pub requested: u32,
+    /// Number of subscriptions actually transitioned to Cancelled.
+    pub cancelled: u32,
+    /// Number of ids skipped as already-cancelled no-ops.
+    pub skipped: u32,
+    /// Number of ids that failed (not found, expired, invalid transition, ...).
+    pub failed: u32,
+    /// The per-batch nonce consumed for replay protection.
+    pub nonce: u64,
+    /// Ledger timestamp when the batch was processed.
+    pub timestamp: u64,
+    /// Event schema version for backwards-compatible indexer decoding.
+    pub schema_version: u32,
 }
 
 /// A read-only snapshot of the contract's configuration and current state.

--- a/docs/admin_authorization_matrix.md
+++ b/docs/admin_authorization_matrix.md
@@ -57,6 +57,32 @@ the host layer when no signature is present.
 | `operator_charge_usage` | Explicit `operator` arg must equal stored operator | `Unauthorized` | `Unauthorized` | Emergency-stop gated; reentrancy guard |
 | `operator_charge_usage_with_reference` | Explicit `operator` arg must equal stored operator | `Unauthorized` | `Unauthorized` | Emergency-stop gated; reentrancy guard |
 
+## Dual-role (admin **or** operator) entrypoints
+
+These operational-hygiene endpoints accept **either** the stored admin or the
+stored operator as `caller`, authorized by `require_admin_or_operator_auth`
+(`caller.require_auth()` runs first, then the address must equal the stored admin
+or operator; anything else is `Unauthorized`). They exist so an operator can pause
+or cancel many subscriptions when a merchant is offboarded or compromised, without
+needing the full admin key.
+
+| Entrypoint | Authorization model | Unauthorized caller | Nonce | Notes |
+| --- | --- | --- | --- | --- |
+| `bulk_pause_subscriptions` | `caller` must equal stored admin **or** operator | `Unauthorized` | Domain 2 (`DOMAIN_OPERATOR_BATCH_CHARGE`), keyed per caller | Partial-failure tolerant; skips already-paused/missing/expired ids; **not** emergency-stop gated (mirrors `pause_subscription`); rejects > `BATCH_MAX_SIZE` ids with `BatchTooLarge`; empty list is a no-op (no nonce, no event) |
+| `bulk_cancel_subscriptions` | `caller` must equal stored admin **or** operator | `Unauthorized` | Domain 2 (`DOMAIN_OPERATOR_BATCH_CHARGE`), keyed per caller | As above, plus refunds each cancelled subscription's prepaid balance; wrapped in a reentrancy guard because the loop performs token transfers; duplicate/already-cancelled ids are skipped so no double refund |
+
+Each call returns a `Vec<BulkSubscriptionResult>` — one entry per requested id, in
+request order — and emits one `BulkPauseEvent`/`BulkCancelEvent` envelope plus the
+usual per-id `SubscriptionPausedEvent`/`SubscriptionCancelledEvent` for ids that
+actually transitioned.
+
+> **Nonce sharing.** The per-batch nonce reuses the `DOMAIN_OPERATOR_BATCH_CHARGE`
+> (domain `2`) counter, which is keyed by `(signer, domain)`. Admin and operator
+> therefore each maintain an independent monotonic sequence, but for a *single*
+> signer this counter is shared across `operator_batch_charge`,
+> `bulk_pause_subscriptions`, and `bulk_cancel_subscriptions`. Read the next
+> expected value with `get_operator_nonce(op)` or `get_admin_nonce(signer, 2)`.
+
 ### Read-only operator helpers (no auth)
 
 | Entrypoint | Returns |


### PR DESCRIPTION
# feat: add bulk pause/cancel admin tools (#497)

## Summary

Adds operator-friendly batch tooling so an admin **or** operator can pause or
cancel many subscriptions in a single transaction when a merchant is offboarded
or compromised — instead of calling `pause_subscription` / `cancel_subscription`
one id at a time.

Two new entrypoints on `SubscriptionVault`:

- `bulk_pause_subscriptions(caller, subscription_ids, nonce) -> Vec<BulkSubscriptionResult>`
- `bulk_cancel_subscriptions(caller, subscription_ids, nonce) -> Vec<BulkSubscriptionResult>`

Both are **partial-failure tolerant**: a missing, expired, or already-in-target-state
id is recorded in the returned per-id outcome and the batch keeps going.

## ⚠️ Baseline note (please read first)

`main` **does not compile** independently of this PR. A prior bad three-way merge
reverted large parts of `contracts/subscription_vault/src/types.rs` relative to
the rest of the crate, dropping `EVENT_SCHEMA_VERSION`, `PayoutSchedule`,
`normalize_amount`, several event `schema_version` fields, `Subscription.cancel_at`,
the `DataKey` enum header, the `validation`/`period_snapshots` module links, and
more (~140 compiler errors; cf. the earlier `#535` "fix duplicate defs blocking
build"). No single ancestor commit contains a clean `types.rs` (the loss lives
inside merge commits), so it needs a dedicated baseline-restoration PR.

**This PR contains the #497 feature only.** It is written against the intended
APIs and is internally consistent, but `cargo test --all` cannot be run until the
baseline is restored. Once `main` compiles again, this branch builds on top with
no feature changes required.

## Behaviour & semantics

| Concern | Behaviour |
|---|---|
| **Authorization** | `caller` must equal the stored admin **or** operator (`require_admin_or_operator_auth`: `require_auth()` first, then identity check; else `Unauthorized`). No other operator privilege is widened. |
| **Replay protection** | Per-batch nonce on `DOMAIN_OPERATOR_BATCH_CHARGE` (domain `2`), keyed per caller — admin and operator keep independent monotonic sequences. |
| **Empty list** | No-op: consumes **no** nonce and emits **no** envelope event. |
| **Already paused/cancelled** | Skipped as an idempotent no-op (`success: true, changed: false`) — never aborts the batch. |
| **Missing / expired / non-transitionable id** | Reported as `success: false` with the `Error` code; batch continues. |
| **Duplicate ids** | Safe: first occurrence transitions, later occurrences observe the target state and are skipped — so **no double-pause / no double-refund**. |
| **Oversized batch** | `> BATCH_MAX_SIZE` (100) is rejected wholesale with `BatchTooLarge` **before** the nonce is consumed or any state is touched. |
| **Refunds (cancel)** | Each cancelled id refunds its prepaid balance to the subscriber via the existing CEI cancel path. |
| **Emergency stop** | **Not** gated — pausing/cancelling must remain available during a circuit-breaker event, mirroring the single-id endpoints. |
| **Events** | One `SubscriptionPausedEvent` / `SubscriptionCancelledEvent` per transitioned id, plus a single `BulkPauseEvent` / `BulkCancelEvent` envelope summarising `requested / changed / skipped / failed`. |

## Implementation notes (easy to review)

- **Reuses internal helpers.** `do_pause_subscription` and `do_cancel_subscription`
  were refactored to extract their mutation tails into `apply_pause` /
  `apply_cancellation`. The single-id endpoints and the bulk loop now share the
  exact same state-machine, refund, index-removal, and event logic — only the
  authorization surface differs. Single-id behaviour is unchanged (check order
  preserved).
- **`bulk_cancel_subscriptions`** is wrapped in a `ReentrancyGuard` because its
  loop performs external token transfers.
- New types in `types.rs`: `BATCH_MAX_SIZE` const, `Error::BatchTooLarge = 6011`,
  `BulkSubscriptionResult`, `BulkPauseEvent`, `BulkCancelEvent`.

## Security review

- **Auth before state.** `caller.require_auth()` runs before any identity check or
  storage access; an unauthenticated or wrong-identity caller is rejected with
  `Unauthorized` and zero side effects.
- **No nonce burn on rejection.** Oversized-batch and empty-batch paths return
  before `check_and_advance`, so a rejected/no-op call cannot consume a nonce.
- **Replay-safe.** Wrong or replayed nonce → `NonceAlreadyUsed`; the existing
  `nonce::check_and_advance` is the single source of truth.
- **No double refund.** Refunds flow only through `apply_cancellation`, which
  transitions to `Cancelled` first; a repeated or already-cancelled id is skipped
  before any transfer.
- **No privilege creep.** The operator gains only these two pause/cancel surfaces;
  withdrawal, rotation, and governance remain admin-only.
- **Bounded resources.** `BATCH_MAX_SIZE` caps per-transaction CPU/storage so one
  oversized batch can't blow Soroban limits mid-loop.

## Tests

New `contracts/subscription_vault/src/test_bulk_admin_ops.rs` (registered as a
`#[cfg(test)] mod`), covering every required edge case:

- admin and operator both authorized; stranger → `Unauthorized` (state untouched)
- empty list no-op (no nonce consumed)
- mixed valid / already-paused / already-cancelled / missing ids
- duplicate ids (pause once / refund once)
- expired id reported as failure, batch continues
- batch > `BATCH_MAX_SIZE` rejected with `BatchTooLarge` (nonce not burned);
  batch == `BATCH_MAX_SIZE` accepted
- nonce advance, wrong-nonce rejection, replay rejection
- admin vs operator independent nonce sequences
- cancel refunds full prepaid balance to subscriber; no double refund

> **Test execution is blocked by the broken baseline above.** The suite is
> complete and reviewable; running `cargo test --all` requires the separate
> baseline-restoration fix first.

## Docs

`docs/admin_authorization_matrix.md` gains a "Dual-role (admin or operator)"
section documenting both endpoints, the auth model, nonce-sharing semantics, and
the `BATCH_MAX_SIZE` / `BatchTooLarge` contract.

## Files changed

- `contracts/subscription_vault/src/lib.rs` — two public entrypoints + re-exports
- `contracts/subscription_vault/src/subscription.rs` — `apply_pause`/`apply_cancellation` refactor + bulk loop, precheck, per-id helpers
- `contracts/subscription_vault/src/admin.rs` — `require_admin_or_operator_auth`
- `contracts/subscription_vault/src/types.rs` — `BATCH_MAX_SIZE`, `BatchTooLarge`, result + envelope event types
- `contracts/subscription_vault/src/test_bulk_admin_ops.rs` — test suite (new)
- `docs/admin_authorization_matrix.md` — authorization matrix update

close #497 