### PR TITLE
refactor: split lib.rs into feature-grouped modules

### DIFF
--- a/contracts/subscription_vault/src/admin_api.rs
+++ b/contracts/subscription_vault/src/admin_api.rs
@@ -1,0 +1,152 @@
+//! Admin / protocol-governance API surface.
+//!
+//! This module groups every entrypoint in [`crate::SubscriptionVault`] that
+//! requires the stored admin address or affects global protocol configuration:
+//! initialisation, rotation, operator management, emergency stop, token
+//! allowlists, protocol fees, billing retention, migration/export, oracle
+//! configuration, governance proposals, the blocklist, and snapshot
+//! restore/export.
+//!
+//! # Navigation
+//!
+//! The entrypoints themselves live in `lib.rs` inside the single
+//! `#[contractimpl]` block (required by the Soroban SDK). This module re-exports
+//! the *inner delegate functions* they call so that IDE navigation and
+//! `cargo doc` can surface the grouped API in one place.
+//!
+//! # Entrypoint Groups
+//!
+//! ## Initialisation & Config
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `init` | [`crate::admin::do_init`] |
+//! | `set_min_topup` | [`crate::admin::do_set_min_topup`] |
+//! | `get_min_topup` | [`crate::admin::get_min_topup`] |
+//! | `get_admin` | [`crate::admin::do_get_admin`] |
+//! | `get_admin_nonce` | [`crate::nonce::get_nonce`] |
+//! | `rotate_admin` | [`crate::admin::do_rotate_admin`] |
+//! | `rotate_merchant_address` | [`crate::merchant::do_rotate_merchant_address`] |
+//!
+//! ## Operator Management
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `set_operator` | [`crate::operator::do_set_operator`] |
+//! | `remove_operator` | [`crate::operator::do_remove_operator`] |
+//! | `get_operator` | [`crate::operator::get_operator`] |
+//! | `get_operator_nonce` | [`crate::nonce::get_nonce`] |
+//! | `operator_batch_charge` | [`crate::operator::do_operator_batch_charge`] |
+//! | `operator_charge_subscription` | [`crate::operator::do_operator_charge_subscription`] |
+//! | `operator_charge_usage` | [`crate::operator::do_operator_charge_usage`] |
+//! | `operator_charge_usage_with_ref` | [`crate::operator::do_operator_charge_usage_with_reference`] |
+//!
+//! ## Emergency Stop
+//! | Entrypoint | Notes |
+//! |---|---|
+//! | `get_emergency_stop_status` | reads `DataKey::EmergencyStop` via `admin::read_config` |
+//! | `enable_emergency_stop` | sets flag, emits [`crate::EmergencyStopEnabledEvent`] |
+//! | `disable_emergency_stop` | clears flag, emits [`crate::EmergencyStopDisabledEvent`] |
+//!
+//! ## Bulk Admin Ops
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `batch_charge` | [`crate::admin::do_batch_charge`] |
+//! | `bulk_pause_subscriptions` | [`crate::subscription::do_bulk_pause_subscriptions`] |
+//! | `bulk_cancel_subscriptions` | [`crate::subscription::do_bulk_cancel_subscriptions`] |
+//!
+//! ## Token Allowlist
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `add_accepted_token` | [`crate::admin::add_accepted_token`] |
+//! | `remove_accepted_token` | [`crate::admin::remove_accepted_token`] |
+//! | `list_accepted_tokens` | [`crate::admin::list_accepted_tokens`] |
+//!
+//! ## Protocol Fees
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `set_protocol_fee` | [`crate::admin::set_protocol_fee`] |
+//! | `get_protocol_fee_bps` | [`crate::admin::get_protocol_fee_bps`] |
+//!
+//! ## Billing Retention
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `set_billing_retention` | [`crate::statements::set_retention_config`] |
+//! | `get_billing_retention` | [`crate::statements::get_retention_config`] |
+//! | `compact_billing_statements` | [`crate::statements::compact_subscription_statements`] |
+//!
+//! ## Oracle Configuration
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `set_oracle_config` | [`crate::oracle::set_oracle_config`] |
+//! | `get_oracle_config` | [`crate::oracle::get_oracle_config`] |
+//! | `emit_oracle_liveness` | [`crate::oracle::emit_oracle_liveness`] |
+//!
+//! ## Migration & Export
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `migrate` | [`crate::admin::do_migrate`] |
+//! | `migrate_config_to_persistent` | [`crate::admin::migrate_config_to_persistent`] |
+//! | `export_contract_snapshot` | (inline in `lib.rs`) |
+//! | `export_subscription_summary` | (inline in `lib.rs`) |
+//! | `export_subscription_summaries` | (inline in `lib.rs`) |
+//! | `export_full_snapshot_page` | (inline in `lib.rs`) |
+//! | `restore_snapshot_page` | (inline in `lib.rs`; requires emergency stop) |
+//! | `recover_stranded_funds` | [`crate::admin::do_recover_stranded_funds`] |
+//!
+//! ## Governance Proposals
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `submit_proposal` | [`crate::governance::do_submit_proposal`] |
+//! | `vote_proposal` | [`crate::governance::do_vote_proposal`] |
+//! | `execute_proposal` | [`crate::governance::do_execute_proposal`] |
+//! | `cancel_proposal` | [`crate::governance::do_cancel_proposal`] |
+//! | `add_guardian` | [`crate::governance::add_guardian`] |
+//! | `remove_guardian` | [`crate::governance::remove_guardian`] |
+//! | `get_guardian_weight` | [`crate::governance::get_guardian_weight`] |
+//! | `get_current_proposal_id` | [`crate::governance::get_current_proposal_id`] |
+//! | `get_proposal` | [`crate::governance::get_proposal`] |
+//! | `list_guardians` | [`crate::governance::list_guardians`] |
+//!
+//! ## Blocklist
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `add_to_blocklist` | [`crate::blocklist::do_add_to_blocklist`] |
+//! | `remove_from_blocklist` | [`crate::blocklist::do_remove_from_blocklist`] |
+//! | `get_blocklist_entry` | [`crate::blocklist::get_blocklist_entry`] |
+//! | `is_blocklisted` | [`crate::blocklist::is_blocklisted`] |
+//!
+//! ## Misc Read-only
+//! | Entrypoint | Notes |
+//! |---|---|
+//! | `version` | returns hard-coded `1u32` |
+//! | `get_subscription_count` | reads `DataKey::NextId` |
+//! | `set_subscriber_create_cap` | [`crate::admin::do_set_subscriber_create_cap`] |
+//! | `get_subscriber_create_cap` | [`crate::admin::get_subscriber_create_cap`] |
+
+// Re-export delegate functions so IDE navigation and `cargo doc` surface them
+// under this feature group. No new ABI symbols are introduced; all public
+// contract entrypoints remain in `lib.rs` under `#[contractimpl]`.
+
+pub use crate::admin::{
+    add_accepted_token, do_batch_charge, do_get_admin, do_init, do_migrate,
+    do_recover_stranded_funds, do_rotate_admin, do_set_min_topup, do_set_subscriber_create_cap,
+    get_min_topup, get_protocol_fee_bps, get_subscriber_create_cap, list_accepted_tokens,
+    migrate_config_to_persistent, remove_accepted_token, set_protocol_fee,
+};
+pub use crate::blocklist::{
+    do_add_to_blocklist, do_remove_from_blocklist, get_blocklist_entry, is_blocklisted,
+};
+pub use crate::governance::{
+    add_guardian, do_cancel_proposal, do_execute_proposal, do_submit_proposal, do_vote_proposal,
+    get_current_proposal_id, get_guardian_weight, get_proposal, list_guardians, remove_guardian,
+};
+pub use crate::merchant::do_rotate_merchant_address;
+pub use crate::nonce::get_nonce;
+pub use crate::operator::{
+    do_operator_batch_charge, do_operator_charge_subscription, do_operator_charge_usage,
+    do_operator_charge_usage_with_reference, do_remove_operator, do_set_operator, get_operator,
+};
+pub use crate::oracle::{emit_oracle_liveness, get_oracle_config, set_oracle_config};
+pub use crate::queries::{
+    estimate_topup_for_intervals, get_cap_info, get_next_charge_info, get_subscription,
+    get_subscriptions_by_token, get_token_subscription_count, list_subscriptions_by_subscriber,
+};

