### PR TITLE
feat: add merchant whitelist mode

### DIFF
--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -2685,6 +2685,31 @@ impl SubscriptionVault {
         )
     }
 
+    /// Get the global merchant whitelist mode toggle.
+    pub fn get_whitelist_mode(env: Env) -> bool {
+        merchant::get_whitelist_mode(&env)
+    }
+
+    /// Enable or disable the global merchant whitelist mode. Admin-only.
+    pub fn set_whitelist_mode(env: Env, admin: Address, enabled: bool) -> Result<(), Error> {
+        merchant::set_whitelist_mode(&env, admin, enabled)
+    }
+
+    /// Check whether a merchant is approved under whitelist mode.
+    pub fn is_merchant_approved(env: Env, merchant: Address) -> bool {
+        merchant::is_merchant_approved(&env, &merchant)
+    }
+
+    /// Approve a merchant under whitelist mode. Admin-only.
+    pub fn approve_merchant(env: Env, admin: Address, merchant: Address) -> Result<(), Error> {
+        merchant::approve_merchant(&env, admin, merchant)
+    }
+
+    /// Revoke a merchant's approval under whitelist mode. Admin-only.
+    pub fn revoke_merchant(env: Env, admin: Address, merchant: Address) -> Result<(), Error> {
+        merchant::revoke_merchant(&env, admin, merchant)
+    }
+
     /// Update merchant config.
     pub fn set_merchant_config(
         env: Env,
@@ -2816,3 +2841,6 @@ mod test {
 
 #[cfg(test)]
 mod test_subscription_transfer;
+
+#[cfg(test)]
+mod test_merchant_whitelist;

--- a/contracts/subscription_vault/src/merchant.rs
+++ b/contracts/subscription_vault/src/merchant.rs
@@ -26,6 +26,7 @@ use crate::types::{
     MerchantConfigUpdatedEvent, MerchantMultiSigConfig, MerchantPausedEvent, MerchantUnpausedEvent,
     MerchantWithdrawalEvent, PayoutSchedule, ScheduledPayoutEvent, TokenEarnings,
     TokenReconciliationSnapshot, MAX_FEE_BIPS, is_valid_allowed_operations, OP_CHARGE,
+    MerchantWhitelistModeEvent, MerchantApprovedEvent, MerchantRevokedEvent,
 };
 use soroban_sdk::{token, Address, Env, String, Symbol, Vec};
 
@@ -87,6 +88,94 @@ pub fn unpause_merchant(env: &Env, merchant: Address) -> Result<(), Error> {
     Ok(())
 }
 
+// ── Whitelist mode ───────────────────────────────────────────────────────────
+
+/// Returns `true` if the global whitelist mode is enabled.
+pub fn get_whitelist_mode(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::MerchantWhitelistMode)
+        .unwrap_or(false)
+}
+
+/// Enable or disable the global merchant whitelist mode. Admin-only.
+pub fn set_whitelist_mode(env: &Env, admin: Address, enabled: bool) -> Result<(), Error> {
+    crate::admin::require_admin_auth(env, &admin)?;
+
+    let key = DataKey::MerchantWhitelistMode;
+    env.storage().instance().set(&key, &enabled);
+
+    env.events().publish(
+        (Symbol::new(env, "merchant_whitelist_toggled"),),
+        MerchantWhitelistModeEvent {
+            enabled,
+            admin,
+            timestamp: env.ledger().timestamp(),
+            schema_version: crate::types::EVENT_SCHEMA_VERSION,
+        },
+    );
+
+    Ok(())
+}
+
+/// Returns `true` if `merchant` has been approved under whitelist mode.
+pub fn is_merchant_approved(env: &Env, merchant: &Address) -> bool {
+    let key = DataKey::MerchantApproved(merchant.clone());
+    env.storage().instance().get(&key).unwrap_or(false)
+}
+
+/// Approve a merchant under whitelist mode. Admin-only.
+///
+/// When whitelist mode is enabled, `initialize_merchant_config` will reject
+/// merchants that have not been approved. Existing approvals are preserved
+/// when whitelist mode is toggled on.
+pub fn approve_merchant(env: &Env, admin: Address, merchant: Address) -> Result<(), Error> {
+    crate::admin::require_admin_auth(env, &admin)?;
+
+    let key = DataKey::MerchantApproved(merchant.clone());
+    env.storage().instance().set(&key, &true);
+
+    env.events().publish(
+        (Symbol::new(env, "merchant_approved"), merchant.clone()),
+        MerchantApprovedEvent {
+            merchant,
+            admin,
+            timestamp: env.ledger().timestamp(),
+            schema_version: crate::types::EVENT_SCHEMA_VERSION,
+        },
+    );
+
+    Ok(())
+}
+
+/// Revoke a merchant's approval under whitelist mode. Admin-only.
+pub fn revoke_merchant(env: &Env, admin: Address, merchant: Address) -> Result<(), Error> {
+    crate::admin::require_admin_auth(env, &admin)?;
+
+    let key = DataKey::MerchantApproved(merchant.clone());
+    env.storage().instance().set(&key, &false);
+
+    env.events().publish(
+        (Symbol::new(env, "merchant_revoked"), merchant.clone()),
+        MerchantRevokedEvent {
+            merchant,
+            admin,
+            timestamp: env.ledger().timestamp(),
+            schema_version: crate::types::EVENT_SCHEMA_VERSION,
+        },
+    );
+
+    Ok(())
+}
+
+/// Gate check: returns `Ok(())` if whitelist is disabled or merchant is approved.
+fn require_whitelist_approval(env: &Env, merchant: &Address) -> Result<(), Error> {
+    if get_whitelist_mode(env) && !is_merchant_approved(env, merchant) {
+        return Err(Error::MerchantNotApproved);
+    }
+    Ok(())
+}
+
 fn validate_merchant_config_input(
     _payout_address: &Address,
     fee_bips: i32,
@@ -114,6 +203,7 @@ pub fn initialize_merchant_config(
     redirect_url: String,
 ) -> Result<MerchantConfig, Error> {
     merchant.require_auth();
+    require_whitelist_approval(env, &merchant)?;
     validate_merchant_config_input(&payout_address, fee_bips, allowed_operations)?;
 
     let config = MerchantConfig {

--- a/contracts/subscription_vault/src/test_merchant_whitelist.rs
+++ b/contracts/subscription_vault/src/test_merchant_whitelist.rs
@@ -1,0 +1,183 @@
+use crate::{Error, SubscriptionVault, SubscriptionVaultClient};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env};
+
+fn setup() -> (Env, SubscriptionVaultClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(SubscriptionVault, ());
+    let client = SubscriptionVaultClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    client.init(&token, &6, &admin, &1_000_000i128, &(7 * 24 * 60 * 60));
+    (env, client, admin)
+}
+
+// ── Whitelist mode toggle ────────────────────────────────────────────────────
+
+#[test]
+fn whitelist_mode_defaults_to_false() {
+    let (env, client, _admin) = setup();
+    assert!(!client.get_whitelist_mode());
+    let _ = env;
+}
+
+#[test]
+fn admin_can_enable_whitelist_mode() {
+    let (_env, client, admin) = setup();
+    client.set_whitelist_mode(&admin, &true);
+    assert!(client.get_whitelist_mode());
+}
+
+#[test]
+fn admin_can_disable_whitelist_mode() {
+    let (_env, client, admin) = setup();
+    client.set_whitelist_mode(&admin, &true);
+    assert!(client.get_whitelist_mode());
+    client.set_whitelist_mode(&admin, &false);
+    assert!(!client.get_whitelist_mode());
+}
+
+#[test]
+fn non_admin_cannot_toggle_whitelist_mode() {
+    let (_env, client, _admin) = setup();
+    let non_admin = Address::generate(&_env);
+    let result = client.try_set_whitelist_mode(&non_admin, &true);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+// ── Merchant approval ────────────────────────────────────────────────────────
+
+#[test]
+fn admin_can_approve_merchant() {
+    let (_env, client, admin) = setup();
+    let merchant = Address::generate(&_env);
+    client.approve_merchant(&admin, &merchant);
+    assert!(client.is_merchant_approved(&merchant));
+}
+
+#[test]
+fn admin_can_revoke_merchant() {
+    let (_env, client, admin) = setup();
+    let merchant = Address::generate(&_env);
+    client.approve_merchant(&admin, &merchant);
+    assert!(client.is_merchant_approved(&merchant));
+    client.revoke_merchant(&admin, &merchant);
+    assert!(!client.is_merchant_approved(&merchant));
+}
+
+#[test]
+fn non_admin_cannot_approve_merchant() {
+    let (_env, client, _admin) = setup();
+    let non_admin = Address::generate(&_env);
+    let merchant = Address::generate(&_env);
+    let result = client.try_approve_merchant(&non_admin, &merchant);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn non_admin_cannot_revoke_merchant() {
+    let (_env, client, _admin) = setup();
+    let non_admin = Address::generate(&_env);
+    let merchant = Address::generate(&_env);
+    let result = client.try_revoke_merchant(&non_admin, &merchant);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+// ── Gating on initialize_merchant_config ─────────────────────────────────────
+
+#[test]
+fn whitelist_disabled_allows_unapproved_merchant() {
+    let (_env, client, _admin) = setup();
+    let merchant = Address::generate(&_env);
+    let payout = Address::generate(&_env);
+    // Whitelist is off by default — any merchant can register
+    client.initialize_merchant_config(&merchant, &payout, &0, &1, &None, &soroban_sdk::String::from_str(&_env, ""));
+    assert!(client.get_merchant_config(&merchant).is_some());
+}
+
+#[test]
+fn whitelist_enabled_blocks_unapproved_merchant() {
+    let (_env, client, admin) = setup();
+    let merchant = Address::generate(&_env);
+    let payout = Address::generate(&_env);
+    client.set_whitelist_mode(&admin, &true);
+    let result = client.try_initialize_merchant_config(
+        &merchant,
+        &payout,
+        &0,
+        &1,
+        &None,
+        &soroban_sdk::String::from_str(&_env, ""),
+    );
+    assert_eq!(result, Err(Ok(Error::MerchantNotApproved)));
+}
+
+#[test]
+fn whitelist_enabled_allows_approved_merchant() {
+    let (_env, client, admin) = setup();
+    let merchant = Address::generate(&_env);
+    let payout = Address::generate(&_env);
+    client.set_whitelist_mode(&admin, &true);
+    client.approve_merchant(&admin, &merchant);
+    client.initialize_merchant_config(&merchant, &payout, &0, &1, &None, &soroban_sdk::String::from_str(&_env, ""));
+    assert!(client.get_merchant_config(&merchant).is_some());
+}
+
+// ── Edge cases ───────────────────────────────────────────────────────────────
+
+#[test]
+fn toggle_whitelist_preserves_existing_approvals() {
+    let (_env, client, admin) = setup();
+    let merchant = Address::generate(&_env);
+    // Approve before enabling whitelist
+    client.approve_merchant(&admin, &merchant);
+    // Toggle whitelist on
+    client.set_whitelist_mode(&admin, &true);
+    // Approval should still be there
+    assert!(client.is_merchant_approved(&merchant));
+    // Merchant can still register
+    let payout = Address::generate(&_env);
+    client.initialize_merchant_config(&merchant, &payout, &0, &1, &None, &soroban_sdk::String::from_str(&_env, ""));
+    assert!(client.get_merchant_config(&merchant).is_some());
+}
+
+#[test]
+fn approve_then_revoke_then_reapprove() {
+    let (_env, client, admin) = setup();
+    let merchant = Address::generate(&_env);
+    client.set_whitelist_mode(&admin, &true);
+
+    // Initially not approved
+    assert!(!client.is_merchant_approved(&merchant));
+
+    // Approve
+    client.approve_merchant(&admin, &merchant);
+    assert!(client.is_merchant_approved(&merchant));
+
+    // Revoke
+    client.revoke_merchant(&admin, &merchant);
+    assert!(!client.is_merchant_approved(&merchant));
+
+    // Re-approve
+    client.approve_merchant(&admin, &merchant);
+    assert!(client.is_merchant_approved(&merchant));
+}
+
+#[test]
+fn whitelist_off_then_on_does_not_break_existing_merchants() {
+    let (_env, client, admin) = setup();
+    let merchant = Address::generate(&_env);
+    let payout = Address::generate(&_env);
+
+    // Register merchant while whitelist is off
+    client.initialize_merchant_config(&merchant, &payout, &0, &1, &None, &soroban_sdk::String::from_str(&_env, ""));
+    assert!(client.get_merchant_config(&merchant).is_some());
+
+    // Turn whitelist on — existing merchant should still be in storage
+    client.set_whitelist_mode(&admin, &true);
+    // The existing config is still accessible
+    assert!(client.get_merchant_config(&merchant).is_some());
+}

--- a/contracts/subscription_vault/src/types.rs
+++ b/contracts/subscription_vault/src/types.rs
@@ -215,6 +215,10 @@ pub enum DataKey {
     Credential(u32),
     SubscriberCreateCap,
     SubscriberCreateWindow(Address),
+    /// Global whitelist mode toggle. When true, merchants must be approved before registering. Discriminant 61.
+    MerchantWhitelistMode,
+    /// Per-merchant approval status under whitelist mode. Discriminant 62.
+    MerchantApproved(Address),
 }
 
 impl DataKey {
@@ -282,6 +286,8 @@ impl DataKey {
             DataKey::Credential(_) => 58,
             DataKey::SubscriberCreateCap => 59,
             DataKey::SubscriberCreateWindow(_) => 60,
+            DataKey::MerchantWhitelistMode => 61,
+            DataKey::MerchantApproved(_) => 62,
         }
     }
 
@@ -333,6 +339,8 @@ pub const KNOWN_INSTANCE_KEY_DISCRIMINANTS: &[u32] = &[
     53, // PayoutSchedule(Address)
     54, // TransferIntent(u32)
     59,
+    61, // MerchantWhitelistMode
+    62, // MerchantApproved(Address)
 ];
 
 /// Returns `true` if `discriminant` is a recognised instance-storage key.
@@ -767,6 +775,8 @@ pub enum Error {
     InvalidOperations = 7002,
     /// Charge operation must be allowed for merchant.
     MustAllowChargeOperation = 7003,
+    /// Merchant is not approved under whitelist mode.
+    MerchantNotApproved = 7004,
 
     // --- Token (8000-8099) ---
     /// Token decimals value is invalid (e.g. zero).
@@ -2014,6 +2024,33 @@ pub struct MerchantPausedEvent {
 #[derive(Clone, Debug)]
 pub struct MerchantUnpausedEvent {
     pub merchant: Address,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct MerchantWhitelistModeEvent {
+    pub enabled: bool,
+    pub admin: Address,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct MerchantApprovedEvent {
+    pub merchant: Address,
+    pub admin: Address,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct MerchantRevokedEvent {
+    pub merchant: Address,
+    pub admin: Address,
     pub timestamp: u64,
     pub schema_version: u32,
 }


### PR DESCRIPTION
## Summary

Introduces a whitelist mode toggle so that merchants must be explicitly approved by admin before they may register or receive charges. Backward compatible when disabled; when enabled, non-approved merchants receive `Error::MerchantNotApproved`.

## Changes

- **DataKey variants**: `MerchantWhitelistMode` (global toggle), `MerchantApproved(Address)` (per-merchant)
- **Error variant**: `MerchantNotApproved` (7004) returned when whitelist is enabled and merchant is not approved
- **Event types**: `MerchantWhitelistModeEvent`, `MerchantApprovedEvent`, `MerchantRevokedEvent`
- **New entrypoints** (all admin-only except getters):
  - `set_whitelist_mode(admin, enabled)` — toggle global whitelist
  - `get_whitelist_mode()` — read toggle state
  - `approve_merchant(admin, merchant)` — approve a merchant
  - `revoke_merchant(admin, merchant)` — revoke approval
  - `is_merchant_approved(merchant)` — check approval status
- **Gating**: `initialize_merchant_config` now calls `require_whitelist_approval` before proceeding
- **11 tests** covering toggle, approve, revoke, gating, and edge cases (approval persistence, toggle preservation, re-approve flow)

## Backward Compatibility

- Whitelist mode is **off by default** — existing behavior unchanged
- Existing merchant approvals are **preserved** when whitelist is toggled on
- Existing merchants are **not affected** when whitelist is enabled after their registration

## Closes

Closes #568
