### PR TITLE
test: reject past expiration on create_subscription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,9 +581,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "fastrand"

--- a/contracts/subscription_vault/src/subscription.rs
+++ b/contracts/subscription_vault/src/subscription.rs
@@ -380,6 +380,15 @@ pub fn do_create_subscription_with_token(
 
     validate_interval(interval_seconds)?;
 
+    // Reject expiration timestamps that are at or before the current ledger time.
+    // A subscription that is already expired at creation would be a zombie entry
+    // that can never be charged.
+    if let Some(exp) = expires_at {
+        if exp <= env.ledger().timestamp() {
+            return Err(Error::InvalidExpiration);
+        }
+    }
+
     if !crate::admin::is_token_accepted(env, &token) {
         return Err(Error::InvalidInput);
     }

--- a/contracts/subscription_vault/src/test_expiration.rs
+++ b/contracts/subscription_vault/src/test_expiration.rs
@@ -233,3 +233,162 @@ fn test_deposit_rejected_when_expired() {
     let res = client.try_deposit_funds(&sub_id, &subscriber, &min_topup, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(res, Err(Ok(Error::SubscriptionExpired)));
 }
+
+/// Reject `create_subscription` when `expires_at == ledger.timestamp()`.
+///
+/// A subscription that is already expired at creation would be a zombie
+/// entry that can never be charged.  The contract must return
+/// `Error::InvalidExpiration` and write no storage entries.
+#[test]
+fn test_reject_expiration_equal_to_now() {
+    let (env, client, token_client, token_admin, _) = setup_test_env();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let expires_at = T0; // equal to current ledger timestamp
+
+    let res = client.try_create_subscription_with_token(
+        &subscriber,
+        &merchant,
+        &token_client.address,
+        &1_000_000i128,
+        &INTERVAL,
+        &false,
+        &None::<i128>,
+        &Some(expires_at),
+    );
+    assert_eq!(res, Err(Ok(Error::InvalidExpiration)));
+}
+
+/// Reject `create_subscription` when `expires_at < ledger.timestamp()`.
+///
+/// An expiration timestamp in the past is equally invalid — the
+/// subscription would be born already expired.  Must return
+/// `Error::InvalidExpiration` and write no storage entries.
+#[test]
+fn test_reject_expiration_in_the_past() {
+    let (env, client, token_client, token_admin, _) = setup_test_env();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let expires_at = T0 - 1; // one second before current ledger time
+
+    let res = client.try_create_subscription_with_token(
+        &subscriber,
+        &merchant,
+        &token_client.address,
+        &1_000_000i128,
+        &INTERVAL,
+        &false,
+        &None::<i128>,
+        &Some(expires_at),
+    );
+    assert_eq!(res, Err(Ok(Error::InvalidExpiration)));
+}
+
+/// `None` expiration must be accepted.
+///
+/// Omitting `expires_at` creates an open-ended subscription that never
+/// expires — this is the standard path and must succeed.
+#[test]
+fn test_none_expiration_accepted() {
+    let (env, client, token_client, token_admin, _) = setup_test_env();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let res = client.try_create_subscription_with_token(
+        &subscriber,
+        &merchant,
+        &token_client.address,
+        &1_000_000i128,
+        &INTERVAL,
+        &false,
+        &None::<i128>,
+        &None::<u64>,
+    );
+    assert!(res.is_ok(), "None expiration must be accepted");
+
+    let sub_id = res.unwrap();
+    let sub = client.get_subscription(&sub_id);
+    assert_eq!(sub.expires_at, None);
+}
+
+/// Accept `expires_at` one second in the future.
+///
+/// The earliest permitted expiration is `ledger.timestamp() + 1`.  This
+/// test confirms that boundary is accepted and the subscription is
+/// created in Active status.
+#[test]
+fn test_future_expiration_one_second_ahead_accepted() {
+    let (env, client, token_client, token_admin, _) = setup_test_env();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let expires_at = T0 + 1; // one second after current ledger time
+
+    let res = client.try_create_subscription_with_token(
+        &subscriber,
+        &merchant,
+        &token_client.address,
+        &1_000_000i128,
+        &INTERVAL,
+        &false,
+        &None::<i128>,
+        &Some(expires_at),
+    );
+    assert!(res.is_ok(), "future expiration must be accepted");
+
+    let sub_id = res.unwrap();
+    let sub = client.get_subscription(&sub_id);
+    assert_eq!(sub.expires_at, Some(expires_at));
+    assert_eq!(sub.status, SubscriptionStatus::Active);
+}
+
+/// Rejected expiration attempts must not write any storage.
+///
+/// After each rejection the subscription counter must remain unchanged
+/// and `get_subscription` must return `NotFound` for any hypothetical
+/// ID that would have been allocated.
+#[test]
+fn test_rejected_expiration_writes_no_storage() {
+    let (env, client, token_client, token_admin, _) = setup_test_env();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    // Record next_id before the failed attempts.
+    let _ = client.try_create_subscription_with_token(
+        &subscriber,
+        &merchant,
+        &token_client.address,
+        &1_000_000i128,
+        &INTERVAL,
+        &false,
+        &None::<i128>,
+        &Some(T0), // equal to now → rejected
+    );
+
+    let _ = client.try_create_subscription_with_token(
+        &subscriber,
+        &merchant,
+        &token_client.address,
+        &1_000_000i128,
+        &INTERVAL,
+        &false,
+        &None::<i128>,
+        &Some(T0 - 1), // in the past → rejected
+    );
+
+    // Now create a valid subscription — it should get id 0 (first ever).
+    let res = client.try_create_subscription_with_token(
+        &subscriber,
+        &merchant,
+        &token_client.address,
+        &1_000_000i128,
+        &INTERVAL,
+        &false,
+        &None::<i128>,
+        &None::<u64>,
+    );
+    assert!(res.is_ok(), "valid subscription must succeed");
+    assert_eq!(res.unwrap(), 0, "first subscription should have id 0");
+}

--- a/contracts/subscription_vault/src/types.rs
+++ b/contracts/subscription_vault/src/types.rs
@@ -543,6 +543,8 @@ pub enum Error {
     MetadataValueTooLong = 3006,
     /// Oracle returned a non-positive price.
     OraclePriceInvalid = 3007,
+    /// Expiration timestamp is at or before the current ledger time.
+    InvalidExpiration = 3008,
 
     // --- State Transition (4000-4099) ---
     /// The requested state transition is not allowed by the state machine.


### PR DESCRIPTION
## Summary

Adds validation to reject `create_subscription` when `expires_at` is at or before the current ledger timestamp, preventing zombie subscriptions that can never be charged. Closes #585.

### Changes

**Validation (`subscription.rs:383-390`)**
- Added `expires_at <= env.ledger().timestamp()` check in `do_create_subscription_with_token`
- Returns `Error::InvalidExpiration` (3008) when the check fails

**Error variant (`types.rs:546-547`)**
- Added `InvalidExpiration = 3008` in the Invalid Args (3000-3099) range

**Tests (`test_expiration.rs`)**
1. `test_reject_expiration_equal_to_now` — `expires_at == T0` rejected
2. `test_reject_expiration_in_the_past` — `expires_at == T0 - 1` rejected
3. `test_none_expiration_accepted` — `None` creates open-ended subscription
4. `test_future_expiration_one_second_ahead_accepted` — `expires_at == T0 + 1` accepted, Active status
5. `test_rejected_expiration_writes_no_storage` — failed attempts do not increment subscription ID counter

### Security Notes
- Zombie subscriptions (born expired) can never be charged, creating dead storage
- The `<=` check covers both equal-to-now and strictly-past timestamps
- `None` expiration (open-ended) continues to work as before
- No storage is written on rejection (early return before ID allocation)
