### PR TITLE
Audit multi-block TWAP oracle manipulation resistance

### DIFF
--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -29,6 +29,7 @@ mod governance;
 mod idempotency;
 mod merchant;
 mod metadata;
+pub mod oracle_adapter;
 pub mod queries;
 mod safe_math;
 mod subscription;
@@ -38,9 +39,9 @@ mod validation;
 pub use safe_math::*;
 pub use types::{
     EVENT_SCHEMA_VERSION, AdminRotatedEvent, Dispute, DisputeOpenedEvent, DisputeRespondedEvent,
-    DisputeResolvedEvent, DisputeStatus, Error, OracleLivenessEvent, ProtocolFeeConfiguredEvent,
-    Proposal, ProposalCancelledEvent, ProposalExecutedEvent, ProposalKind,
-    ProposalSubmittedEvent, ProposalVotedEvent,
+    DisputeResolvedEvent, DisputeStatus, Error, OracleKind, OracleLivenessEvent,
+    ProtocolFeeConfiguredEvent, Proposal, ProposalCancelledEvent, ProposalExecutedEvent,
+    ProposalKind, ProposalSubmittedEvent, ProposalVotedEvent,
 };
 
 // ── Stub modules for features not yet extracted to separate files ─────────────
@@ -154,7 +155,7 @@ pub mod accounting {
 /// Oracle: optional on-chain price oracle for dynamic charge amounts.
 pub mod oracle {
     #![allow(unused_variables, dead_code)]
-    use crate::types::{Error, OracleConfig, OracleLivenessEvent, Subscription};
+    use crate::types::{Error, OracleConfig, OracleKind, OracleLivenessEvent, Subscription};
     use soroban_sdk::{Address, Env, Symbol};
 
     /// Resolve the charge amount for a subscription, applying oracle pricing when enabled.

--- a/contracts/subscription_vault/src/oracle_adapter.rs
+++ b/contracts/subscription_vault/src/oracle_adapter.rs
@@ -19,6 +19,13 @@ use soroban_sdk::{Address, Env, Vec};
 /// Oracle prices are represented with 7 decimal places (e.g. Stellar asset precision).
 pub const PRICE_SCALE: u128 = 10_000_000; // 10^7
 
+/// Conservative minimum TWAP window for manipulation-resistant pricing.
+///
+/// A one-block flash-loan attacker can only be neutralized if the window is long
+/// enough to include multiple observations. A 60-second window is the minimum we
+/// enforce here; for mainnet deployments we recommend a 5-minute default.
+pub const MIN_TWAP_WINDOW_SECS: u64 = 60;
+
 // ── OracleAdapter trait ───────────────────────────────────────────────────────
 
 /// Generic pricing source abstraction.
@@ -99,6 +106,8 @@ impl OracleAdapter for TwapAdapter {
         _base: &Address,
         _quote: &Address,
     ) -> Result<u128, Error> {
+        validate_twap_config(config)?;
+
         let oracle_addr = config.oracle.clone().ok_or(Error::OracleNotConfigured)?;
         let now = env.ledger().timestamp();
         let window_start = now.saturating_sub(config.window_secs);
@@ -135,6 +144,13 @@ impl OracleAdapter for TwapAdapter {
 
         Ok(median(&mut prices))
     }
+}
+
+fn validate_twap_config(config: &OracleConfig) -> Result<(), Error> {
+    if config.window_secs < MIN_TWAP_WINDOW_SECS {
+        return Err(Error::InvalidInput);
+    }
+    Ok(())
 }
 
 /// Compute the median of a non-empty slice (sorts in-place, allocator-free).

--- a/contracts/subscription_vault/src/test.rs
+++ b/contracts/subscription_vault/src/test.rs
@@ -230,10 +230,18 @@ struct MockOracle;
 #[contractimpl]
 impl MockOracle {
     pub fn set_price(env: Env, price: i128, timestamp: u64) {
-        env.storage().instance().set(
-            &Symbol::new(&env, "price"),
-            &OraclePrice { price, timestamp },
-        );
+        let key = Symbol::new(&env, "price");
+        let mut observations: Vec<OraclePrice> = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "observations"))
+            .unwrap_or(Vec::new(&env));
+        observations.push_back(OraclePrice { price, timestamp });
+
+        env.storage().instance().set(&key, &OraclePrice { price, timestamp });
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "observations"), &observations);
     }
 
     pub fn latest_price(env: Env) -> OraclePrice {
@@ -244,6 +252,21 @@ impl MockOracle {
                 price: 0,
                 timestamp: 0,
             })