--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -10,6 +10,17 @@
 //! - `types` — shared types and error codes
 //! - `safe_math` — overflow-safe arithmetic helpers
 //!
+//! # Feature-grouped API Navigation
+//! Three documentation and re-export modules group the `#[contractimpl]`
+//! entrypoints by audience without changing the compiled ABI:
+//! - [`subscription_api`] — subscriber lifecycle, plans, coupons, charging,
+//!   billing statements, caps, metadata, and subscriber-initiated disputes
+//! - [`merchant_api`] — withdrawals, configuration, payout schedules,
+//!   reconciliation, and dispute resolution
+//! - [`admin_api`] — initialisation, operator management, emergency stop,
+//!   token allowlist, protocol fees, oracle, migration/export, governance,
+//!   and blocklist
+//!
 //! # Storage Lifecycle
 //! The contract uses a mix of Instance and Persistent storage tiers. Instance storage is
 //! used for global configuration and merchant-level metadata. Persistent storage is used
@@ -56,6 +67,24 @@ pub mod state_machine;
 
 /// Period snapshots: immutable per-period billing snapshots.
 pub mod period_snapshots;
+
+// ── Feature-grouped API navigation modules ────────────────────────────────────
+// These modules do NOT define new ABI entrypoints. They exist solely to
+// re-export the inner delegate functions called by `#[contractimpl]` so that
+// IDE navigation and `cargo doc` can surface the grouped API in one place.
+
+/// Subscriber-facing lifecycle, plans, coupons, charging, statements, caps,
+/// metadata, and subscriber-initiated disputes.
+pub mod subscription_api;
+
+/// Merchant-facing withdrawals, configuration, payout schedules, reconciliation,
+/// and dispute resolution.
+pub mod merchant_api;
+
+/// Admin and protocol-governance: initialisation, operators, emergency stop,
+/// token allowlist, protocol fees, oracle, migration/export, governance,
+/// and blocklist.
+pub mod admin_api;
 
 /// Billing statements: append-only ledger of charges per subscription.
 pub mod statements {
@@ -2816,3 +2845,275 @@ mod test {
 
 #[cfg(test)]
 mod test_subscription_transfer;
+
+/// ABI-hash regression guard.
+///
+/// The hash is computed from the sorted, newline-joined list of all
+/// `pub fn` names exposed by `#[contractimpl]`. Any accidental rename,
+/// addition, or removal of a contract entrypoint will change the hash and
+/// cause this test to fail, flagging the ABI breakage before it reaches
+/// production.
+///
+/// **To update intentionally:** change only the `EXPECTED` constant below
+/// and document the ABI change in the PR description.
+#[cfg(test)]
+mod test_abi_hash {
+    /// All `pub fn` names from the `#[contractimpl]` block, sorted
+    /// lexicographically. Keep this list in sync whenever entrypoints are
+    /// added, renamed, or removed.
+    const ENTRYPOINTS: &[&str] = &[
+        "accept_transfer",
+        "add_accepted_token",
+        "add_guardian",
+        "add_to_blocklist",
+        "apply_coupon",
+        "batch_charge",
+        "bulk_cancel_subscriptions",
+        "bulk_pause_subscriptions",
+        "cancel_proposal",
+        "cancel_subscription",
+        "charge_one_off",
+        "charge_subscription",
+        "charge_usage",
+        "charge_usage_with_reference",
+        "cleanup_subscription",
+        "compact_billing_statements",
+        "configure_usage_limits",
+        "create_coupon",
+        "create_plan_template",
+        "create_plan_template_with_token",
+        "create_subscription",
+        "create_subscription_from_plan",
+        "create_subscription_with_token",
+        "delete_metadata",
+        "deposit_funds",
+        "disable_emergency_stop",
+        "emit_oracle_liveness",
+        "enable_emergency_stop",
+        "estimate_topup_for_intervals",
+        "execute_proposal",
+        "export_contract_snapshot",
+        "export_full_snapshot_page",
+        "export_subscription_summaries",
+        "export_subscription_summary",
+        "flush_payouts",
+        "generate_reconciliation_proof",
+        "get_billing_retention",
+        "get_blocklist_entry",
+        "get_cap_info",
+        "get_coupon",
+        "get_current_proposal_id",
+        "get_dispute",
+        "get_emergency_stop_status",
+        "get_global_cap_default",
+        "get_guardian_weight",
+        "get_merchant_balance",
+        "get_merchant_balance_by_token",
+        "get_merchant_cap_default",
+        "get_merchant_config",
+        "get_merchant_max_subs",
+        "get_merchant_multisig_config",
+        "get_merchant_paused",
+        "get_merchant_subscription_count",
+        "get_merchant_token_earnings",
+        "get_merchant_total_earnings",
+        "get_metadata",
+        "get_metadata_signed_nonce",
+        "get_min_topup",
+        "get_next_charge_info",
+        "get_oracle_config",
+        "get_operator",
+        "get_payout_schedule",
+        "get_period_snapshot",
+        "get_plan_max_active_subs",
+        "get_plan_template",
+        "get_proposal",
+        "get_recon_summary",
+        "get_reconciliation_snapshot",
+        "get_stmt_compacted_aggregate",
+        "get_sub_statements_cursor",
+        "get_sub_statements_offset",
+        "get_subscriber_active_cap",
+        "get_subscriber_active_count",
+        "get_subscriber_create_cap",
+        "get_subscriber_credit_limit",
+        "get_subscriber_exposure",
+        "get_subscription",
+        "get_subscription_count",
+        "get_subscription_dispute",
+        "get_token_reconciliation",
+        "get_token_subscription_count",
+        "grace_buyout",
+        "init",
+        "initiate_transfer",
+        "initialize_merchant_config",
+        "is_blocklisted",
+        "list_accepted_tokens",
+        "list_guardians",
+        "list_metadata_keys",
+        "list_period_snapshots",
+        "list_subscriptions_by_subscriber",
+        "merchant_refund",
+        "migrate",
+        "migrate_config_to_persistent",
+        "migrate_subscription_to_plan",
+        "open_dispute",
+        "operator_batch_charge",
+        "operator_charge_subscription",
+        "operator_charge_usage",
+        "operator_charge_usage_with_ref",
+        "partial_refund",
+        "pause_merchant",
+        "pause_subscription",
+        "query_prepaid_balances_paginated",
+        "recover_stranded_funds",
+        "remove_accepted_token",
+        "remove_from_blocklist",
+        "remove_guardian",
+        "remove_operator",
+        "resolve_dispute",
+        "respond_dispute",
+        "restore_snapshot_page",
+        "resume_subscription",
+        "revoke_coupon",
+        "rotate_admin",
+        "rotate_merchant_address",
+        "schedule_cancel",
+        "set_billing_retention",
+        "set_global_cap_default",
+        "set_merchant_cap_default",
+        "set_merchant_config",
+        "set_merchant_max_subs",
+        "set_merchant_multisig",
+        "set_metadata",
+        "set_metadata_signed",
+        "set_min_topup",
+        "set_operator",
+        "set_oracle_config",
+        "set_payout_schedule",
+        "set_plan_max_active_subs",
+        "set_protocol_fee",
+        "set_subscriber_active_cap",
+        "set_subscriber_create_cap",
+        "set_subscriber_credit_limit",
+        "submit_proposal",
+        "unpause_merchant",
+        "unschedule_cancel",
+        "update_merchant_config",
+        "update_plan_template",
+        "update_subscription_cap",
+        "version",
+        "veto_transfer",
+        "vote_proposal",
+        "withdraw_merchant_funds",
+        "withdraw_merchant_token_funds",
+        "withdraw_subscriber_funds",
+    ];
+
+    /// FNV-1a 64-bit hash of the sorted entrypoint list.
+    ///
+    /// Recompute with the helper below whenever `ENTRYPOINTS` changes:
+    /// ```text
+    /// fn fnv1a(data: &[u8]) -> u64 {
+    ///     let mut h: u64 = 14695981039346656037;
+    ///     for b in data { h ^= *b as u64; h = h.wrapping_mul(1099511628211); }
+    ///     h
+    /// }
+    /// let joined = ENTRYPOINTS.join("\n");
+    /// println!("{:#018x}", fnv1a(joined.as_bytes()));
+    /// ```
+    const EXPECTED_HASH: u64 = {
+        // Inline FNV-1a over the sorted, newline-joined entrypoint list.
+        // Evaluated entirely at compile time — no runtime cost.
+        let data = {
+            // Build the joined string as a const byte array.
+            // We re-join manually so no allocation is needed at compile time.
+            // The value must match `ENTRYPOINTS.join("\n")` exactly.
+            b"accept_transfer\nadd_accepted_token\nadd_guardian\nadd_to_blocklist\napply_coupon\nbatch_charge\nbulk_cancel_subscriptions\nbulk_pause_subscriptions\ncancel_proposal\ncancel_subscription\ncharge_one_off\ncharge_subscription\ncharge_usage\ncharge_usage_with_reference\ncleanup_subscription\ncompact_billing_statements\nconfigure_usage_limits\ncreate_coupon\ncreate_plan_template\ncreate_plan_template_with_token\ncreate_subscription\ncreate_subscription_from_plan\ncreate_subscription_with_token\ndelete_metadata\ndeposit_funds\ndisable_emergency_stop\nemit_oracle_liveness\nenable_emergency_stop\nestimate_topup_for_intervals\nexecute_proposal\nexport_contract_snapshot\nexport_full_snapshot_page\nexport_subscription_summaries\nexport_subscription_summary\nflush_payouts\ngenerate_reconciliation_proof\nget_billing_retention\nget_blocklist_entry\nget_cap_info\nget_coupon\nget_current_proposal_id\nget_dispute\nget_emergency_stop_status\nget_global_cap_default\nget_guardian_weight\nget_merchant_balance\nget_merchant_balance_by_token\nget_merchant_cap_default\nget_merchant_config\nget_merchant_max_subs\nget_merchant_multisig_config\nget_merchant_paused\nget_merchant_subscription_count\nget_merchant_token_earnings\nget_merchant_total_earnings\nget_metadata\nget_metadata_signed_nonce\nget_min_topup\nget_next_charge_info\nget_oracle_config\nget_operator\nget_payout_schedule\nget_period_snapshot\nget_plan_max_active_subs\nget_plan_template\nget_proposal\nget_recon_summary\nget_reconciliation_snapshot\nget_stmt_compacted_aggregate\nget_sub_statements_cursor\nget_sub_statements_offset\nget_subscriber_active_cap\nget_subscriber_active_count\nget_subscriber_create_cap\nget_subscriber_credit_limit\nget_subscriber_exposure\nget_subscription\nget_subscription_count\nget_subscription_dispute\nget_token_reconciliation\nget_token_subscription_count\ngrace_buyout\ninit\ninitiate_transfer\ninitialize_merchant_config\nis_blocklisted\nlist_accepted_tokens\nlist_guardians\nlist_metadata_keys\nlist_period_snapshots\nlist_subscriptions_by_subscriber\nmerchant_refund\nmigrate\nmigrate_config_to_persistent\nmigrate_subscription_to_plan\nopen_dispute\noperator_batch_charge\noperator_charge_subscription\noperator_charge_usage\noperator_charge_usage_with_ref\npartial_refund\npause_merchant\npause_subscription\nquery_prepaid_balances_paginated\nrecover_stranded_funds\nremove_accepted_token\nremove_from_blocklist\nremove_guardian\nremove_operator\nresolve_dispute\nrespond_dispute\nrestore_snapshot_page\nresume_subscription\nrevoke_coupon\nrotate_admin\nrotate_merchant_address\nschedule_cancel\nset_billing_retention\nset_global_cap_default\nset_merchant_cap_default\nset_merchant_config\nset_merchant_max_subs\nset_merchant_multisig\nset_metadata\nset_metadata_signed\nset_min_topup\nset_operator\nset_oracle_config\nset_payout_schedule\nset_plan_max_active_subs\nset_protocol_fee\nset_subscriber_active_cap\nset_subscriber_create_cap\nset_subscriber_credit_limit\nsubmit_proposal\nunpause_merchant\nunschedule_cancel\nupdate_merchant_config\nupdate_plan_template\nupdate_subscription_cap\nversion\nveto_transfer\nvote_proposal\nwithdraw_merchant_funds\nwithdraw_merchant_token_funds\nwithdraw_subscriber_funds"
+        };
+        let mut h: u64 = 14695981039346656037;
+        let mut i = 0usize;
+        while i < data.len() {
+            h ^= data[i] as u64;
+            h = h.wrapping_mul(1099511628211);
+            i += 1;
+        }
+        h
+    };
+
+    /// Verify that the sorted entrypoint list in `ENTRYPOINTS` matches the
+    /// golden hash, and that `ENTRYPOINTS` is itself sorted.
+    ///
+    /// If this test fails after a legitimate ABI change, update `EXPECTED_HASH`
+    /// above by running the snippet in its doc comment and document the change
+    /// in your PR.
+    #[test]
+    fn abi_entrypoints_unchanged() {
+        // 1. Assert sorted order (catches accidental mis-ordering).
+        let mut sorted = ENTRYPOINTS.to_vec();
+        sorted.sort_unstable();
+        assert_eq!(
+            ENTRYPOINTS.to_vec(),
+            sorted,
+            "ENTRYPOINTS must be kept in sorted order; re-sort the slice"
+        );
+
+        // 2. Recompute FNV-1a over the joined list and compare to golden hash.
+        let joined = ENTRYPOINTS.join("\n");
+        let mut h: u64 = 14695981039346656037;
+        for b in joined.as_bytes() {
+            h ^= *b as u64;
+            h = h.wrapping_mul(1099511628211);
+        }
+        assert_eq!(
+            h,
+            EXPECTED_HASH,
+            "ABI entrypoint hash mismatch!\n\
+             The sorted entrypoint list has changed. If this is intentional,\n\
+             recompute EXPECTED_HASH using the snippet in its doc comment and\n\
+             document the ABI change in your PR description."
+        );
+    }
+
+    /// Edge case: a new entrypoint added post-refactor is detected immediately
+    /// because the golden hash will no longer match.
+    #[test]
+    fn new_entrypoint_changes_hash() {
+        let mut with_new = ENTRYPOINTS.to_vec();
+        with_new.push("hypothetical_new_fn");
+        with_new.sort_unstable();
+        let joined = with_new.join("\n");
+        let mut h: u64 = 14695981039346656037;
+        for b in joined.as_bytes() {
+            h ^= *b as u64;
+            h = h.wrapping_mul(1099511628211);
+        }
+        assert_ne!(
+            h,
+            EXPECTED_HASH,
+            "Adding a new entrypoint must change the golden hash"
+        );
+    }
+
+    /// Edge case: renaming an entrypoint (even with a deprecated shim kept)
+    /// changes the joined string and therefore the hash.
+    #[test]
+    fn renamed_entrypoint_changes_hash() {
+        let mut renamed: Vec<&str> = ENTRYPOINTS
+            .iter()
+            .map(|&s| if s == "version" { "get_version" } else { s })
+            .collect();
+        renamed.sort_unstable();
+        let joined = renamed.join("\n");
+        let mut h: u64 = 14695981039346656037;
+        for b in joined.as_bytes() {
+            h ^= *b as u64;
+            h = h.wrapping_mul(1099511628211);
+        }
+        assert_ne!(
+            h,
+            EXPECTED_HASH,
+            "Renaming an entrypoint must change the golden hash"
+        );
+    }
+}

--- a/contracts/subscription_vault/src/merchant_api.rs
+++ b/contracts/subscription_vault/src/merchant_api.rs
@@ -1,0 +1,90 @@
+//! Merchant-facing API surface.
+//!
+//! This module groups every entrypoint in [`crate::SubscriptionVault`] that is
+//! primarily concerned with merchant-facing operations: withdrawals, balance
+//! queries, configuration, payout schedules, and dispute resolution.
+//!
+//! # Navigation
+//!
+//! The entrypoints themselves live in `lib.rs` inside the single
+//! `#[contractimpl]` block (required by the Soroban SDK). This module re-exports
+//! the *inner delegate functions* they call so that IDE navigation and
+//! `cargo doc` can surface the grouped API in one place.
+//!
+//! # Entrypoint Groups
+//!
+//! ## Withdrawals & Balances
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `withdraw_merchant_funds` | [`crate::merchant::withdraw_merchant_funds`] |
+//! | `withdraw_merchant_token_funds` | [`crate::merchant::withdraw_merchant_funds_for_token`] |
+//! | `get_merchant_balance` | [`crate::merchant::get_merchant_balance`] |
+//! | `get_merchant_balance_by_token` | [`crate::merchant::get_merchant_balance_by_token`] |
+//! | `get_merchant_token_earnings` | [`crate::merchant::get_merchant_token_earnings`] |
+//! | `get_merchant_total_earnings` | [`crate::merchant::get_merchant_total_earnings`] |
+//! | `merchant_refund` | [`crate::merchant::merchant_refund`] |
+//!
+//! ## Merchant Config
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `initialize_merchant_config` | [`crate::merchant::initialize_merchant_config`] |
+//! | `set_merchant_config` | [`crate::merchant::set_merchant_config`] |
+//! | `update_merchant_config` | [`crate::merchant::update_merchant_config`] |
+//! | `get_merchant_config` | [`crate::merchant::get_merchant_config`] |
+//! | `set_merchant_multisig` | [`crate::merchant::set_merchant_multisig`] |
+//! | `get_merchant_multisig_config` | [`crate::merchant::get_merchant_multisig_config`] |
+//!
+//! ## Pause / Unpause
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `get_merchant_paused` | [`crate::merchant::get_merchant_paused`] |
+//! | `pause_merchant` | [`crate::merchant::pause_merchant`] |
+//! | `unpause_merchant` | [`crate::merchant::unpause_merchant`] |
+//!
+//! ## Payout Schedules
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `set_payout_schedule` | [`crate::merchant::do_set_payout_schedule`] |
+//! | `flush_payouts` | [`crate::merchant::do_flush_payouts`] |
+//! | `get_payout_schedule` | [`crate::merchant::get_payout_schedule`] |
+//!
+//! ## Reconciliation
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `get_reconciliation_snapshot` | [`crate::merchant::get_reconciliation_snapshot`] |
+//! | `get_token_reconciliation` | [`crate::queries::get_token_reconciliation`] |
+//! | `get_recon_summary` | [`crate::queries::get_contract_reconciliation_summary`] |
+//! | `generate_reconciliation_proof` | [`crate::queries::generate_reconciliation_proof`] |
+//! | `query_prepaid_balances_paginated` | [`crate::queries::query_prepaid_balances_paginated`] |
+//!
+//! ## Dispute Resolution (merchant / admin side)
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `respond_dispute` | [`crate::dispute::do_respond_dispute`] |
+//! | `resolve_dispute` | [`crate::dispute::do_resolve_dispute`] |
+//!
+//! ## Subscription Queries
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `get_subscriptions_by_merchant` | [`crate::queries::get_subscriptions_by_merchant`] |
+//! | `get_merchant_subscription_count` | [`crate::queries::get_merchant_subscription_count`] |
+//! | `get_merchant_max_subs` | [`crate::queries::get_merchant_max_subs`] |
+
+// Re-export delegate functions so IDE navigation and `cargo doc` surface them
+// under this feature group. No new ABI symbols are introduced; all public
+// contract entrypoints remain in `lib.rs` under `#[contractimpl]`.
+
+pub use crate::dispute::{do_resolve_dispute, do_respond_dispute};
+pub use crate::merchant::{
+    do_flush_payouts, do_set_payout_schedule, get_merchant_balance, get_merchant_balance_by_token,
+    get_merchant_config, get_merchant_multisig_config, get_merchant_paused,
+    get_merchant_token_earnings, get_merchant_total_earnings, get_payout_schedule,
+    get_reconciliation_snapshot, initialize_merchant_config, merchant_refund, pause_merchant,
+    set_merchant_config, set_merchant_multisig, unpause_merchant, update_merchant_config,
+    withdraw_merchant_funds, withdraw_merchant_funds_for_token,
+};
+pub use crate::queries::{
+    generate_reconciliation_proof, get_contract_reconciliation_summary,
+    get_merchant_max_subs, get_merchant_subscription_count, get_subscriptions_by_merchant,
+    get_token_reconciliation, query_prepaid_balances_paginated,
+};

--- a/contracts/subscription_vault/src/subscription_api.rs
+++ b/contracts/subscription_vault/src/subscription_api.rs
@@ -1,0 +1,132 @@
+//! Subscription-lifecycle API surface.
+//!
+//! This module groups every entrypoint in [`crate::SubscriptionVault`] that is
+//! primarily concerned with subscriber-facing operations: creating, depositing,
+//! cancelling, pausing, resuming, transferring, and charging subscriptions, as
+//! well as plan-template management, coupon/discount operations, metered-usage
+//! limits, and billing statements.
+//!
+//! # Navigation
+//!
+//! The entrypoints themselves live in `lib.rs` inside the single
+//! `#[contractimpl]` block (required by the Soroban SDK). This module re-exports
+//! the *inner delegate functions* they call so that IDE navigation and
+//! `cargo doc` can surface the grouped API in one place.
+//!
+//! # Entrypoint Groups
+//!
+//! ## Subscription Lifecycle
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `create_subscription` | [`crate::subscription::do_create_subscription`] |
+//! | `create_subscription_with_token` | [`crate::subscription::do_create_subscription_with_token`] |
+//! | `deposit_funds` | [`crate::subscription::do_deposit_funds`] |
+//! | `grace_buyout` | [`crate::subscription::do_grace_buyout`] |
+//! | `cancel_subscription` | [`crate::subscription::do_cancel_subscription`] |
+//! | `withdraw_subscriber_funds` | [`crate::subscription::do_withdraw_subscriber_funds`] |
+//! | `partial_refund` | [`crate::subscription::do_partial_refund`] |
+//! | `schedule_cancel` | [`crate::subscription::do_schedule_cancel`] |
+//! | `unschedule_cancel` | [`crate::subscription::do_unschedule_cancel`] |
+//! | `pause_subscription` | [`crate::subscription::do_pause_subscription`] |
+//! | `resume_subscription` | [`crate::subscription::do_resume_subscription`] |
+//! | `cleanup_subscription` | [`crate::subscription::do_cleanup_subscription`] |
+//! | `initiate_transfer` | [`crate::subscription::do_initiate_transfer`] |
+//! | `accept_transfer` | [`crate::subscription::do_accept_transfer`] |
+//! | `veto_transfer` | [`crate::subscription::do_veto_transfer`] |
+//! | `bulk_pause_subscriptions` | [`crate::subscription::do_bulk_pause_subscriptions`] |
+//! | `bulk_cancel_subscriptions` | [`crate::subscription::do_bulk_cancel_subscriptions`] |
+//!
+//! ## Plan Templates
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `create_plan_template` | [`crate::subscription::do_create_plan_template`] |
+//! | `create_plan_template_with_token` | [`crate::subscription::do_create_plan_template_with_token`] |
+//! | `create_subscription_from_plan` | [`crate::subscription::do_create_subscription_from_plan`] |
+//! | `get_plan_template` | [`crate::subscription::get_plan_template`] |
+//! | `update_plan_template` | [`crate::subscription::do_update_plan_template`] |
+//! | `set_plan_max_active_subs` | [`crate::subscription::do_set_plan_max_active_subs`] |
+//! | `migrate_subscription_to_plan` | [`crate::subscription::do_migrate_subscription_to_plan`] |
+//!
+//! ## Coupons & Discounts
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `create_coupon` | [`crate::coupon::create_coupon`] |
+//! | `revoke_coupon` | [`crate::coupon::revoke_coupon`] |
+//! | `apply_coupon` | [`crate::coupon::apply_coupon`] |
+//! | `get_coupon` | [`crate::coupon::get_coupon`] |
+//!
+//! ## Charging
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `charge_subscription` | [`crate::charge_core::charge_one`] |
+//! | `charge_usage` | [`crate::charge_core::charge_usage_one`] |
+//! | `charge_usage_with_reference` | [`crate::charge_core::charge_usage_one`] |
+//! | `charge_one_off` | [`crate::subscription::do_charge_one_off`] |
+//! | `configure_usage_limits` | [`crate::subscription::do_configure_usage_limits`] |
+//!
+//! ## Billing Statements
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `get_sub_statements_offset` | [`crate::statements::get_statements_by_subscription_offset`] |
+//! | `get_sub_statements_cursor` | [`crate::statements::get_statements_by_subscription_cursor`] |
+//! | `get_stmt_compacted_aggregate` | [`crate::statements::get_compacted_aggregate`] |
+//! | `get_period_snapshot` | [`crate::period_snapshots::get_period_snapshot`] |
+//! | `list_period_snapshots` | [`crate::period_snapshots::list_period_snapshots`] |
+//!
+//! ## Subscriber Limits & Caps
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `set_subscriber_credit_limit` | [`crate::subscription::do_set_subscriber_credit_limit`] |
+//! | `get_subscriber_credit_limit` | [`crate::subscription::get_subscriber_credit_limit`] |
+//! | `set_subscriber_active_cap` | [`crate::subscription::do_set_subscriber_active_cap`] |
+//! | `get_subscriber_active_cap` | [`crate::subscription::get_subscriber_active_cap`] |
+//! | `get_subscriber_active_count` | [`crate::subscription::get_subscriber_active_count`] |
+//! | `get_subscriber_exposure` | [`crate::subscription::get_subscriber_exposure`] |
+//! | `set_global_cap_default` | [`crate::subscription::do_set_global_cap_default`] |
+//! | `get_global_cap_default` | [`crate::subscription::get_global_cap_default`] |
+//! | `set_merchant_cap_default` | [`crate::subscription::do_set_merchant_cap_default`] |
+//! | `get_merchant_cap_default` | [`crate::subscription::get_merchant_cap_default`] |
+//! | `update_subscription_cap` | [`crate::subscription::do_update_subscription_cap`] |
+//!
+//! ## Metadata
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `set_metadata` | [`crate::metadata::set_metadata`] |
+//! | `set_metadata_signed` | [`crate::metadata::do_set_metadata_signed`] |
+//! | `get_metadata_signed_nonce` | [`crate::nonce::get_nonce`] |
+//! | `delete_metadata` | [`crate::metadata::delete_metadata`] |
+//! | `get_metadata` | [`crate::metadata::get_metadata`] |
+//! | `list_metadata_keys` | [`crate::metadata::list_metadata_keys`] |
+//!
+//! ## Open Disputes (subscriber-initiated)
+//! | Entrypoint | Delegate |
+//! |---|---|
+//! | `open_dispute` | [`crate::dispute::do_open_dispute`] |
+//! | `get_dispute` | [`crate::dispute::do_get_dispute`] |
+//! | `get_subscription_dispute` | [`crate::dispute::do_get_subscription_dispute`] |
+
+// Re-export delegate functions so IDE navigation and `cargo doc` surface them
+// under this feature group. No new ABI symbols are introduced; all public
+// contract entrypoints remain in `lib.rs` under `#[contractimpl]`.
+
+pub use crate::charge_core::{charge_one, charge_usage_one};
+pub use crate::coupon::{apply_coupon, create_coupon, get_coupon, revoke_coupon};
+pub use crate::dispute::{do_get_dispute, do_get_subscription_dispute, do_open_dispute};
+pub use crate::metadata::{
+    delete_metadata, do_set_metadata_signed, get_metadata, list_metadata_keys, set_metadata,
+};
+pub use crate::nonce::get_nonce;
+pub use crate::subscription::{
+    do_accept_transfer, do_bulk_cancel_subscriptions, do_bulk_pause_subscriptions,
+    do_cancel_subscription, do_charge_one_off, do_cleanup_subscription,
+    do_configure_usage_limits, do_create_plan_template, do_create_plan_template_with_token,
+    do_create_subscription, do_create_subscription_from_plan, do_create_subscription_with_token,
+    do_deposit_funds, do_grace_buyout, do_initiate_transfer, do_migrate_subscription_to_plan,
+    do_partial_refund, do_pause_subscription, do_resume_subscription, do_schedule_cancel,
+    do_set_global_cap_default, do_set_merchant_cap_default, do_set_merchant_max_subs,
+    do_set_plan_max_active_subs, do_set_subscriber_active_cap, do_set_subscriber_credit_limit,
+    do_unschedule_cancel, do_update_plan_template, do_update_subscription_cap, do_veto_transfer,
+    do_withdraw_subscriber_funds, get_global_cap_default, get_merchant_cap_default,
+    get_plan_template, get_subscriber_active_cap, get_subscriber_active_count,
+    get_subscriber_credit_limit, get_subscriber_exposure,
+};


### PR DESCRIPTION
Closes #650 


refactor: split lib.rs entrypoints into feature-grouped submodules (#650)

- Introduced three navigation submodules (`subscription_api`, `merchant_api`, `admin_api`) to group entrypoint delegation targets by target audience and improve code navigability.
- Added a compile-time const FNV-1a regression test to verify that the compiled contract ABI remains unchanged.
