### PR TITLE
docs: add threat model to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Soroban smart contracts for **Stellabill** — prepaid USDC subscription billing
 
 ## Table of contents
 
+- [Threat model](#threat-model)
 - [What’s in this repo](#whats-in-this-repo)
 - [Prerequisites](#prerequisites)
 - [Local setup](#local-setup)
@@ -15,6 +16,52 @@ Soroban smart contracts for **Stellabill** — prepaid USDC subscription billing
 - [License](#license)
 
 ---
+
+## Threat model
+
+This repository is anchored by a top-level threat model that defines the trust boundaries, adversary assumptions, and mitigations for the `subscription_vault` contract. It is intended to serve as the primary reference for future audits and security reviews.
+
+### Actors and trust boundaries
+
+- **Admin**: the highest-trust actor. Authorized to charge subscriptions, set configuration, rotate the admin key, enable emergency stop, and recover stranded funds. Admin compromise is a primary threat.
+- **Merchant**: a semi-trusted actor. May withdraw merchant balances, pause/resume/cancel their own subscriptions, and manage merchant-scoped blocklists. Merchants cannot move subscriber funds or modify unrelated subscriptions.
+- **Subscriber**: a semi-trusted actor. May create subscriptions, deposit funds, cancel/pause/resume their own subscriptions, and withdraw remaining balance after cancellation. Subscribers cannot withdraw merchant balances or alter other subscribers' subscriptions.
+- **Oracle contract**: an external price feed. When enabled, the oracle provides pricing data used to resolve token amounts. It is treated as partially untrusted; bad data, stale updates, or drift must be detected and rejected.
+- **Token contract**: the USDC token contract used for deposits and withdrawals. It is treated as untrusted for callback/reentrancy behavior, upgradeability risks, and non-standard transfer mechanics.
+- **Soroban runtime**: trusted to enforce authentication, ledger timestamp semantics, and atomic execution of transactions.
+
+### Assumed adversary capabilities
+
+- Unauthorized callers may attempt to invoke admin-only or ownership-restricted entrypoints.
+- A compromised admin key may attempt forced billing, configuration changes, emergency stop manipulation, or recovery operations.
+- A malicious or buggy token contract may attempt recursive callbacks, transfer failures, fee-on-transfer behavior, or upgradeable semantics changes.
+- An oracle may deliver stale, invalid, or manipulated prices, or drift outside configured freshness bounds.
+- Attackers may attempt double-charging, replay billing requests, or exploit interval boundary edge cases.
+- External observers may rely on events for indexing; the contract must emit consistent, auditable events while avoiding sensitive data leakage.
+
+### Key mitigations by module
+
+- **Authentication and authorization**: strict signer checks for admin-only, merchant-only, and subscriber-only flows. Shared owner checks and explicit caller validation prevent abuse of entrypoints.
+- **Reentrancy protection**: the contract follows a checks-effects-interactions pattern and uses guard logic where external token calls occur, ensuring internal state is updated before any transfer.
+- **Replay protection**: billing and sensitive state-changing operations use idempotency or nonce mechanisms to prevent duplicate execution and ensure once-only semantics.
+- **Safe arithmetic**: all balance updates use checked arithmetic and explicit underflow/overflow handling to preserve invariants and prevent wraparound.
+- **Oracle safety**: oracle pricing is gated by explicit configuration, a maximum age for price data, and rejection of invalid or stale quotes.
+- **Event audit surface**: each lifecycle transition, charge attempt, withdrawal, admin rotation, oracle configuration change, and emergency stop action emits an on-chain event for auditability.
+- **Data segregation**: subscription records store fixed fields per subscription, including subscriber, merchant, token address, interval, status, prepaid balance, and expiration. All calls operate on the stored token per-subscription to prevent cross-token confusion.
+
+### Data classes and event surface
+
+- `Subscription`: captured in storage with fields for `subscriber`, `merchant`, `amount`, `interval_seconds`, `last_payment_timestamp`, `status`, `prepaid_balance`, `expiration`, and `usage_enabled`.
+- `Charge` and `deposit` flows: maintain explicit prepaid balances and status transitions such as `Active`, `Paused`, `Cancelled`, `InsufficientBalance`, and `GracePeriod`.
+- Event surface includes creation, deposit, charge success/failure, withdrawal, admin rotation, oracle configuration updates, emergency stop toggles, and recovery actions.
+
+### New attacker surface for current architecture
+
+- **Upgradeable token contracts**: the token contract may change behavior after deployment, introducing fee-on-transfer, callback semantics, or decimals changes. The contract assumes standard token transfer behavior and defends against callbacks by updating internal state before any external call.
+- **Oracle drift**: an oracle may become stale or return invalid prices. The contract enforces freshness via `max_age_seconds`, rejects invalid quotes, and falls back to safe behavior when oracle pricing is disabled or unavailable.
+- **Admin key compromise**: a compromised admin is treated as a high-severity threat. Mitigations include immediate admin rotation, strong auth checks, and audit-event emission for all admin operations.
+
+For deeper details, see [docs/security.md](docs/security.md).
 
 ## What’s in this repo
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Soroban smart contracts for **Stellabill** — prepaid USDC subscription billing
 
 ## Table of contents
 
+- [Threat model and audit anchor](#threat-model-and-audit-anchor)
 - [What’s in this repo](#whats-in-this-repo)
 - [Prerequisites](#prerequisites)
 - [Local setup](#local-setup)
@@ -13,6 +14,58 @@ Soroban smart contracts for **Stellabill** — prepaid USDC subscription billing
 - [Contributing (open source)](#contributing-open-source)
 - [Project layout](#project-layout)
 - [License](#license)
+
+---
+
+## Threat model and audit anchor
+
+This section is the top-level security reference for the subscription vault and should be treated as the anchor document for future audits, reviews, and incident response. It complements the deeper guidance in [docs/security.md](docs/security.md) and should be read alongside the lifecycle and reentrancy notes in the docs directory.
+
+### Trust boundaries
+
+| Boundary | Primary actors | Trust level | Main concerns | Primary mitigations |
+|----------|----------------|-------------|--------------|---------------------|
+| Admin | Contract admin and upgrade/operational controllers | High privilege, minimal trust | Unauthorized state changes, compromised admin keys, excessive charging or threshold changes | Require explicit auth for privileged entrypoints, keep admin actions narrow, rotate admin keys, and prefer multisig or timelocked controls for critical operations. |
+| Merchant | Subscription merchant receiving payouts | Semi-trusted | Attempting to withdraw more than earned balance, exploiting cross-subscription accounting | Enforce owner checks, validate balances before transfer, and keep withdrawals bounded to the merchant’s accrued funds. |
+| Subscriber | Subscription owner who deposits funds and manages lifecycle | Semi-trusted | Replaying state transitions, circumventing billing windows, attempting invalid status changes | Validate lifecycle transitions, enforce auth per subscription owner, and ensure billing windows and balances are checked before each charge. |
+| Oracle | Optional external price/feed provider for future pricing logic | Untrusted unless cryptographically verified | Stale, manipulated, or inconsistent data | Use freshness windows, bounded price deltas, authentication/signature checks, and fail-closed behavior when data is invalid. |
+| Token contracts | USDC/SAC or any token used for custody and transfers | Untrusted | Reentrancy callbacks, transfer failure, arbitrary token semantics, upgradeable token behavior | Follow CEI ordering, update internal state before external calls, verify balances before transfer, and assume external token logic may behave unexpectedly. |
+
+### Assumed adversary capabilities
+
+The threat model assumes an attacker can:
+
+- Call public entrypoints with arbitrary addresses and attempt to exploit missing or weak authorization.
+- Re-enter the contract or trigger callbacks through token contracts or upgradeable token behavior.
+- Attempt to replay or duplicate charges, manipulate subscription state, or force invalid lifecycle transitions.
+- Exploit arithmetic edge cases such as underflow, overflow, or balance mismatches.
+- Abuse compromised admin keys, stale admin roles, or unauthorized upgrades if they are introduced.
+- Introduce oracle drift, stale price data, or inconsistent data feeds where pricing logic depends on external oracles.
+- Spam the contract with many subscriptions or state changes to increase gas or storage pressure.
+
+### Data classes and event surface
+
+The security properties of the vault depend on a small set of sensitive data classes:
+
+- Subscription state: subscriber, merchant, amount, interval, status, timestamps, prepaid balance, and expiry.
+- Configuration and authorization: admin identity, minimum top-up thresholds, and other operational parameters.
+- Financial state: internal vault balances, merchant withdrawal claims, and balance deltas caused by deposits or charges.
+- External dependencies: token transfer results, oracle inputs, and any future upgrade metadata.
+
+For every state-changing operation, the implementation should emit auditable events that make it possible to reconstruct who acted, what changed, and whether the operation succeeded or failed. At minimum, the event surface should cover subscription creation, funding, charging, cancellation, pausing, resuming, merchant withdrawals, and admin rotation or emergency actions.
+
+### Mitigations by module
+
+- Auth and admin controls: use explicit signer checks, owner validation, and admin rotation paths that remove stale permissions immediately.
+- Billing and lifecycle logic: enforce status-transition rules, check time windows before charging, and prevent double charging or replayed operations.
+- Accounting and safety: use checked arithmetic, validate balances before and after state changes, and ensure any transfer is safe and bounded.
+- Token interaction safety: prefer CEI ordering, preserve internal state before external calls, and treat token contracts as potentially adversarial.
+- Oracle hardening (future): require freshness, signatures or attestation, bounded price deltas, and fail-safe behavior when inputs are invalid.
+- Operational resilience: keep a documented incident response path, protect admin keys, and prefer multisig or timelocked controls for high-impact actions.
+
+### Security assumptions and review checklist
+
+This model assumes the underlying Soroban runtime enforces authorization correctly, the token contract behaves deterministically for transfer semantics, and state updates are committed atomically. The implementation should be reviewed against these assumptions whenever auth, token transfers, accounting, or upgrade paths change. A future audit should verify that the contract remains fail-safe under admin compromise, token callback abuse, replay attempts, stale oracle data, and arithmetic edge conditions.
 
 ---
 


### PR DESCRIPTION
Add a top-level threat model and audit anchor section to README. This includes trust boundaries, assumed adversary capabilities, new attacker surfaces for token upgrades, oracle drift, and admin compromise, plus cross-links to docs/security.md.