+    }
+
+    pub fn get_observations(env: Env, since: u64) -> Vec<OraclePrice> {
+        let observations: Vec<OraclePrice> = env
+            .storage()
+            .instance()
+            .get(&Symbol::new(&env, "observations"))
+            .unwrap_or(Vec::new(&env));
+        let mut filtered = Vec::new(&env);
+        for obs in observations.iter() {
+            if obs.timestamp >= since {
+                filtered.push_back(obs);
+            }
+        }
+        filtered
     }
 }
 
@@ -5111,7 +5134,83 @@ fn test_oracle_stale_quote_rejected() {
 }
 
 #[test]
+fn test_twap_adapter_resists_single_block_manipulation() {
+    use crate::oracle_adapter::{OracleAdapter, TwapAdapter};
+    use crate::types::{OracleConfig, OracleKind, OraclePrice};
 
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let oracle_id = env.register(MockOracle, ());
+    let oracle = MockOracleClient::new(&env, &oracle_id);
+
+    // Simulate a malicious single-block spike that would dominate a mean-based window.
+    oracle.set_price(&10_000_000i128, &1000);
+    oracle.set_price(&1_000_000i128, &1000);
+    oracle.set_price(&1_000_000i128, &1000);
+
+    let config = OracleConfig {
+        enabled: true,
+        oracle: Some(oracle_id.clone()),
+        max_age_seconds: 10_000,
+        kind: OracleKind::Twap,
+        window_secs: 60,
+        fixed_numerator: 0,
+        fixed_denominator: 1,
+    };
+
+    let result = TwapAdapter::quote(&env, &config, &Address::generate(&env), &Address::generate(&env));
+    assert_eq!(result, Ok(1_000_000));
+}
+
+#[test]
+fn test_twap_adapter_returns_unavailable_for_empty_window() {
+    use crate::oracle_adapter::{OracleAdapter, TwapAdapter};
+    use crate::types::{OracleConfig, OracleKind};
+
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let oracle_id = env.register(MockOracle, ());
+
+    let config = OracleConfig {
+        enabled: true,
+        oracle: Some(oracle_id.clone()),
+        max_age_seconds: 10_000,
+        kind: OracleKind::Twap,
+        window_secs: 60,
+        fixed_numerator: 0,
+        fixed_denominator: 1,
+    };
+
+    let result = TwapAdapter::quote(&env, &config, &Address::generate(&env), &Address::generate(&env));
+    assert_eq!(result, Err(Error::OraclePriceUnavailable));
+}
+
+#[test]
+fn test_twap_adapter_filters_stale_samples() {
+    use crate::oracle_adapter::{OracleAdapter, TwapAdapter};
+    use crate::types::{OracleConfig, OracleKind};
+
+    let env = Env::default();
+    env.ledger().set_timestamp(1_500);
+    let oracle_id = env.register(MockOracle, ());
+    let oracle = MockOracleClient::new(&env, &oracle_id);
+    oracle.set_price(&2_000_000i128, &1000);
+
+    let config = OracleConfig {
+        enabled: true,
+        oracle: Some(oracle_id.clone()),
+        max_age_seconds: 100,
+        kind: OracleKind::Twap,
+        window_secs: 60,
+        fixed_numerator: 0,
+        fixed_denominator: 1,
+    };
+
+    let result = TwapAdapter::quote(&env, &config, &Address::generate(&env), &Address::generate(&env));
+    assert_eq!(result, Err(Error::OraclePriceStale));
+}
+
+#[test]
 fn test_create_subscription_with_unaccepted_token_fails() {
     let test_env = TestEnv::default();
     let subscriber = Address::generate(&test_env.env);

--- a/contracts/subscription_vault/src/types.rs
+++ b/contracts/subscription_vault/src/types.rs
@@ -1135,6 +1135,15 @@ pub struct DiscountAppliedEvent {
 
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Pricing strategy used to resolve oracle-based quotes.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum OracleKind {
+    Spot = 0,
+    Twap = 1,
+    FixedRate = 2,
+}
+
 /// Optional oracle pricing configuration for cross-currency plans.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -108,59 +108,69 @@ Column definitions:
 
 | Code | Variant | Category | Emitting entrypoints (modules) | Recovery action | Related event |
 |---:|:---|:---|:---|:---|:---|
-| 1001 | `Unauthorized` | Auth | `admin.rs`, `dispute.rs`, `governance.rs`, `lib.rs`, `subscription.rs`, `test.rs`, `test_governance.rs`, `test_recovery.rs`, `test_require_auth.rs`, `test_security.rs` | Rebuild request with correct signer; do not retry unchanged. | AdminRotatedEvent (if admin changed) |
+| 1001 | `Unauthorized` | Auth | `admin.rs`, `coupon.rs`, `dispute.rs`, `governance.rs`, `lib.rs`, `subscription.rs`, `test.rs`, `test_bulk_admin_ops.rs`, `test_coupon.rs`, `test_governance.rs`, `test_recovery.rs`, `test_require_auth.rs`, `test_security.rs` | Rebuild request with correct signer; do not retry unchanged. | AdminRotatedEvent (if admin changed) |
 | 1002 | `Forbidden` | Auth | `lib.rs`, `metadata.rs`, `subscription.rs`, `test.rs`, `test_require_auth.rs`, `test_scheduled_cancel.rs` | Surface permission error; caller authenticated but not authorised for resource. | — |
 | 1003 | `SubscriberBlocklisted` | Auth | `blocklist.rs`, `test.rs` | Escalate to admin/support flow; stop retrying. | BlocklistAddedEvent |
-| 1004 | `SelfRotation` | Auth | `admin.rs`, `merchant.rs`, `test.rs`, `test_governance.rs` | Fix request payload — new_admin must differ from current_admin. | — |
-| 1005 | `NonceAlreadyUsed` | Auth | `lib.rs`, `metadata.rs`, `nonce.rs`, `test.rs`, `test_governance.rs`, `test_metadata_signed.rs`, `test_operator.rs` | Re-fetch nonce via get_admin_nonce / get_operator_nonce, then retry. | NonceConsumedEvent |
-| 2001 | `NotFound` | Not Found | `admin.rs`, `blocklist.rs`, `governance.rs`, `lib.rs`, `merchant.rs`, `metadata.rs`, `queries.rs`, `subscription.rs`, `test.rs`, `test_governance.rs`, `test_metadata_signed.rs`, `test_reentrancy_invariants.rs`, `test_require_auth.rs` | Verify identifiers before retrying. | — |
-| 2002 | `NotInitialized` | Not Found | `admin.rs`, `lib.rs` | Admin must call init before any other operation. | — |
-| 3001 | `InvalidAmount` | Invalid Args | `admin.rs`, `charge_core.rs`, `dispute.rs`, `lib.rs`, `merchant.rs`, `subscription.rs`, `test.rs`, `test_reentrancy_invariants.rs`, `test_require_auth.rs` | Fix input; amount must be > 0. | — |
-| 3002 | `InvalidInput` | Invalid Args | `admin.rs`, `governance.rs`, `lib.rs`, `merchant.rs`, `metadata.rs`, `period_snapshots.rs`, `queries.rs`, `subscription.rs`, `test.rs`, `test_abi_validators_integration.rs`, `test_billing_period_snapshots.rs`, `test_decimal_normalization.rs`, `test_metadata_signed.rs`, `test_operator.rs`, `test_scheduled_cancel.rs`, `test_validation.rs`, `validation.rs` | Fix request parameters. | — |
+| 1004 | `SelfRotation` | Auth | `admin.rs`, `test.rs`, `test_governance.rs` | Fix request payload — new_admin must differ from current_admin. | — |
+| 1005 | `NonceAlreadyUsed` | Auth | `lib.rs`, `metadata.rs`, `nonce.rs`, `test.rs`, `test_bulk_admin_ops.rs`, `test_governance.rs`, `test_metadata_signed.rs`, `test_operator.rs` | Re-fetch nonce via get_admin_nonce / get_operator_nonce, then retry. | NonceConsumedEvent |
+| 2001 | `NotFound` | Not Found | `admin.rs`, `blocklist.rs`, `governance.rs`, `lib.rs`, `merchant.rs`, `metadata.rs`, `queries.rs`, `subscription.rs`, `test.rs`, `test_bulk_admin_ops.rs`, `test_governance.rs`, `test_metadata_signed.rs`, `test_reentrancy_invariants.rs`, `test_require_auth.rs` | Verify identifiers before retrying. | — |
+| 2002 | `NotInitialized` | Not Found | `admin.rs` | Admin must call init before any other operation. | — |
+| 3001 | `InvalidAmount` | Invalid Args | `accounting.rs`, `admin.rs`, `charge_core.rs`, `dispute.rs`, `lib.rs`, `merchant.rs`, `subscription.rs`, `test.rs`, `test_reentrancy_invariants.rs`, `test_require_auth.rs` | Fix input; amount must be > 0. | — |
+| 3002 | `InvalidInput` | Invalid Args | `admin.rs`, `coupon.rs`, `governance.rs`, `lib.rs`, `merchant.rs`, `metadata.rs`, `oracle_adapter.rs`, `period_snapshots.rs`, `queries.rs`, `subscription.rs`, `test.rs`, `test_abi_validators_integration.rs`, `test_billing_period_snapshots.rs`, `test_decimal_normalization.rs`, `test_metadata_signed.rs`, `test_operator.rs`, `test_scheduled_cancel.rs`, `test_validation.rs`, `validation.rs` | Fix request parameters. | — |
 | 3003 | `InvalidRecoveryAmount` | Invalid Args | `admin.rs`, `test_recovery.rs` | Fix amount; must be > 0. | — |
 | 3004 | `InvalidNewAdmin` | Invalid Args | `admin.rs`, `test.rs`, `test_governance.rs` | Fix payload; new_admin must not equal contract address. | — |
 | 3005 | `MetadataKeyTooLong` | Invalid Args | `lib.rs`, `metadata.rs`, `test_metadata_signed.rs` | Trim key to ≤ MAX_METADATA_KEY_LENGTH bytes and retry. | — |
 | 3006 | `MetadataValueTooLong` | Invalid Args | `lib.rs`, `metadata.rs`, `test_metadata_signed.rs` | Trim value to ≤ MAX_METADATA_VALUE_LENGTH bytes and retry. | — |
-| 3007 | `OraclePriceInvalid` | Invalid Args | `test.rs` | Treat as terminal for this request; investigate oracle data feed. | OracleConfigUpdatedEvent |
+| 3007 | `OraclePriceInvalid` | Invalid Args | `oracle_adapter.rs`, `test.rs` | Treat as terminal for this request; investigate oracle data feed. | OracleConfigUpdatedEvent |
 | 4001 | `InvalidStatusTransition` | State Transition | `lib.rs`, `period_snapshots.rs`, `state_machine.rs`, `subscription.rs`, `test.rs`, `test_billing_period_snapshots.rs` | Refresh subscription state before presenting the next action. | — |
 | 4002 | `NotActive` | State Transition | `charge_core.rs`, `subscription.rs`, `test.rs`, `test_operator.rs`, `test_reentrancy_invariants.rs`, `test_subscription_status_transitions.rs` | Refresh state; do not blindly retry. | — |
-| 4003 | `SubscriptionExpired` | State Transition | `charge_core.rs`, `subscription.rs`, `test_expiration.rs` | Stop retrying mutating operations on this subscription. | SubscriptionExpiredEvent |
+| 4003 | `SubscriptionExpired` | State Transition | `charge_core.rs`, `subscription.rs`, `test_bulk_admin_ops.rs`, `test_expiration.rs` | Stop retrying mutating operations on this subscription. | SubscriptionExpiredEvent |
 | 4004 | `IntervalNotElapsed` | State Transition | `charge_core.rs`, `merchant.rs`, `test.rs`, `test_payout_schedule.rs` | Retry only after next_charge_timestamp reported by get_next_charge_info. | — |
 | 4005 | `Replay` | State Transition | `admin.rs`, `charge_core.rs`, `test.rs`, `test_recovery.rs`, `test_reentrancy_invariants.rs` | Treat as idempotent duplicate; do not retry with a new key for the same action. | — |
 | 4006 | `RecoveryNotAllowed` | State Transition | `lib.rs` | Stop and inspect subscription state or policy before retrying. | RecoveryEvent |
 | 4007 | `EmergencyStopActive` | State Transition | `lib.rs`, `test.rs`, `test_emergency_stop_lifetime_caps.rs`, `test_emergency_stop_matrix.rs`, `test_operator.rs`, `test_reentrancy_invariants.rs` | Pause writes; poll get_emergency_stop_status and retry after admin clears stop. | EmergencyStopDisabledEvent |
 | 4008 | `AlreadyInitialized` | State Transition | `admin.rs`, `test.rs` | Do not retry; contract is already set up. | — |
-| 4009 | `MerchantPaused` | State Transition | `charge_core.rs`, `lib.rs`, `subscription.rs` | Retry only after merchant pause is removed (unpause_merchant). | MerchantUnpausedEvent |
+| 4009 | `MerchantPaused` | State Transition | `charge_core.rs`, `subscription.rs` | Retry only after merchant pause is removed (unpause_merchant). | MerchantUnpausedEvent |
 | 4010 | `Reentrancy` | State Transition | `reentrancy.rs` | Treat as a security failure; investigate calling path immediately. | — |
 | 5001 | `InsufficientBalance` | Accounting | `admin.rs`, `dispute.rs`, `lib.rs`, `merchant.rs`, `subscription.rs`, `test.rs`, `test_recovery.rs`, `test_reentrancy_invariants.rs` | Retry only after subscriber deposits funds via deposit_funds. | FundsDepositedEvent |
 | 5002 | `InsufficientPrepaidBalance` | Accounting | `charge_core.rs`, `subscription.rs`, `test.rs` | Top up subscription via deposit_funds, then retry. | FundsDepositedEvent |
 | 5003 | `BelowMinimumTopup` | Accounting | `subscription.rs`, `test.rs` | Increase deposit amount above get_min_topup() threshold and retry. | — |
-| 5004 | `Underflow` | Accounting | `admin.rs`, `dispute.rs`, `merchant.rs`, `safe_math.rs`, `test_security.rs`, `types.rs` | Treat as terminal; investigate accounting invariant violation; not user-retriable. | — |
-| 5005 | `Overflow` | Accounting | `charge_core.rs`, `dispute.rs`, `governance.rs`, `lib.rs`, `merchant.rs`, `metadata.rs`, `nonce.rs`, `period_snapshots.rs`, `safe_math.rs`, `subscription.rs`, `test.rs`, `test_decimal_normalization.rs`, `test_metadata_signed.rs`, `test_security.rs`, `types.rs` | Treat as terminal; investigate arithmetic overflow; not user-retriable. | — |
-| 5006 | `OracleNotConfigured` | Accounting | `lib.rs`, `test.rs`, `test_oracle_liveness.rs` | Admin must call set_oracle_config with a valid oracle address. | OracleConfigUpdatedEvent |
-| 5007 | `OraclePriceUnavailable` | Accounting | `test.rs` | Retry only after oracle data feed recovers. | OracleChargeResolvedEvent |
-| 5008 | `OraclePriceStale` | Accounting | `test.rs` | Retry only after a fresh oracle quote is published. | OracleChargeResolvedEvent |
+| 5004 | `Underflow` | Accounting | `accounting.rs`, `admin.rs`, `dispute.rs`, `merchant.rs`, `safe_math.rs`, `test_security.rs`, `types.rs` | Treat as terminal; investigate accounting invariant violation; not user-retriable. | — |
+| 5005 | `Overflow` | Accounting | `accounting.rs`, `charge_core.rs`, `dispute.rs`, `governance.rs`, `invariants.rs`, `lib.rs`, `merchant.rs`, `metadata.rs`, `nonce.rs`, `period_snapshots.rs`, `safe_math.rs`, `subscription.rs`, `test.rs`, `test_decimal_normalization.rs`, `test_metadata_signed.rs`, `test_security.rs`, `types.rs` | Treat as terminal; investigate arithmetic overflow; not user-retriable. | — |
+| 5006 | `OracleNotConfigured` | Accounting | `lib.rs`, `oracle_adapter.rs`, `test.rs`, `test_oracle_liveness.rs` | Admin must call set_oracle_config with a valid oracle address. | OracleConfigUpdatedEvent |
+| 5007 | `OraclePriceUnavailable` | Accounting | `oracle_adapter.rs`, `test.rs` | Retry only after oracle data feed recovers. | OracleChargeResolvedEvent |
+| 5008 | `OraclePriceStale` | Accounting | `oracle_adapter.rs`, `test.rs` | Retry only after a fresh oracle quote is published. | OracleChargeResolvedEvent |
 | 6001 | `SubscriptionLimitReached` | Limits | `lib.rs`, `subscription.rs`, `test.rs` | Treat as terminal capacity failure; no new subscriptions can be created. | — |
 | 6002 | `LifetimeCapReached` | Limits | `admin.rs`, `charge_core.rs`, `subscription.rs`, `test.rs`, `test_emergency_stop_lifetime_caps.rs` | Stop charging; surface terminal state to user. | LifetimeCapReachedEvent |
 | 6003 | `UsageNotEnabled` | Limits | `charge_core.rs`, `subscription.rs`, `test.rs` | Fix request — subscription was created with usage_enabled=false. | — |
 | 6004 | `InvalidExportLimit` | Limits | `lib.rs` | Fix pagination limit to [1, 100]. | — |
 | 6005 | `MetadataKeyLimitReached` | Limits | `lib.rs`, `metadata.rs`, `test_metadata_signed.rs` | Delete or update existing keys (up to MAX_METADATA_KEYS) before retrying. | MetadataDeletedEvent |
-| 6006 | `MaxConcurrentSubscriptionsReached` | Limits | `lib.rs`, `subscription.rs`, `test.rs` | Subscriber already at plan concurrency limit; cancel an existing subscription first. | SubscriptionCancelledEvent |
+| 6006 | `MaxConcurrentSubscriptionsReached` | Limits | `subscription.rs`, `test.rs` | Subscriber already at plan concurrency limit; cancel an existing subscription first. | SubscriptionCancelledEvent |
 | 6007 | `CreditLimitExceeded` | Limits | `subscription.rs`, `test.rs`, `test_insufficient_balance.rs` | Reduce deposit / subscription amount or raise limit via set_subscriber_credit_limit. | — |
 | 6008 | `RateLimitExceeded` | Limits | — | Retry after the rate window resets (see configure_usage_limits). | UsageLimitsConfiguredEvent |
 | 6009 | `UsageCapExceeded` | Limits | — | Retry only after new billing period begins or cap is raised. | UsageLimitsConfiguredEvent |
 | 6010 | `BurstLimitExceeded` | Limits | — | Retry after burst_min_interval_secs elapses. | UsageLimitsConfiguredEvent |
-| 7001 | `InvalidFeeBips` | Merchant Config | `lib.rs`, `merchant.rs` | Fix fee_bips to be in range [0, 10000]. | MerchantConfigUpdatedEvent |
-| 7002 | `InvalidOperations` | Merchant Config | `lib.rs`, `merchant.rs` | Fix allowed_operations bitmap to use only valid OP_* bits. | MerchantConfigUpdatedEvent |
-| 7003 | `MustAllowChargeOperation` | Merchant Config | `lib.rs`, `merchant.rs` | Set OP_CHARGE bit in allowed_operations; merchants must accept charges. | MerchantConfigUpdatedEvent |
-| 8001 | `InvalidTokenDecimals` | Token | `admin.rs`, `test_decimal_normalization.rs` | Fix token_decimals; must be in [1, 19]. | — |
-| 8002 | `InvalidToken` | Token | `admin.rs`, `test_decimal_normalization.rs` | Provide an accepted token address from list_accepted_tokens. | — |
+| 6011 | `CouponNotFound` | Limits | `coupon.rs` | ⚠ No remediation documented — add entry to `REMEDIATION` map in script. | — |
+| 6012 | `CouponExpired` | Limits | `coupon.rs`, `test_coupon.rs` | ⚠ No remediation documented — add entry to `REMEDIATION` map in script. | — |
+| 6013 | `CouponRedemptionLimitReached` | Limits | `coupon.rs`, `test_coupon.rs` | ⚠ No remediation documented — add entry to `REMEDIATION` map in script. | — |
+| 6014 | `CouponRevoked` | Limits | `coupon.rs`, `test_coupon.rs` | ⚠ No remediation documented — add entry to `REMEDIATION` map in script. | — |
+| 6015 | `CouponAlreadyExists` | Limits | `coupon.rs`, `test_coupon.rs` | ⚠ No remediation documented — add entry to `REMEDIATION` map in script. | — |
+| 6016 | `CouponAlreadyApplied` | Limits | `coupon.rs`, `test_coupon.rs` | ⚠ No remediation documented — add entry to `REMEDIATION` map in script. | — |
+| 6017 | `CouponTokenMismatch` | Limits | `coupon.rs`, `test_coupon.rs` | ⚠ No remediation documented — add entry to `REMEDIATION` map in script. | — |
+| 7001 | `InvalidFeeBips` | Merchant Config | `merchant.rs` | Fix fee_bips to be in range [0, 10000]. | MerchantConfigUpdatedEvent |
+| 7002 | `InvalidOperations` | Merchant Config | `merchant.rs` | Fix allowed_operations bitmap to use only valid OP_* bits. | MerchantConfigUpdatedEvent |
+| 7003 | `MustAllowChargeOperation` | Merchant Config | `merchant.rs` | Set OP_CHARGE bit in allowed_operations; merchants must accept charges. | MerchantConfigUpdatedEvent |
+| 8001 | `InvalidTokenDecimals` | Token | `admin.rs`, `test_decimal_normalization.rs`, `types.rs` | Fix token_decimals; must be in [1, 19]. | — |
+| 8002 | `InvalidToken` | Token | `admin.rs`, `test_decimal_normalization.rs`, `types.rs` | Provide an accepted token address from list_accepted_tokens. | — |
 | 9001 | `CannotChangeUsageMode` | Subscription Update | `subscription.rs` | Cannot toggle usage_enabled on an existing subscription; create a new one. | — |
-| 9101 | `SchemaMigrationDowngrade` | Schema Migration | `admin.rs`, `lib.rs`, `test.rs`, `test_config_migration.rs` | Downgrade rejected; deploy the correct binary version. | SchemaMigratedEvent |
+| 9101 | `SchemaMigrationDowngrade` | Schema Migration | `admin.rs`, `test.rs`, `test_config_migration.rs` | Downgrade rejected; deploy the correct binary version. | SchemaMigratedEvent |
 | 10001 | `DisputeNotFound` | Dispute | `dispute.rs`, `lib.rs`, `test.rs` | Verify dispute ID before retrying. | — |
 | 10002 | `DisputeAlreadyResolved` | Dispute | `dispute.rs`, `lib.rs`, `test.rs` | Inspect existing resolution; do not retry. | DisputeResolvedEvent |
 | 10003 | `DisputeNotResponded` | Dispute | `dispute.rs`, `lib.rs`, `test.rs` | Wait for admin response or dispute window to elapse. | DisputeRespondedEvent |
 | 10004 | `DisputeWindowElapsed` | Dispute | — | Check auto-resolution rules; dispute can now be resolved. | — |
 | 10005 | `DisputeAlreadyOpen` | Dispute | `dispute.rs`, `lib.rs`, `test.rs` | A dispute is already open for this subscription; wait for resolution. | DisputeOpenedEvent |
 | 10006 | `DisputeAlreadyResponded` | Dispute | `dispute.rs`, `lib.rs`, `test.rs` | Dispute is not in `Open` status; cannot respond twice. | DisputeRespondedEvent |
+
+> **⚠ Undocumented variants** — the following variants are present in `types.rs` but have no entry in the script's `REMEDIATION` map: `CouponNotFound`, `CouponExpired`, `CouponRedemptionLimitReached`, `CouponRevoked`, `CouponAlreadyExists`, `CouponAlreadyApplied`, `CouponTokenMismatch`. Add them to `scripts/generate_error_table.py` to resolve this warning.
+
 <!-- GENERATED:entrypoint-table:end -->

--- a/docs/oracle_pricing.md
+++ b/docs/oracle_pricing.md
@@ -87,12 +87,12 @@ match client.emit_oracle_liveness(&env) {
 
 ### OracleLivenessEvent Fields
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `last_sample_ts` | `u64` | Timestamp of the latest oracle price sample |
-| `age` | `u64` | Age of the sample in seconds (`current_time - last_sample_ts`) |
-| `healthy` | `bool` | `true` if `age <= max_age_seconds / 2`, indicating healthy oracle |
-| `timestamp` | `u64` | Ledger timestamp when this liveness check was performed |
+| Field            | Type   | Description                                                       |
+| ---------------- | ------ | ----------------------------------------------------------------- |
+| `last_sample_ts` | `u64`  | Timestamp of the latest oracle price sample                       |
+| `age`            | `u64`  | Age of the sample in seconds (`current_time - last_sample_ts`)    |
+| `healthy`        | `bool` | `true` if `age <= max_age_seconds / 2`, indicating healthy oracle |
+| `timestamp`      | `u64`  | Ledger timestamp when this liveness check was performed           |
 
 ### Health Threshold
 
@@ -164,6 +164,7 @@ The `oracle_config_updated` event now includes `kind`, `window_secs`, `fixed_num
 ### SpotAdapter
 
 Reads the latest `OraclePrice` from `oracle.latest_price()` and validates it:
+
 - Rejects non-positive prices (`OraclePriceInvalid`).
 - Rejects prices whose age exceeds `max_age_seconds` (`OraclePriceStale`).
 
@@ -184,6 +185,12 @@ median = prices[len(prices) / 2]  // middle element for odd-length
 ```
 
 Using the median rather than the mean means an attacker must control **more than half** of the observations inside the window to shift the output meaningfully. This resists single-block (flash-loan) price manipulation.
+
+**Recommended configuration**
+
+- Enforce a minimum TWAP window of at least 60 seconds in code.
+- For mainnet deployments, use a default window of 5 minutes (300 seconds) or longer so that a single-block spike is diluted by several honest observations.
+- Pair the TWAP with conservative slippage bounds such as 0.5%-1.0% for standard billing flows; tighter bounds may be appropriate for volatile markets or when the oracle feed itself is not well-distributed.
 
 **Edge cases:**
 | Scenario | Result |
@@ -228,10 +235,10 @@ All adapters share the same `OracleAdapter` trait and return a `u128` price scal
 
 ### Security Rationale
 
-| Property | Spot | TWAP | FixedRate |
-|---|---|---|---|
-| Oracle reads | Yes | Yes | No |
-| Staleness enforced | Yes | Yes (per observation) | N/A |
-| Manipulation resistance | Low | High (median) | Perfect (static) |
-| Oracle dependency | Required | Required | None |
-| Admin auth to change | Yes | Yes | Yes |
+| Property                | Spot     | TWAP                  | FixedRate        |
+| ----------------------- | -------- | --------------------- | ---------------- |
+| Oracle reads            | Yes      | Yes                   | No               |
+| Staleness enforced      | Yes      | Yes (per observation) | N/A              |
+| Manipulation resistance | Low      | High (median)         | Perfect (static) |
+| Oracle dependency       | Required | Required              | None             |
+| Admin auth to change    | Yes      | Yes                   | Yes              |


### PR DESCRIPTION
Closes #631

Summary
This PR hardens the TWAP oracle path by enforcing a minimum observation window and documenting a mainnet-safe default configuration for manipulation resistance.

What changed
Enforced a conservative minimum TWAP window of 60 seconds in the adapter
Added regression tests covering single-block manipulation, empty windows, and stale samples
Documented recommended mainnet defaults and conservative slippage guidance
Testing
Attempted to run:
cargo test -p subscription_vault --lib test_twap_adapter -- --nocapture
Current blocker:
the local Soroban/Rust dependency stack fails during ethnum compilation before the tests execute
Notes
The change is ready for review and PR submission
The repo test suite remains blocked by the local toolchain/dependency issue described above