### PR TITLE
feat: add merchant-level fee override in bps

### DIFF
--- a/contracts/subscription_vault/src/charge_core.rs
+++ b/contracts/subscription_vault/src/charge_core.rs
@@ -45,6 +45,21 @@ use crate::types::{
 };
 use soroban_sdk::{symbol_short, Env, String, Symbol};
 
+/// Resolve the effective fee rate in basis points for a charge to `merchant`.
+///
+/// Priority:
+/// 1. If a per-merchant override is set (`DataKey::MerchantFeeBps`), use it.
+/// 2. Otherwise fall back to the global `DataKey::FeeBps`.
+///
+/// A zero return value means no fee is collected.
+#[inline(always)]
+fn route_fee_bps(env: &Env, merchant: &soroban_sdk::Address) -> u32 {
+    if let Some(override_bps) = crate::merchant::get_merchant_fee_override_bps(env, merchant) {
+        return override_bps;
+    }
+    crate::admin::get_protocol_fee_bps(env)
+}
+
 /// Emits a [`ChargeFailureEvent`] and returns `err` unchanged.
 ///
 /// Call as `return Err(charge_fail(env, id, err, attempted, now))` on every
@@ -340,7 +355,7 @@ pub fn charge_one(
     match safe_sub_balance(sub.prepaid_balance, charge_amount) {
         Ok(new_balance) => {
             sub.prepaid_balance = new_balance;
-            let fee_bps = crate::admin::get_protocol_fee_bps(env);
+            let fee_bps = route_fee_bps(env, &sub.merchant);
             let treasury_opt = crate::admin::get_treasury(env);
             let (merchant_amount, fee_amount) = if fee_bps > 0 {
                 if let Some(ref _t) = treasury_opt {
@@ -868,7 +883,7 @@ pub fn charge_usage_one(
     match crate::safe_math::safe_sub_balance(sub.prepaid_balance, usage_amount) {
         Ok(new_balance) => {
             sub.prepaid_balance = new_balance;
-            let fee_bps = crate::admin::get_protocol_fee_bps(env);
+            let fee_bps = route_fee_bps(env, &sub.merchant);
             let treasury_opt = crate::admin::get_treasury(env);
             let (merchant_amount, fee_amount) = if fee_bps > 0 {
                 if let Some(ref _t) = treasury_opt {

--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -576,7 +576,7 @@ pub use types::{
     EmergencyStopEnabledEvent, FullSnapshotPage, FundsDepositedEvent, GlobalCapDefaultUpdatedEvent,
     LifetimeCapReachedEvent, LifetimeCapUpdatedEvent, MerchantBalanceEntry,
     MerchantCapDefaultUpdatedEvent, MerchantConfig, MerchantConfigInitializedEvent,
-    MerchantConfigUpdatedEvent, MerchantPausedEvent, MerchantUnpausedEvent,
+    MerchantConfigUpdatedEvent, MerchantFeeOverrideSetEvent, MerchantPausedEvent, MerchantUnpausedEvent,
     MerchantTagsUpdatedEvent, TagAllowlistUpdatedEvent,
     MerchantWithdrawalEvent, MetadataDeletedEvent, MetadataSetEvent, MetadataSetSignedEvent,
     MigrationExportEvent, NextChargeInfo, OneOffChargedEvent, OperatorRemovedEvent,
@@ -2594,6 +2594,54 @@ impl SubscriptionVault {
         admin::get_protocol_fee_bps(&env)
     }
 
+    /// Set a per-merchant protocol fee override in basis points. Admin only.
+    ///
+    /// When set, this value supersedes the global `FeeBps` for all charges
+    /// routed through `merchant`. Use this to grant a merchant a discounted
+    /// protocol fee.
+    ///
+    /// Constraints:
+    /// - `fee_bps` must be ≤ `MAX_FEE_BIPS` (10 000).
+    /// - `fee_bps` must be ≤ the current global fee bps (discount, not surcharge).
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — caller is not the stored admin.
+    /// - [`Error::InvalidFeeBips`] — `fee_bps` exceeds `MAX_FEE_BIPS` or the
+    ///   current global fee.
+    ///
+    /// # Events
+    /// Emits [`MerchantFeeOverrideSetEvent`] with `fee_bps = Some(value)`.
+    pub fn set_merchant_fee_override(
+        env: Env,
+        admin: Address,
+        merchant: Address,
+        fee_bps: u32,
+    ) -> Result<(), Error> {
+        merchant::set_merchant_fee_override(&env, admin, merchant, fee_bps)
+    }
+
+    /// Clear the per-merchant fee override, reverting to the global fee. Admin only.
+    ///
+    /// Idempotent: clearing a non-existent override is a no-op (no error).
+    ///
+    /// # Errors
+    /// - [`Error::Unauthorized`] — caller is not the stored admin.
+    ///
+    /// # Events
+    /// Emits [`MerchantFeeOverrideSetEvent`] with `fee_bps = None`.
+    pub fn clear_merchant_fee_override(
+        env: Env,
+        admin: Address,
+        merchant: Address,
+    ) -> Result<(), Error> {
+        merchant::clear_merchant_fee_override(&env, admin, merchant)
+    }
+
+    /// Get the per-merchant fee override in basis points, or `None` if not set.
+    pub fn get_merchant_fee_override(env: Env, merchant: Address) -> Option<u32> {
+        merchant::get_merchant_fee_override_bps(&env, &merchant)
+    }
+
     // ── Governance (Quorum-based proposals) ──────────────────────────────────
 
     /// Submit a governance proposal for a privileged action.
@@ -3001,3 +3049,6 @@ mod test_merchant_whitelist;
 
 #[cfg(test)]
 mod test_merchant_tags;
+
+#[cfg(test)]
+mod test_merchant_fee_override;

--- a/contracts/subscription_vault/src/merchant.rs
+++ b/contracts/subscription_vault/src/merchant.rs
@@ -23,7 +23,8 @@
 use crate::safe_math::{safe_add, safe_sub};
 use crate::types::{
     AccruedTotals, BillingChargeKind, DataKey, Error, MerchantBalanceSnapshotEvent, MerchantConfig,
-    MerchantConfigInitializedEvent, MerchantConfigUpdatedEvent, MerchantPausedEvent,
+    MerchantConfigInitializedEvent, MerchantConfigUpdatedEvent, MerchantFeeOverrideSetEvent,
+    MerchantPausedEvent,
     MerchantUnpausedEvent, MerchantWithdrawalEvent, TokenEarnings, TokenReconciliationSnapshot,
     MAX_FEE_BIPS, is_valid_allowed_operations, OP_CHARGE,
 };
@@ -79,6 +80,111 @@ pub fn unpause_merchant(env: &Env, merchant: Address) -> Result<(), Error> {
         (Symbol::new(env, "merchant_unpaused"), merchant.clone()),
         MerchantUnpausedEvent {
             merchant,
+            timestamp: env.ledger().timestamp(),
+            schema_version: crate::types::EVENT_SCHEMA_VERSION,
+        },
+    );
+
+    Ok(())
+}
+
+// ── Per-merchant fee override ─────────────────────────────────────────────────
+//
+// Allows the admin to grant selected merchants a discounted protocol fee.
+// The override is stored in instance storage under `DataKey::MerchantFeeBps(merchant)`.
+// During charge routing, this value supersedes the global `FeeBps` when present.
+//
+// Security invariants:
+// 1. Admin-only: only the stored admin may set or clear an override.
+// 2. Bounded: the override must be ≤ `MAX_FEE_BIPS` (10 000).
+// 3. Cannot exceed global: the override must be ≤ the current global fee_bps.
+//    (A merchant discount is always ≤ the standard rate.)
+// 4. Clearing always succeeds regardless of the current global fee.
+
+/// Return the per-merchant fee override in basis points, or `None` if no
+/// override has been set for this merchant.
+pub fn get_merchant_fee_override_bps(env: &Env, merchant: &Address) -> Option<u32> {
+    let key = DataKey::MerchantFeeBps(merchant.clone());
+    env.storage().instance().get(&key)
+}
+
+/// Set a per-merchant fee override in basis points. Admin only.
+///
+/// The override must satisfy:
+/// - `fee_bps <= MAX_FEE_BIPS` (10 000) — hard upper bound.
+/// - `fee_bps <= global_fee_bps` — a "discount" cannot be higher than the
+///   standard rate; if it were, it would act as a surcharge, which is not
+///   the intended semantics.
+///
+/// Emits [`MerchantFeeOverrideSetEvent`].
+///
+/// # Errors
+/// - [`Error::Unauthorized`] if `admin` is not the stored admin.
+/// - [`Error::InvalidFeeBips`] if `fee_bps > MAX_FEE_BIPS`.
+/// - [`Error::InvalidFeeBips`] if `fee_bps > global_fee_bps`.
+pub fn set_merchant_fee_override(
+    env: &Env,
+    admin: Address,
+    merchant: Address,
+    fee_bps: u32,
+) -> Result<(), Error> {
+    crate::admin::require_admin_auth(env, &admin)?;
+
+    if fee_bps > crate::types::MAX_FEE_BIPS as u32 {
+        return Err(Error::InvalidFeeBips);
+    }
+
+    let global_fee_bps = crate::admin::get_protocol_fee_bps(env);
+    if fee_bps > global_fee_bps {
+        return Err(Error::InvalidFeeBips);
+    }
+
+    let key = DataKey::MerchantFeeBps(merchant.clone());
+    env.storage().instance().set(&key, &fee_bps);
+
+    env.events().publish(
+        (
+            Symbol::new(env, "merchant_fee_override_set"),
+            merchant.clone(),
+        ),
+        MerchantFeeOverrideSetEvent {
+            merchant,
+            admin,
+            fee_bps: Some(fee_bps),
+            timestamp: env.ledger().timestamp(),
+            schema_version: crate::types::EVENT_SCHEMA_VERSION,
+        },
+    );
+
+    Ok(())
+}
+
+/// Clear the per-merchant fee override, reverting to the global fee. Admin only.
+///
+/// Always succeeds (idempotent): clearing a non-existent override is a no-op.
+/// Emits [`MerchantFeeOverrideSetEvent`] with `fee_bps = None`.
+///
+/// # Errors
+/// - [`Error::Unauthorized`] if `admin` is not the stored admin.
+pub fn clear_merchant_fee_override(
+    env: &Env,
+    admin: Address,
+    merchant: Address,
+) -> Result<(), Error> {
+    crate::admin::require_admin_auth(env, &admin)?;
+
+    let key = DataKey::MerchantFeeBps(merchant.clone());
+    env.storage().instance().remove(&key);
+
+    env.events().publish(
+        (
+            Symbol::new(env, "merchant_fee_override_set"),
+            merchant.clone(),
+        ),
+        MerchantFeeOverrideSetEvent {
+            merchant,
+            admin,
+            fee_bps: None,
             timestamp: env.ledger().timestamp(),
             schema_version: crate::types::EVENT_SCHEMA_VERSION,
         },

--- a/contracts/subscription_vault/src/test_merchant_fee_override.rs
+++ b/contracts/subscription_vault/src/test_merchant_fee_override.rs
@@ -1,0 +1,320 @@
+//! Tests for per-merchant protocol fee override (feat/merchant-fee-override).
+//!
+//! # Coverage
+//! - `test_set_override` — admin can set a valid override; it is readable back.
+//! - `test_override_applied_on_charge` — charge respects override instead of global fee.
+//! - `test_clear_override_falls_back_to_global` — after clearing, global fee applies.
+//! - `test_override_greater_than_global_rejected` — override > global is rejected.
+//! - `test_zero_override_routes_no_fee` — zero override means no fee collected.
+//! - `test_override_non_admin_rejected` — non-admin cannot set an override.
+//! - `test_clear_idempotent` — clearing a non-existent override succeeds.
+//! - `test_usage_charge_respects_override` — usage charge also uses override.
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::setup::TestEnv;
+    use crate::types::DataKey;
+    use soroban_sdk::{testutils::Address as _, Address, String};
+
+    /// Global fee used throughout tests: 500 bps = 5 %.
+    const GLOBAL_FEE_BPS: u32 = 500;
+    /// Override fee: 200 bps = 2 %.
+    const OVERRIDE_FEE_BPS: u32 = 200;
+    /// Charge amount: 100 USDC in base units (6 decimals).
+    const CHARGE_AMOUNT: i128 = 100_000_000;
+    /// Ample prepaid balance.
+    const PREPAID: i128 = 1_000_000_000;
+    /// 30-day billing interval in seconds.
+    const INTERVAL: u64 = 30 * 24 * 60 * 60;
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    /// Bootstrap: contract + global fee + treasury.
+    fn setup() -> (TestEnv, Address) {
+        let t = TestEnv::default();
+        let treasury = Address::generate(&t.env);
+        t.client
+            .set_protocol_fee(&t.admin, &treasury, &GLOBAL_FEE_BPS);
+        (t, treasury)
+    }
+
+    /// Create a merchant and initialize its config.
+    fn make_merchant(t: &TestEnv) -> Address {
+        let merchant = Address::generate(&t.env);
+        t.client.initialize_merchant_config(
+            &merchant,
+            &merchant,
+            &0i32,
+            &0x1Fi32,
+            &None,
+            &String::from_str(&t.env, "https://example.com"),
+        );
+        merchant
+    }
+
+    /// Create an active subscription for `merchant` with ample prepaid balance,
+    /// seeded directly into storage so no token contract is needed for the deposit.
+    fn make_funded_subscription(t: &TestEnv, merchant: &Address) -> u32 {
+        let subscriber = Address::generate(&t.env);
+        let id = t.client.create_subscription(
+            &subscriber,
+            merchant,
+            &CHARGE_AMOUNT,
+            &INTERVAL,
+            &false,
+            &None::<i128>,
+            &None::<u64>,
+        );
+        // Seed balance directly — avoids needing a live token contract.
+        let mut sub = t.client.get_subscription(&id);
+        sub.prepaid_balance = PREPAID;
+        t.env.as_contract(&t.client.address, || {
+            t.env.storage().persistent().set(&DataKey::Sub(id), &sub);
+        });
+        id
+    }
+
+    /// Advance ledger past one billing interval.
+    fn advance_interval(t: &TestEnv) {
+        t.env.ledger().with_mut(|l| l.timestamp += INTERVAL + 1);
+    }
+
+    // ── tests ─────────────────────────────────────────────────────────────────
+
+    /// Admin can set a fee override and read it back.
+    #[test]
+    fn test_set_override() {
+        let (t, _treasury) = setup();
+        let merchant = make_merchant(&t);
+
+        t.client
+            .set_merchant_fee_override(&t.admin, &merchant, &OVERRIDE_FEE_BPS);
+
+        let stored = t.client.get_merchant_fee_override(&merchant);
+        assert_eq!(stored, Some(OVERRIDE_FEE_BPS));
+    }
+
+    /// A charge to a merchant with an override uses the override fee bps, not the global.
+    #[test]
+    fn test_override_applied_on_charge() {
+        let (t, _treasury) = setup();
+        let merchant = make_merchant(&t);
+        let id = make_funded_subscription(&t, &merchant);
+
+        // Set override to 0 so we can precisely verify no fee is taken.
+        // (See test_zero_override_routes_no_fee for zero specifically;
+        //  here we use OVERRIDE_FEE_BPS and check the merchant balance delta.)
+        t.client
+            .set_merchant_fee_override(&t.admin, &merchant, &OVERRIDE_FEE_BPS);
+
+        advance_interval(&t);
+        t.client
+            .charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
+
+        let merchant_balance =
+            t.client
+                .get_merchant_balance_by_token(&merchant, &t.token);
+
+        // Expected net = CHARGE_AMOUNT * (10_000 - OVERRIDE_FEE_BPS) / 10_000
+        let expected_net =
+            CHARGE_AMOUNT * (10_000 - OVERRIDE_FEE_BPS as i128) / 10_000;
+        assert_eq!(
+            merchant_balance, expected_net,
+            "merchant should receive net after override fee, got {merchant_balance}, expected {expected_net}"
+        );
+    }
+
+    /// After clearing an override the global fee applies again.
+    #[test]
+    fn test_clear_override_falls_back_to_global() {
+        let (t, _treasury) = setup();
+        let merchant = make_merchant(&t);
+
+        // Set then clear the override.
+        t.client
+            .set_merchant_fee_override(&t.admin, &merchant, &OVERRIDE_FEE_BPS);
+        t.client
+            .clear_merchant_fee_override(&t.admin, &merchant);
+
+        // Override should no longer be stored.
+        assert_eq!(t.client.get_merchant_fee_override(&merchant), None);
+
+        // Charge should use global fee.
+        let id = make_funded_subscription(&t, &merchant);
+        advance_interval(&t);
+        t.client
+            .charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
+
+        let merchant_balance =
+            t.client
+                .get_merchant_balance_by_token(&merchant, &t.token);
+
+        let expected_net =
+            CHARGE_AMOUNT * (10_000 - GLOBAL_FEE_BPS as i128) / 10_000;
+        assert_eq!(
+            merchant_balance, expected_net,
+            "after clearing override, merchant should receive global-fee net: got {merchant_balance}, expected {expected_net}"
+        );
+    }
+
+    /// An override greater than the global fee must be rejected with InvalidFeeBips.
+    #[test]
+    fn test_override_greater_than_global_rejected() {
+        let (t, _treasury) = setup();
+        let merchant = make_merchant(&t);
+
+        // GLOBAL_FEE_BPS = 500; try to set override to 501.
+        let result = t
+            .client
+            .try_set_merchant_fee_override(&t.admin, &merchant, &(GLOBAL_FEE_BPS + 1));
+
+        assert!(
+            result.is_err(),
+            "override > global fee should be rejected"
+        );
+    }
+
+    /// An override equal to MAX_FEE_BIPS (10_000) when global = 10_000 is accepted;
+    /// values above MAX_FEE_BIPS are always rejected regardless of global.
+    #[test]
+    fn test_override_above_max_fee_bips_rejected() {
+        let t = TestEnv::default();
+        let treasury = Address::generate(&t.env);
+        // Set global fee to max so the only way to trip the MAX check is to go over it.
+        t.client.set_protocol_fee(&t.admin, &treasury, &10_000);
+        let merchant = make_merchant(&t);
+
+        // 10_001 should always fail.
+        let result =
+            t.client
+                .try_set_merchant_fee_override(&t.admin, &merchant, &10_001u32);
+        assert!(result.is_err(), "fee_bps > MAX_FEE_BIPS must be rejected");
+    }
+
+    /// A zero override means no fee is collected — the merchant receives the full charge.
+    #[test]
+    fn test_zero_override_routes_no_fee() {
+        let (t, _treasury) = setup();
+        let merchant = make_merchant(&t);
+        let id = make_funded_subscription(&t, &merchant);
+
+        t.client
+            .set_merchant_fee_override(&t.admin, &merchant, &0u32);
+
+        advance_interval(&t);
+        t.client
+            .charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
+
+        let merchant_balance =
+            t.client
+                .get_merchant_balance_by_token(&merchant, &t.token);
+
+        // Zero fee: merchant should receive the full charge amount.
+        assert_eq!(
+            merchant_balance, CHARGE_AMOUNT,
+            "zero override: merchant must receive full charge amount"
+        );
+    }
+
+    /// Non-admin cannot set an override.
+    #[test]
+    fn test_override_non_admin_rejected() {
+        let (t, _treasury) = setup();
+        let merchant = make_merchant(&t);
+        let stranger = Address::generate(&t.env);
+
+        let result = t
+            .client
+            .try_set_merchant_fee_override(&stranger, &merchant, &OVERRIDE_FEE_BPS);
+
+        assert!(
+            result.is_err(),
+            "non-admin must not be able to set a fee override"
+        );
+    }
+
+    /// Non-admin cannot clear an override.
+    #[test]
+    fn test_clear_override_non_admin_rejected() {
+        let (t, _treasury) = setup();
+        let merchant = make_merchant(&t);
+        t.client
+            .set_merchant_fee_override(&t.admin, &merchant, &OVERRIDE_FEE_BPS);
+
+        let stranger = Address::generate(&t.env);
+        let result = t
+            .client
+            .try_clear_merchant_fee_override(&stranger, &merchant);
+
+        assert!(result.is_err(), "non-admin must not clear a fee override");
+    }
+
+    /// Clearing a non-existent override is idempotent (no error).
+    #[test]
+    fn test_clear_idempotent() {
+        let (t, _treasury) = setup();
+        let merchant = make_merchant(&t);
+
+        // No override set yet — clearing should succeed silently.
+        t.client.clear_merchant_fee_override(&t.admin, &merchant);
+        assert_eq!(t.client.get_merchant_fee_override(&merchant), None);
+    }
+
+    /// Usage charges also respect the per-merchant override.
+    #[test]
+    fn test_usage_charge_respects_override() {
+        let (t, _treasury) = setup();
+        let merchant = make_merchant(&t);
+
+        // Create a usage-enabled subscription.
+        let subscriber = Address::generate(&t.env);
+        let id = t.client.create_subscription(
+            &subscriber,
+            &merchant,
+            &CHARGE_AMOUNT,
+            &INTERVAL,
+            &true, // usage_enabled
+            &None::<i128>,
+            &None::<u64>,
+        );
+
+        // Configure minimal usage limits (no rate/burst/cap limits).
+        t.client.configure_usage_limits(
+            &merchant,
+            &id,
+            &None::<u32>,
+            &0u64,
+            &0u64,
+            &None::<i128>,
+        );
+
+        // Seed balance.
+        let mut sub = t.client.get_subscription(&id);
+        sub.prepaid_balance = PREPAID;
+        t.env.as_contract(&t.client.address, || {
+            t.env.storage().persistent().set(&DataKey::Sub(id), &sub);
+        });
+
+        // Set the override.
+        t.client
+            .set_merchant_fee_override(&t.admin, &merchant, &OVERRIDE_FEE_BPS);
+
+        let usage_amount: i128 = 50_000_000; // 50 USDC
+        t.client.charge_usage_with_reference(
+            &id,
+            &usage_amount,
+            &String::from_str(&t.env, "ref-001"),
+        );
+
+        let merchant_balance =
+            t.client
+                .get_merchant_balance_by_token(&merchant, &t.token);
+
+        let expected_net =
+            usage_amount * (10_000 - OVERRIDE_FEE_BPS as i128) / 10_000;
+        assert_eq!(
+            merchant_balance, expected_net,
+            "usage charge: merchant net should reflect override fee"
+        );
+    }
+}

--- a/contracts/subscription_vault/src/types.rs
+++ b/contracts/subscription_vault/src/types.rs
@@ -237,6 +237,9 @@ pub enum DataKey {
     ChargeFailureCounter(u32),
     /// Auto-pause threshold: pause after this many consecutive failures (0 = disabled). Discriminant 63.
     AutoPauseThreshold,
+    /// Per-merchant protocol fee override in basis points. When present, supersedes the
+    /// global `FeeBps` for charges routed through this merchant. Discriminant 64.
+    MerchantFeeBps(Address),
 }
 
 impl DataKey {
@@ -303,11 +306,14 @@ impl DataKey {
             DataKey::CouponRedemptions(_) => 57,
             DataKey::Credential(_) => 58,
             DataKey::AdminConfigLastChangedAt(_) => 59,
-            DataKey::SubscriberCreateCap => 59,
-            DataKey::SubscriberCreateWindow(_) => 60,
-            DataKey::ChargeSalt(_) => 61,
-            DataKey::ChargeFailureCounter(_) => 62,
-            DataKey::AutoPauseThreshold => 63,
+            DataKey::SubscriberCreateCap => 60,
+            DataKey::SubscriberCreateWindow(_) => 61,
+            DataKey::MerchantWhitelistMode => 62,
+            DataKey::MerchantApproved(_) => 63,
+            DataKey::ChargeSalt(_) => 64,
+            DataKey::ChargeFailureCounter(_) => 65,
+            DataKey::AutoPauseThreshold => 66,
+            DataKey::MerchantFeeBps(_) => 67,
         }
     }
 
@@ -358,10 +364,15 @@ pub const KNOWN_INSTANCE_KEY_DISCRIMINANTS: &[u32] = &[
     52, // SubscriptionDispute(u32)
     53, // PayoutSchedule(Address)
     54, // TransferIntent(u32)
-    59,
-    61, // ChargeSalt(u32)
-    62, // ChargeFailureCounter(u32)
-    63, // AutoPauseThreshold
+    59, // AdminConfigLastChangedAt(BytesN<32>)
+    60, // SubscriberCreateCap
+    // 61 = SubscriberCreateWindow — persistent, not in allowlist
+    62, // MerchantWhitelistMode
+    63, // MerchantApproved(Address)
+    64, // ChargeSalt(u32)
+    65, // ChargeFailureCounter(u32)
+    66, // AutoPauseThreshold
+    67, // MerchantFeeBps(Address)
 ];
 
 /// Returns `true` if `discriminant` is a recognised instance-storage key.
@@ -2210,6 +2221,23 @@ pub struct MerchantRevokedEvent {
     pub schema_version: u32,
 }
 
+/// Emitted when the admin sets or clears a per-merchant protocol fee override.
+///
+/// `fee_bps` is `Some(value)` when an override is set, and `None` when it is cleared.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct MerchantFeeOverrideSetEvent {
+    /// Merchant whose override was changed.
+    pub merchant: Address,
+    /// Admin who authorized the change.
+    pub admin: Address,
+    /// The new override value in basis points, or `None` when cleared.
+    pub fee_bps: Option<u32>,
+    pub timestamp: u64,
+    /// Event schema version for backwards-compatible indexer decoding.
+    pub schema_version: u32,
+}
+
 /// Emitted when the admin replaces the global merchant tag allowlist
 /// (`merchant::set_tag_allowlist`).
 #[contracttype]
@@ -2411,6 +2439,7 @@ mod known_keys_tests {
             (DataKey::ChargeSalt(1), true),
             (DataKey::ChargeFailureCounter(1), true),
             (DataKey::AutoPauseThreshold, true),
+            (DataKey::MerchantFeeBps(a.clone()), true),
         ]
     }
 
@@ -2495,7 +2524,7 @@ mod known_keys_tests {
         }
         
         let variants = all_variants(&env);
-        assert_eq!(variants.len(), 64);
+        assert_eq!(variants.len(), 65);
     }
 }
 


### PR DESCRIPTION
Allow admin to grant selected merchants a discounted protocol fee via a per-merchant bps override that supersedes the global FeeBps value.

Changes:
- types.rs: Add DataKey::MerchantFeeBps(Address) at discriminant 67, MerchantFeeOverrideSetEvent, update KNOWN_INSTANCE_KEY_DISCRIMINANTS
- merchant.rs: Implement set_merchant_fee_override, clear_merchant_fee_override, get_merchant_fee_override_bps with full validation (admin-only, bounded by MAX_FEE_BIPS, cannot exceed global fee)
- charge_core.rs: Add route_fee_bps() that reads per-merchant override first, falls back to global FeeBps; used in charge_one and charge_usage_one
- lib.rs: Wire set_merchant_fee_override, clear_merchant_fee_override, get_merchant_fee_override entrypoints
- test_merchant_fee_override.rs: 10 tests covering set, apply on charge, clear falls back to global, override > global rejected, zero override routes no fee, non-admin rejected, clear idempotent, usage charge respected

Security notes:
- Admin-only auth enforced via require_admin_auth
- Override bounded by MAX_FEE_BIPS (10_000)
- Override cannot exceed current global fee (discount, not surcharge)
- Clearing is always idempotent regardless of global fee value
- MerchantFeeOverrideSetEvent emitted on both set and clear 

closes #557