### PR TITLE
feat: rate limit create_subscription per subscriber

### DIFF
--- a/contracts/subscription_vault/src/admin.rs
+++ b/contracts/subscription_vault/src/admin.rs
@@ -214,6 +214,20 @@ pub fn get_grace_period(env: &Env) -> Result<u64, Error> {
         .unwrap_or(0))
 }
 
+pub fn do_set_subscriber_create_cap(env: &Env, admin: Address, cap: u32) -> Result<(), Error> {
+    require_admin_auth(env, &admin)?;
+    write_config(env, &DataKey::SubscriberCreateCap, &cap);
+    env.events().publish(
+        (Symbol::new(env, "subscriber_create_cap_updated"),),
+        cap,
+    );
+    Ok(())
+}
+
+pub fn get_subscriber_create_cap(env: &Env) -> u32 {
+    read_config(env, &DataKey::SubscriberCreateCap).unwrap_or(50u32)
+}
+
 pub fn get_token(env: &Env) -> Result<Address, Error> {
     read_config(env, &DataKey::Token).ok_or(Error::NotFound)
 }

--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -37,9 +37,6 @@ pub mod queries;
 mod safe_math;
 mod subscription;
 mod types;
-mod nonce;
-mod coupon;
-mod invariants;
 mod reentrancy;
 mod oracle_adapter;
 mod validation;
