### PR TITLE
feat: add merchant multi-sig withdrawal quorum

### DIFF
--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -1747,6 +1747,12 @@ impl SubscriptionVault {
     /// Update merchant config.
     pub fn set_merchant_config(env: Env, merchant: Address, config: MerchantConfig) -> Result<(), Error> { merchant::set_merchant_config(&env, merchant, config) }
 
+    /// Configure merchant withdrawal co-signers and threshold.
+    pub fn set_merchant_multisig(env: Env, admin: Address, merchant: Address, signers: Vec<Address>, threshold: u32) -> Result<(), Error> { merchant::set_merchant_multisig(&env, admin, merchant, signers, threshold) }
+
+    /// Get merchant withdrawal co-signer config.
+    pub fn get_merchant_multisig_config(env: Env, merchant: Address) -> Option<crate::types::MerchantMultiSigConfig> { merchant::get_merchant_multisig_config(&env, merchant) }
+
     /// Partial update merchant config.
     pub fn update_merchant_config(env: Env, merchant: Address, new_payout_address: Option<Address>, new_fee_bips: Option<i32>, new_allowed_operations: Option<i32>, new_is_active: Option<bool>, new_fee_address: Option<Option<Address>>, new_redirect_url: Option<String>, new_is_paused: Option<bool>) -> Result<MerchantConfig, Error> { merchant::update_merchant_config(&env, merchant, new_payout_address, new_fee_bips, new_allowed_operations, new_is_active, new_fee_address, new_redirect_url, new_is_paused) }
 

--- a/contracts/subscription_vault/src/merchant.rs
+++ b/contracts/subscription_vault/src/merchant.rs
@@ -23,9 +23,9 @@
 use crate::safe_math::{safe_add, safe_sub};
 use crate::types::{
     AccruedTotals, BillingChargeKind, DataKey, Error, MerchantConfig, MerchantConfigInitializedEvent,
-    MerchantConfigUpdatedEvent, MerchantPausedEvent, MerchantUnpausedEvent, MerchantWithdrawalEvent,
-    PayoutSchedule, ScheduledPayoutEvent, TokenEarnings, TokenReconciliationSnapshot,
-    MAX_FEE_BIPS, is_valid_allowed_operations, OP_CHARGE,
+    MerchantConfigUpdatedEvent, MerchantMultiSigConfig, MerchantPausedEvent, MerchantUnpausedEvent,
+    MerchantWithdrawalEvent, PayoutSchedule, ScheduledPayoutEvent, TokenEarnings,
+    TokenReconciliationSnapshot, MAX_FEE_BIPS, is_valid_allowed_operations, OP_CHARGE,
 };
 use soroban_sdk::{token, Address, Env, String, Symbol, Vec};
 
@@ -180,7 +180,10 @@ pub fn get_merchant_config(env: &Env, merchant: Address) -> Option<MerchantConfi
     env.storage().instance().get(&key)
 }
 
-
+pub fn get_merchant_multisig_config(env: &Env, merchant: Address) -> Option<MerchantMultiSigConfig> {
+    let key = DataKey::MerchantMultiSig(merchant);
+    env.storage().instance().get(&key)
+}
 
 fn merchant_balance_key(merchant: &Address, token: &Address) -> DataKey {
     DataKey::MerchantBalance(merchant.clone(), token.clone())
@@ -356,6 +359,44 @@ pub fn credit_merchant_balance_for_token(
 
     Ok(())
 }
+pub fn set_merchant_multisig(
+    env: &Env,
+    admin: Address,
+    merchant: Address,
+    signers: Vec<Address>,
+    threshold: u32,
+) -> Result<(), Error> {
+    crate::admin::require_admin_auth(env, &admin)?;
+    merchant.require_auth();
+
+    if threshold == 0 {
+        return Err(Error::InvalidInput);
+    }
+
+    if threshold as usize > signers.len() {
+        return Err(Error::InvalidInput);
+    }
+
+    let mut seen = Vec::new(env);
+    for signer in signers.iter() {
+        if seen.contains(&signer) {
+            return Err(Error::InvalidInput);
+        }
+        seen.push_back(signer.clone());
+    }
+
+    let key = DataKey::MerchantMultiSig(merchant.clone());
+    env.storage().instance().set(
+        &key,
+        &MerchantMultiSigConfig {
+            signers: signers.clone(),
+            threshold,
+        },
+    );
+
+    Ok(())
+}
+
 pub fn withdraw_merchant_funds(env: &Env, merchant: Address, amount: i128) -> Result<(), Error> {
     let token_addr = crate::admin::get_token(env)?;
     withdraw_merchant_funds_for_token(env, merchant, token_addr, amount)
@@ -368,6 +409,17 @@ pub fn withdraw_merchant_funds_for_token(
     amount: i128,
 ) -> Result<(), Error> {
     merchant.require_auth();
+
+    if let Some(config) = get_merchant_multisig_config(env, merchant.clone()) {
+        let required_signers = config.threshold.min(config.signers.len() as u32);
+        let mut iter = 0u32;
+        while iter < required_signers {
+            let signer = config.signers.get(iter).unwrap_or_default();
+            signer.require_auth();
+            iter += 1;
+        }
+    }
+
     crate::blocklist::require_not_blocklisted(env, &merchant)?;
 
     if amount <= 0 {

--- a/contracts/subscription_vault/src/test_require_auth.rs
+++ b/contracts/subscription_vault/src/test_require_auth.rs
@@ -20,7 +20,7 @@
 //!  3. **correct_auth** — `mock_all_auths` + correct address → call succeeds.
 
 use crate::{DataKey, Error, SubscriptionStatus, SubscriptionVault, SubscriptionVaultClient};
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -332,6 +332,60 @@ fn withdraw_merchant_funds_correct_auth() {
 
     let balance_before = client.get_merchant_balance(&merchant);
     assert_eq!(balance_before, withdraw_amount);
+    client.withdraw_merchant_funds(&merchant, &withdraw_amount);
+    assert_eq!(client.get_merchant_balance(&merchant), 0);
+}
+
+#[test]
+fn set_merchant_multisig_rejects_zero_threshold() {
+    let (env, client, _, admin) = setup();
+    let merchant = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(Address::generate(&env));
+
+    let res = client.try_set_merchant_multisig(&admin, &merchant, &signers, &0u32);
+    assert!(res.is_err());
+}
+
+#[test]
+fn set_merchant_multisig_rejects_threshold_above_signer_count() {
+    let (env, client, _, admin) = setup();
+    let merchant = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(Address::generate(&env));
+
+    let res = client.try_set_merchant_multisig(&admin, &merchant, &signers, &2u32);
+    assert!(res.is_err());
+}
+
+#[test]
+fn set_merchant_multisig_rejects_duplicate_signers() {
+    let (env, client, _, admin) = setup();
+    let merchant = Address::generate(&env);
+    let duplicate = Address::generate(&env);
+    let mut signers = Vec::new(&env);
+    signers.push_back(duplicate.clone());
+    signers.push_back(duplicate);
+
+    let res = client.try_set_merchant_multisig(&admin, &merchant, &signers, &2u32);
+    assert!(res.is_err());
+}
+
+#[test]
+fn withdraw_merchant_funds_without_multisig_config_keeps_merchant_auth_fallback() {
+    let (env, client, token, _) = setup();
+    let merchant = Address::generate(&env);
+    let withdraw_amount: i128 = 1_000_000;
+
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(
+            &DataKey::MerchantBalance(merchant.clone(), token.clone()),
+            &withdraw_amount,
+        );
+    });
+    soroban_sdk::token::StellarAssetClient::new(&env, &token)
+        .mint(&client.address, &withdraw_amount);
+
     client.withdraw_merchant_funds(&merchant, &withdraw_amount);
     assert_eq!(client.get_merchant_balance(&merchant), 0);
 }

--- a/contracts/subscription_vault/src/types.rs
+++ b/contracts/subscription_vault/src/types.rs
@@ -201,6 +201,8 @@ pub enum DataKey {
     SubscriptionDispute(u32),
     /// Payout schedule configuration for a merchant. Discriminant 53.
     PayoutSchedule(Address),
+    /// Merchant withdrawal multi-sig configuration. Discriminant 54.
+    MerchantMultiSig(Address),
 }
 
 impl DataKey {
@@ -260,6 +262,7 @@ impl DataKey {
             DataKey::NextDisputeId => 51,
             DataKey::SubscriptionDispute(_) => 52,
             DataKey::PayoutSchedule(_) => 53,
+            DataKey::MerchantMultiSig(_) => 54,
         }
     }
 
@@ -309,6 +312,7 @@ pub const KNOWN_INSTANCE_KEY_DISCRIMINANTS: &[u32] = &[
     51, // NextDisputeId
     52, // SubscriptionDispute(u32)
     53, // PayoutSchedule(Address)
+    54, // MerchantMultiSig(Address)
 ];
 
 /// Returns `true` if `discriminant` is a recognised instance-storage key.
@@ -1771,6 +1775,13 @@ pub struct MerchantConfig {
     pub redirect_url: String,
     pub is_paused: bool,
     pub last_updated: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MerchantMultiSigConfig {
+    pub signers: Vec<Address>,
+    pub threshold: u32,
 }
 
 #[contracttype]


### PR DESCRIPTION
## Summary
Add merchant withdrawal multisig quorum support so high-value merchants can require N-of-M co-signer authorization before funds can be withdrawn.

## What changed
- Added a new merchant multisig config storage entry under the appended DataKey variant.
- Added a new entrypoint to configure merchant withdrawal signers and threshold.
- Enforced co-signer authorization during merchant withdrawals when a multisig config is present.
- Preserved the existing merchant-auth fallback path when no multisig config is configured.
- Added tests covering invalid threshold values, duplicate signers, and the fallback behavior.

## Security notes
- The withdrawal flow now requires the configured co-signers to authenticate before the transfer proceeds.
- Thresholds are validated to prevent zero-threshold or over-sized quorum config values.
- Duplicate signers are rejected to avoid ambiguous approvals.

## Testing
- Added targeted contract tests for multisig config validation and withdrawal fallback behavior.

Closes: #552 