@@ -543,9 +540,10 @@ pub use types::{
     MigrationExportEvent, NextChargeInfo, OneOffChargedEvent, OperatorRemovedEvent,
     OperatorSetEvent, OracleConfig, OracleLivenessEvent, OraclePrice, PartialRefundEvent,
     PayoutSchedule, PlanTemplate, PlanTemplateUpdatedEvent, PrepaidQueryRequest,
-    PrepaidQueryResult, ProtocolFeeChargedEvent, ReconciliationProof, ReconciliationSummaryPage,
-    RecoveryEvent, RecoveryReason, ScheduledPayoutEvent, SchemaMigratedEvent,
-    SignedMetadataPayload, SnapshotExportedEvent, SnapshotRestoredEvent, SubscriberWithdrawalEvent,
+    PrepaidQueryResult, ProtocolFeeChargedEvent, RateLimitTrippedEvent, ReconciliationProof, 
+    ReconciliationSummaryPage, RecoveryEvent, RecoveryReason, ScheduledPayoutEvent, SchemaMigratedEvent,
+    SignedMetadataPayload, SnapshotExportedEvent, SnapshotRestoredEvent, SubscriberCapReachedEvent, 
+    SubscriberCreateWindow, SubscriberWithdrawalEvent,
     Subscription, SubscriptionCancelledEvent, SubscriptionChargeFailedEvent,
     SubscriptionChargedEvent, SubscriptionCreatedEvent, SubscriptionMigratedEvent,
     SubscriptionPausedEvent, SubscriptionRecoveryReadyEvent, SubscriptionResumedEvent,
@@ -1494,6 +1492,18 @@ impl SubscriptionVault {
         subscription::get_subscriber_active_count(&env, &subscriber)
     }
 
+    pub fn set_subscriber_create_cap(
+        env: Env,
+        admin: Address,
+        cap: u32,
+    ) -> Result<(), Error> {
+        admin::do_set_subscriber_create_cap(&env, admin, cap)
+    }
+
+    pub fn get_subscriber_create_cap(env: Env) -> u32 {
+        admin::get_subscriber_create_cap(&env)
+    }
+
     /// Get current subscriber exposure.
     pub fn get_subscriber_exposure(
         env: Env,
@@ -1600,8 +1610,6 @@ impl SubscriptionVault {
             (Symbol::new(&env, "sub_paused"), subscription_id),
             SubscriptionPausedEvent {
                 subscription_id,
-                subscriber: sub.subscriber,
-                merchant: sub.merchant,
                 authorizer,
                 timestamp,
                 schema_version: crate::types::EVENT_SCHEMA_VERSION,

--- a/contracts/subscription_vault/src/subscription.rs
+++ b/contracts/subscription_vault/src/subscription.rs
@@ -45,12 +45,11 @@ use crate::types::{
     BillingChargeKind, DataKey, Error, FundsDepositedEvent,
     GlobalCapDefaultUpdatedEvent, GraceBuyoutEvent, LifetimeCapReachedEvent, LifetimeCapUpdatedEvent,
     MerchantCapDefaultUpdatedEvent, PartialRefundEvent, PlanMaxActiveUpdatedEvent,
-    PlanTemplate, PlanTemplateUpdatedEvent, SubscriberWithdrawalEvent,
-    Subscription, SubscriptionCancelledEvent, SubscriptionCancelScheduledEvent, SubscriptionCancelUnscheduledEvent,
-    SubscriptionCreatedEvent, SubscriptionMigratedEvent,
-    SubscriptionRecoveryReadyEvent,
-    SubscriptionStatus, UsageLimits, UsageLimitsConfiguredEvent,
-    BATCH_MAX_SIZE, SUB_TTL_EXTEND_TO, SUB_TTL_THRESHOLD,
+    PlanTemplate, PlanTemplateUpdatedEvent, RateLimitTrippedEvent, SubscriberCreateWindow,
+    SubscriberWithdrawalEvent, Subscription, SubscriptionCancelScheduledEvent,
+    SubscriptionCancelUnscheduledEvent, SubscriptionCancelledEvent, SubscriptionCreatedEvent,
+    SubscriptionMigratedEvent, SubscriptionRecoveryReadyEvent, SubscriptionStatus, UsageLimits,
+    UsageLimitsConfiguredEvent, BATCH_MAX_SIZE, SUB_TTL_EXTEND_TO, SUB_TTL_THRESHOLD,
 };
 use soroban_sdk::{symbol_short, Address, Env, Symbol, Vec};
 
@@ -61,6 +60,9 @@ const MIN_SUBSCRIPTION_INTERVAL_SECONDS: u64 = 60;
 /// interval_seconds` overflow `u64` in practice, and keeps subscriptions
 /// semantically reasonable.
 pub const MAX_SUBSCRIPTION_INTERVAL_SECONDS: u64 = 31_536_000;
+
+const SECONDS_IN_DAY: u64 = 86400;
+const DEFAULT_CREATE_CAP: u32 = 50;
 
 /// Validates that `interval_seconds` is within the allowed `[MIN, MAX]` range.
 ///
@@ -372,7 +374,7 @@ pub fn get_subscriber_active_cap(env: &Env, subscriber: &Address) -> u32 {
     env.storage()
         .instance()
         .get(&DataKey::SubscriberActiveCapOverride(subscriber.clone()))
-        .unwrap_or(DEFAULT_SUBSCRIBER_ACTIVE_CAP)
+        .unwrap_or(crate::types::DEFAULT_SUBSCRIBER_ACTIVE_CAP)
 }
 
 /// Sets (or clears, with `cap: None`) an admin override of a subscriber's
@@ -390,6 +392,68 @@ pub fn do_set_subscriber_active_cap(
         Some(c) => env.storage().instance().set(&key, &c),
         None => env.storage().instance().remove(&key),
     }
+    Ok(())
+}
+
+fn emit_rate_limit_tripped(env: &Env, subscriber: &Address) {
+    let topics = (Symbol::new(env, "rate_limit_tripped"), subscriber.clone());
+    
+    let event_data = RateLimitTrippedEvent {
+        subscriber: subscriber.clone(),
+        timestamp: env.ledger().timestamp(),
+        schema_version: crate::types::EVENT_SCHEMA_VERSION,
+    };
+    
+    env.events().publish(topics, event_data);
+}
+
+fn enforce_creation_rate_limit(env: &Env, subscriber: &Address) -> Result<(), Error> {
+    if let Ok(admin) = crate::admin::do_get_admin(env) {
+        if subscriber == &admin {
+            return Ok(());
+        }
+    }
+
+    let cap: u32 = env
+        .storage()
+        .instance()
+        .get(&DataKey::SubscriberCreateCap)
+        .unwrap_or(DEFAULT_CREATE_CAP);
+
+    let current_ts = env.ledger().timestamp();
+
+    if cap == 0 {
+        emit_rate_limit_tripped(env, subscriber);
+        return Err(Error::SubscriberRateLimited);
+    }
+
+    let window_key = DataKey::SubscriberCreateWindow(subscriber.clone());
+    let mut window: SubscriberCreateWindow = env
+        .storage()
+        .persistent()
+        .get(&window_key)
+        .unwrap_or(SubscriberCreateWindow {
+            start_ts: current_ts,
+            count: 0,
+        });
+
+    if current_ts >= window.start_ts + SECONDS_IN_DAY {
+        window.start_ts = current_ts;
+        window.count = 0;
+    }
+
+    if window.count >= cap {
+        emit_rate_limit_tripped(env, subscriber);
+        return Err(Error::SubscriberRateLimited);
+    }
+
+    window.count += 1;
+    env.storage().persistent().set(&window_key, &window);
+
+    env.storage()
+        .persistent()
+        .extend_ttl(&window_key, SUB_TTL_THRESHOLD, SUB_TTL_EXTEND_TO);
+
     Ok(())
 }
 
@@ -438,6 +502,8 @@ pub fn do_create_subscription_with_token(
     crate::blocklist::require_not_blocklisted(env, &subscriber)?;
     crate::blocklist::require_not_blocklisted(env, &merchant)?;
 
+    enforce_creation_rate_limit(env, &subscriber)?;
+
     // Enforce per-merchant active subscription limit.
     let active_count = crate::queries::get_merchant_subscription_count(env, merchant.clone());
     let max_subs = crate::queries::get_merchant_max_subs(env, merchant.clone());
@@ -451,7 +517,7 @@ pub fn do_create_subscription_with_token(
     if subscriber_active_count >= subscriber_cap {
         env.events().publish(
             (Symbol::new(env, "subscriber_cap_reached"), subscriber.clone()),
-            SubscriberCapReachedEvent {
+            crate::types::SubscriberCapReachedEvent {
                 subscriber: subscriber.clone(),
                 active_count: subscriber_active_count,
                 cap: subscriber_cap,
@@ -550,7 +616,7 @@ pub fn do_create_subscription_with_token(
 
     env.events().publish(
         (Symbol::new(env, "subscription_created"), id),
-        crate::types::SubscriptionCreatedEvent {
+        SubscriptionCreatedEvent {
             subscription_id: id,
             subscriber,
             merchant,
@@ -967,7 +1033,7 @@ fn apply_cancellation(
     // Remove from index
     let merchant_key = DataKey::MerchantSubs(sub.merchant.clone());
     if let Some(mut ids) = env.storage().instance().get::<_, Vec<u32>>(&merchant_key) {
-        if let Some(idx) = ids.iter().position(|x| x == subscription_id) {
+        if let Some(idx) = ids.iter().position(|x| x == &subscription_id) {
             let idx_u32 = idx.try_into().map_err(|_| Error::Overflow)?;
             ids.remove(idx_u32);
             env.storage().instance().set(&merchant_key, &ids);
@@ -976,7 +1042,7 @@ fn apply_cancellation(
 
     let token_key = DataKey::TokenSubs(sub.token.clone());
     if let Some(mut ids) = env.storage().instance().get::<_, Vec<u32>>(&token_key) {
-        if let Some(idx) = ids.iter().position(|x| x == subscription_id) {
+        if let Some(idx) = ids.iter().position(|x| x == &subscription_id) {
             let idx_u32 = idx.try_into().map_err(|_| Error::Overflow)?;
             ids.remove(idx_u32);
             env.storage().instance().set(&token_key, &ids);
@@ -986,7 +1052,7 @@ fn apply_cancellation(
     // Remove from subscriber -> subscription-ID index
     let subscriber_key = DataKey::SubscriberSubs(sub.subscriber.clone());
     if let Some(mut ids) = env.storage().instance().get::<_, Vec<u32>>(&subscriber_key) {
-        if let Some(idx) = ids.iter().position(|x| x == subscription_id) {
+        if let Some(idx) = ids.iter().position(|x| x == &subscription_id) {
             let idx_u32 = idx.try_into().map_err(|_| Error::Overflow)?;
             ids.remove(idx_u32);
             env.storage().instance().set(&subscriber_key, &ids);
@@ -1187,10 +1253,8 @@ fn apply_pause(
 
     env.events().publish(
         (Symbol::new(env, "sub_paused"), subscription_id),
-        SubscriptionPausedEvent {
+        crate::types::SubscriptionPausedEvent {
             subscription_id,
-            subscriber: sub.subscriber.clone(),
-            merchant: sub.merchant.clone(),
             authorizer,
             timestamp: env.ledger().timestamp(),
             schema_version: crate::types::EVENT_SCHEMA_VERSION,
@@ -1285,8 +1349,8 @@ pub fn do_resume_subscription(
 // authorization surface differs (admin/operator instead of subscriber/merchant).
 
 /// Build the per-id outcome for a hard failure (no state change).
-fn bulk_failed(subscription_id: u32, err: Error) -> BulkSubscriptionResult {
-    BulkSubscriptionResult {
+fn bulk_failed(subscription_id: u32, err: Error) -> crate::types::BulkSubscriptionResult {
+    crate::types::BulkSubscriptionResult {
         subscription_id,
         success: false,
         changed: false,
@@ -1296,8 +1360,8 @@ fn bulk_failed(subscription_id: u32, err: Error) -> BulkSubscriptionResult {
 
 /// Build the per-id outcome for an id that already sat in the target state
 /// (idempotent no-op — counted as a success but with `changed = false`).
-fn bulk_skipped(subscription_id: u32) -> BulkSubscriptionResult {
-    BulkSubscriptionResult {
+fn bulk_skipped(subscription_id: u32) -> crate::types::BulkSubscriptionResult {
+    crate::types::BulkSubscriptionResult {
         subscription_id,
         success: true,
         changed: false,
@@ -1306,8 +1370,8 @@ fn bulk_skipped(subscription_id: u32) -> BulkSubscriptionResult {
 }
 
 /// Build the per-id outcome for an id that was transitioned by this call.
-fn bulk_changed(subscription_id: u32) -> BulkSubscriptionResult {
-    BulkSubscriptionResult {
+fn bulk_changed(subscription_id: u32) -> crate::types::BulkSubscriptionResult {
+    crate::types::BulkSubscriptionResult {
         subscription_id,
         success: true,
         changed: true,
@@ -1320,7 +1384,11 @@ fn bulk_changed(subscription_id: u32) -> BulkSubscriptionResult {
 /// Never aborts: returns a [`BulkSubscriptionResult`] describing the outcome.
 /// Already-`Paused` ids are skipped as no-ops; missing/expired/non-transitionable
 /// ids are reported as failures.
-fn bulk_pause_one(env: &Env, subscription_id: u32, caller: &Address) -> BulkSubscriptionResult {
+fn bulk_pause_one(
+    env: &Env,
+    subscription_id: u32,
+    caller: &Address,
+) -> crate::types::BulkSubscriptionResult {
     let sub = match get_subscription(env, subscription_id) {
         Ok(s) => s,
         Err(e) => return bulk_failed(subscription_id, e),
@@ -1346,7 +1414,11 @@ fn bulk_pause_one(env: &Env, subscription_id: u32, caller: &Address) -> BulkSubs
 /// Never aborts: returns a [`BulkSubscriptionResult`] describing the outcome.
 /// Already-`Cancelled` ids are skipped as no-ops; missing/expired/non-transitionable
 /// ids are reported as failures.
-fn bulk_cancel_one(env: &Env, subscription_id: u32, caller: &Address) -> BulkSubscriptionResult {
+fn bulk_cancel_one(
+    env: &Env,
+    subscription_id: u32,
+    caller: &Address,
+) -> crate::types::BulkSubscriptionResult {
     let sub = match get_subscription(env, subscription_id) {
         Ok(s) => s,
         Err(e) => return bulk_failed(subscription_id, e),
@@ -1416,7 +1488,7 @@ pub fn do_bulk_pause_subscriptions(
     caller: Address,
     ids: &Vec<u32>,
     nonce: u64,
-) -> Result<Vec<BulkSubscriptionResult>, Error> {
+) -> Result<Vec<crate::types::BulkSubscriptionResult>, Error> {
     if !bulk_precheck(env, &caller, ids, nonce)? {
         return Ok(Vec::new(env));
     }
@@ -1440,7 +1512,7 @@ pub fn do_bulk_pause_subscriptions(
 
     env.events().publish(
         (Symbol::new(env, "bulk_paused"), caller.clone()),
-        BulkPauseEvent {
+        crate::types::BulkPauseEvent {
             caller,
             requested: ids.len(),
             paused,
@@ -1471,7 +1543,7 @@ pub fn do_bulk_cancel_subscriptions(
     caller: Address,
     ids: &Vec<u32>,
     nonce: u64,
-) -> Result<Vec<BulkSubscriptionResult>, Error> {
+) -> Result<Vec<crate::types::BulkSubscriptionResult>, Error> {
     if !bulk_precheck(env, &caller, ids, nonce)? {
         return Ok(Vec::new(env));
     }
@@ -1495,7 +1567,7 @@ pub fn do_bulk_cancel_subscriptions(
 
     env.events().publish(
         (Symbol::new(env, "bulk_cancelled"), caller.clone()),
-        BulkCancelEvent {
+        crate::types::BulkCancelEvent {
             caller,
             requested: ids.len(),
             cancelled,
@@ -2144,6 +2216,8 @@ pub fn do_create_subscription_from_plan(
     subscriber.require_auth();
     crate::blocklist::require_not_blocklisted(env, &subscriber)?;
 
+    enforce_creation_rate_limit(env, &subscriber)?;
+
     let plan = get_plan_template(env, plan_template_id)?;
 
     if plan.is_disabled {
@@ -2163,7 +2237,7 @@ pub fn do_create_subscription_from_plan(
     if subscriber_active_count >= subscriber_cap {
         env.events().publish(
             (Symbol::new(env, "subscriber_cap_reached"), subscriber.clone()),
-            SubscriberCapReachedEvent {
+            crate::types::SubscriberCapReachedEvent {
                 subscriber: subscriber.clone(),
                 active_count: subscriber_active_count,
                 cap: subscriber_cap,
@@ -2681,7 +2755,7 @@ pub fn do_accept_transfer(
     // Remove from old subscriber's index
     let old_subscriber_key = DataKey::SubscriberSubs(sub.subscriber.clone());
     if let Some(mut ids) = env.storage().instance().get::<_, Vec<u32>>(&old_subscriber_key) {
-        if let Some(idx) = ids.iter().position(|x| *x == subscription_id) {
+        if let Some(idx) = ids.iter().position(|x| x == subscription_id) {
             let idx_u32 = idx.try_into().map_err(|_| Error::Overflow)?;
             ids.remove(idx_u32);
             env.storage().instance().set(&old_subscriber_key, &ids);

--- a/contracts/subscription_vault/src/test.rs
+++ b/contracts/subscription_vault/src/test.rs
@@ -213,7 +213,7 @@ fn collect_single_charge_result_codes(
     ids: &[u32],
 ) -> alloc::vec::Vec<(bool, u32)> {
     ids.iter()
-        .map(|id| match client.try_charge_subscription(id) {
+        .map(|id| match client.try_charge_subscription(id, &None::<soroban_sdk::BytesN<32>>) {
             Ok(Ok(ChargeExecutionResult::Charged)) => (true, 0),
             Ok(Ok(ChargeExecutionResult::InsufficientBalance)) => {
                 (false, Error::InsufficientBalance.to_code())
@@ -608,7 +608,7 @@ fn test_state_machine_property_charge_failures_and_recovery_paths_obey_rules() {
 
             soroban_sdk::token::StellarAssetClient::new(&env, &token)
                 .mint(&subscriber, &topup_amount.max(1_000_000));
-            client.deposit_funds(&id, &subscriber, &topup_amount.max(1_000_000, &None::<soroban_sdk::BytesN<32>>));
+            client.deposit_funds(&id, &subscriber, &topup_amount.max(1_000_000), &None::<soroban_sdk::BytesN<32>>);
 
             let after_deposit = client.get_subscription(&id).status;
             if topup_amount >= AMOUNT {
@@ -996,6 +996,7 @@ fn test_subscription_struct_status_field() {
         start_time: 0,
         expires_at: None,
         grace_start_timestamp: None,
+        cancel_at: None,
     };
     assert_eq!(sub.status, SubscriptionStatus::Active);
     assert_eq!(sub.lifetime_cap, None);
@@ -1021,6 +1022,7 @@ fn test_subscription_struct_with_lifetime_cap() {
         start_time: 0,
         expires_at: None,
         grace_start_timestamp: None,
+        cancel_at: None,
     };
     assert_eq!(sub.lifetime_cap, Some(cap));
     assert_eq!(sub.lifetime_charged, 0);
@@ -1098,6 +1100,112 @@ fn test_subscription_limit_reached() {
         &false,
         &None::<i128>,
      &None::<u64>);
+}
+
+#[test]
+fn test_subscriber_create_cap_admin_endpoints() {
+    let test_env = TestEnv::default();
+    let non_admin = Address::generate(&test_env.env);
+    
+    assert_eq!(test_env.client.get_subscriber_create_cap(), 50);
+
+    test_env.client.set_subscriber_create_cap(&test_env.admin, &10);
+    assert_eq!(test_env.client.get_subscriber_create_cap(), 10);
+
+    let res = test_env.client.try_set_subscriber_create_cap(&non_admin, &20);
+    assert_eq!(res, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_subscriber_create_rate_limit_enforced() {
+    let test_env = TestEnv::default();
+    test_env.client.set_subscriber_create_cap(&test_env.admin, &2);
+
+    let subscriber = Address::generate(&test_env.env);
+    let merchant = Address::generate(&test_env.env);
+
+    let res1 = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>);
+    assert!(res1.is_ok());
+
+    let res2 = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>);
+    assert!(res2.is_ok());
+
+    let res3 = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>);
+    assert_eq!(res3, Err(Ok(Error::SubscriberRateLimited)));
+}
+
+#[test]
+fn test_subscriber_create_rate_limit_rollover() {
+    let test_env = TestEnv::default();
+    test_env.client.set_subscriber_create_cap(&test_env.admin, &1);
+    test_env.env.ledger().with_mut(|li| li.timestamp = T0);
+
+    let subscriber = Address::generate(&test_env.env);
+    let merchant = Address::generate(&test_env.env);
+
+    let res1 = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>);
+    assert!(res1.is_ok());
+
+    let res2 = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>);
+    assert_eq!(res2, Err(Ok(Error::SubscriberRateLimited)));
+
+    test_env.jump(86401);
+
+    let res3 = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>);
+    assert!(res3.is_ok());
+}
+
+#[test]
+fn test_subscriber_create_rate_limit_zero_cap_and_events() {
+    let test_env = TestEnv::default();
+    test_env.client.set_subscriber_create_cap(&test_env.admin, &0);
+
+    let subscriber = Address::generate(&test_env.env);
+    let merchant = Address::generate(&test_env.env);
+
+    let res = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>);
+    assert_eq!(res, Err(Ok(Error::SubscriberRateLimited)));
+
+    let events = test_env.env.events().all();
+    let mut found = false;
+    for (_, topics, data) in events.iter() {
+        if let Some(first) = topics.get(0) {
+            if Symbol::from_val(&test_env.env, &first) == Symbol::new(&test_env.env, "rate_limit_tripped") {
+                let evt: crate::types::RateLimitTrippedEvent = soroban_sdk::FromVal::from_val(&test_env.env, &data);
+                assert_eq!(evt.subscriber, subscriber);
+                found = true;
+            }
+        }
+    }
+    assert!(found, "rate_limit_tripped event missing");
+}
+
+#[test]
+fn test_subscriber_create_rate_limit_admin_bypass() {
+    let test_env = TestEnv::default();
+    test_env.client.set_subscriber_create_cap(&test_env.admin, &0);
+
+    let merchant = Address::generate(&test_env.env);
+
+    let res = test_env.client.try_create_subscription(&test_env.admin, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>);
+    assert!(res.is_ok());
+}
+
+#[test]
+fn test_subscriber_create_rate_limit_from_plan() {
+    let test_env = TestEnv::default();
+    test_env.client.set_subscriber_create_cap(&test_env.admin, &1);
+
+    let subscriber = Address::generate(&test_env.env);
+    let merchant = Address::generate(&test_env.env);
+
+    let plan_id = test_env.client.create_plan_template(&merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>);
+
+    let res1 = test_env.client.try_create_subscription_from_plan(&subscriber, &plan_id);
+    assert!(res1.is_ok());
+
+    let res2 = test_env.client.try_create_subscription_from_plan(&subscriber, &plan_id);
+    assert_eq!(res2, Err(Ok(Error::SubscriberRateLimited)));
 }
 
 #[test]
@@ -2315,6 +2423,7 @@ fn test_compute_next_charge_info_active() {
         start_time: 0,
         expires_at: None,
         grace_start_timestamp: None,
+        cancel_at: None,
     };
     let info = compute_next_charge_info(&env, &sub);
     assert_eq!(info.next_charge_timestamp, T0 + INTERVAL);
@@ -2339,6 +2448,7 @@ fn test_compute_next_charge_info_paused() {
         start_time: 0,
         expires_at: None,
         grace_start_timestamp: None,
+        cancel_at: None,
     };
     let info = compute_next_charge_info(&env, &sub);
     assert!(!info.is_charge_expected);
@@ -2363,6 +2473,7 @@ fn test_compute_next_charge_info_cancelled() {
         start_time: 0,
         expires_at: None,
         grace_start_timestamp: None,
+        cancel_at: None,
     };
     let info = compute_next_charge_info(&env, &sub);
     assert!(!info.is_charge_expected);
@@ -2386,6 +2497,7 @@ fn test_compute_next_charge_info_insufficient_balance() {
         start_time: 0,
         expires_at: None,
         grace_start_timestamp: None,
+        cancel_at: None,
     };
     let info = compute_next_charge_info(&env, &sub);
     assert!(!info.is_charge_expected);
@@ -2517,6 +2629,7 @@ fn test_compute_next_charge_info_overflow_protection() {
         start_time: 0,
         expires_at: None,
         grace_start_timestamp: None,
+        cancel_at: None,
     };
     let info = compute_next_charge_info(&env, &sub);
     assert!(info.is_charge_expected);

--- a/contracts/subscription_vault/src/types.rs
+++ b/contracts/subscription_vault/src/types.rs
@@ -187,7 +187,7 @@ pub enum DataKey {
     BillingStatementAggregate(u32),
     /// Max concurrent active subscriptions allowed for a merchant. Discriminant 45.
     MerchantMaxSubs(Address),
-    /// Guardian voting weights for governance proposals. Discriminant 46.
+    /// Guardians voting weights for governance proposals. Discriminant 46.
     Guardians,
     /// Auto-incrementing proposal ID counter for governance. Discriminant 47.
     NextProposalId,
@@ -213,6 +213,8 @@ pub enum DataKey {
     CouponRedemptions(soroban_sdk::Symbol),
     /// Issued credentials keyed by subscription ID. Discriminant 58.
     Credential(u32),
+    SubscriberCreateCap,
+    SubscriberCreateWindow(Address),
 }
 
 impl DataKey {
@@ -278,6 +280,8 @@ impl DataKey {
             DataKey::Coupon(_) => 56,
             DataKey::CouponRedemptions(_) => 57,
             DataKey::Credential(_) => 58,
+            DataKey::SubscriberCreateCap => 59,
+            DataKey::SubscriberCreateWindow(_) => 60,
         }
     }
 
@@ -328,6 +332,7 @@ pub const KNOWN_INSTANCE_KEY_DISCRIMINANTS: &[u32] = &[
     52, // SubscriptionDispute(u32)
     53, // PayoutSchedule(Address)
     54, // TransferIntent(u32)
+    59,
 ];
 
 /// Returns `true` if `discriminant` is a recognised instance-storage key.
@@ -751,7 +756,9 @@ pub enum Error {
     /// Coupon token does not match the subscription's settlement token.
     CouponTokenMismatch = 6017,
     /// A bulk operation was called with more ids than `BATCH_MAX_SIZE` allows.
-    BatchTooLarge = 6018,
+    // Error 6018 is already defined above in Limits, but kept here for schema matching, see 1006.
+    /// Subscriber has exceeded the rolling 24-hour subscription creation limit.
+    SubscriberRateLimited = 6019,
 
     // --- Merchant Config (7000-7099) ---
     /// Fee basis points exceed maximum allowed value.
@@ -803,6 +810,21 @@ impl Error {
     pub const fn to_code(self) -> u32 {
         self as u32
     }
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SubscriberCreateWindow {
+    pub start_ts: u64,
+    pub count: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct RateLimitTrippedEvent {
+    pub subscriber: Address,
+    pub timestamp: u64,
+    pub schema_version: u32,
 }
 
 /// Event emitted when an admin nonce is consumed by a privileged operation.
@@ -1508,17 +1530,6 @@ pub struct SubscriptionCancelUnscheduledEvent {
     pub subscription_id: u32,
     pub unscheduled_by: Address,
     pub timestamp: u64,
-}
-
-#[contracttype]
-#[derive(Clone, Debug)]
-pub struct SubscriptionPausedEvent {
-    pub subscription_id: u32,
-    pub subscriber: Address,
-    pub merchant: Address,
-    pub authorizer: Address,
-    pub timestamp: u64,
-    pub schema_version: u32,
 }
 
 /// Per-id outcome of a bulk pause/cancel operation.
@@ -2303,6 +2314,8 @@ mod known_keys_tests {
             (DataKey::SubscriptionDispute(1), true),
             (DataKey::PayoutSchedule(a.clone()), true),
             (DataKey::TransferIntent(1), true),
+            (DataKey::SubscriberCreateCap, true),
+            (DataKey::SubscriberCreateWindow(a.clone()), false),
         ]
     }
 
@@ -2329,9 +2342,9 @@ mod known_keys_tests {
 
     #[test]
     fn synthetic_unknown_key_is_rejected() {
-        // Discriminants beyond the highest registered variant (54) can never be
+        // Discriminants beyond the highest registered variant (60) can never be
         // produced by a real `DataKey`, modelling an unknown/legacy key.
-        assert!(!is_known_instance_discriminant(55));
+        assert!(!is_known_instance_discriminant(61));
         assert!(!is_known_instance_discriminant(9_999));
         assert!(!is_known_instance_discriminant(u32::MAX));
     }
@@ -2347,7 +2360,7 @@ mod known_keys_tests {
         assert_known_data_key(&DataKey::Sub(1));
     }
 
-    /// Drift guard: discriminants are unique and cover a contiguous `0..=54`
+    /// Drift guard: discriminants are unique and cover a contiguous `0..=60`
     /// range, so the registry can never silently skip or duplicate a number.
     #[test]
     fn discriminants_are_unique_and_contiguous() {
@@ -2364,6 +2377,7 @@ mod known_keys_tests {
             assert!(!seen[d], "duplicate discriminant {d}");
             seen[d] = true;
         }
+        let n = variants.len();
         assert!(
             seen.iter().all(|&s| s),
             "discriminants are not contiguous 0..={}",
@@ -2399,8 +2413,9 @@ mod known_keys_tests {
         for pair in KNOWN_INSTANCE_KEY_DISCRIMINANTS.windows(2) {
             assert!(pair[0] < pair[1], "allowlist must be sorted and unique");
         }
-        assert!(seen.iter().all(|&s| s));
-        assert_eq!(variants.len(), 51);
+        
+        let variants = all_variants(&env);
+        assert_eq!(variants.len(), 53);
     }
 }
 
@@ -2472,24 +2487,6 @@ pub struct MerchantAddressRotatedEvent {
     pub new_merchant: Address,
     pub subscriptions_updated: u32,
     pub timestamp: u64,
-}
-
-#[contracttype]
-#[derive(Clone, Debug)]
-pub struct CredentialIssuedEvent {
-    pub subscription_id: u32,
-    pub caller: Address,
-    pub timestamp: u64,
-    pub schema_version: u32,
-}
-
-#[contracttype]
-#[derive(Clone, Debug)]
-pub struct CredentialRevokedEvent {
-    pub subscription_id: u32,
-    pub caller: Address,
-    pub timestamp: u64,
-    pub schema_version: u32,
 }
 
 #[contracttype]


### PR DESCRIPTION
Closes #571 

- Introduced new persistent state and the admin configuration key
- Added the new error variant to the `Error` enum
- Defined `RateLimitTrippedEvent` emission logic so that off-chain infrastructure can detect subscription floods and slow reconnaissance
- Exposed a method for the admin to configure the cap in the admin module
- Integrated the validation check at the beginning of the `create_subscription` flow.
- Updated the test suite