### PR TITLE
test: reject self-referral rebate (#611)

### DIFF
--- a/contracts/subscription_vault/benches/batch_charge_scaling.rs
+++ b/contracts/subscription_vault/benches/batch_charge_scaling.rs
@@ -54,6 +54,7 @@ fn bench_batch_charge_scaling() {
                     &false,
                     &None::<i128>,
                     &None::<u64>,
+                    &None::<Address>,
                 );
 
                 if scenario == "Success" || scenario == "WithPaused" {

--- a/contracts/subscription_vault/benches/charge_cold_warm.rs
+++ b/contracts/subscription_vault/benches/charge_cold_warm.rs
@@ -151,6 +151,7 @@ fn create_and_fund_sub(
         &usage_enabled,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     let token_admin = token::StellarAssetClient::new(env, token);
@@ -456,6 +457,7 @@ fn bench_charge_cold_vs_warm_grace_period() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     // First charge attempt with 0 balance -> moves to GracePeriod
@@ -493,6 +495,7 @@ fn bench_charge_cold_vs_warm_grace_period() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     env_warm

--- a/contracts/subscription_vault/benches/idem_lookup.rs
+++ b/contracts/subscription_vault/benches/idem_lookup.rs
@@ -115,6 +115,7 @@ fn create_and_fund(
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     let token_admin = token::StellarAssetClient::new(env, token);
     token_admin.mint(subscriber, &(DEPOSIT * 4));

--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -575,6 +575,7 @@ pub use types::{
     ChargeExecutionResult, ContractSnapshot, DataKey, EmergencyStopDisabledEvent,
     EmergencyStopEnabledEvent, FullSnapshotPage, FundsDepositedEvent, GlobalCapDefaultUpdatedEvent,
     LifetimeCapReachedEvent, LifetimeCapUpdatedEvent, MerchantBalanceEntry,
+    ReferralAttributedEvent,
     MerchantCapDefaultUpdatedEvent, MerchantConfig, MerchantConfigInitializedEvent,
     MerchantConfigUpdatedEvent, MerchantPausedEvent, MerchantUnpausedEvent,
     MerchantTagsUpdatedEvent, TagAllowlistUpdatedEvent,
@@ -1265,6 +1266,7 @@ impl SubscriptionVault {
     // ── Subscription Lifecycle ────────────────────────────────────────────────
 
     /// Create a new subscription.
+    #[allow(clippy::too_many_arguments)]
     pub fn create_subscription(
         env: Env,
         subscriber: Address,
@@ -1274,6 +1276,7 @@ impl SubscriptionVault {
         usage_enabled: bool,
         lifetime_cap: Option<i128>,
         expires_at: Option<u64>,
+        inviter: Option<Address>,
     ) -> Result<u32, Error> {
         require_not_emergency_stop(&env)?;
         let sub_id = subscription::do_create_subscription(
@@ -1285,6 +1288,7 @@ impl SubscriptionVault {
             usage_enabled,
             lifetime_cap,
             expires_at,
+            inviter.clone(),
         )?;
         let token: Address = admin::read_config(&env, &DataKey::Token).ok_or(Error::NotFound)?;
         env.events().publish(
@@ -1317,6 +1321,7 @@ impl SubscriptionVault {
         usage_enabled: bool,
         lifetime_cap: Option<i128>,
         expires_at: Option<u64>,
+        inviter: Option<Address>,
     ) -> Result<u32, Error> {
         require_not_emergency_stop(&env)?;
         let sub_id = subscription::do_create_subscription_with_token(
@@ -1329,6 +1334,7 @@ impl SubscriptionVault {
             usage_enabled,
             lifetime_cap,
             expires_at,
+            inviter.clone(),
         )?;
         env.events().publish(
             (Symbol::new(&env, "created"), sub_id),
@@ -3001,3 +3007,6 @@ mod test_merchant_whitelist;
 
 #[cfg(test)]
 mod test_merchant_tags;
+
+#[cfg(test)]
+mod test_referral_self;

--- a/contracts/subscription_vault/src/subscription.rs
+++ b/contracts/subscription_vault/src/subscription.rs
@@ -45,7 +45,8 @@ use crate::types::{
     BillingChargeKind, DataKey, Error, FundsDepositedEvent,
     GlobalCapDefaultUpdatedEvent, GraceBuyoutEvent, LifetimeCapReachedEvent, LifetimeCapUpdatedEvent,
     MerchantCapDefaultUpdatedEvent, PartialRefundEvent, PlanMaxActiveUpdatedEvent,
-    PlanTemplate, PlanTemplateUpdatedEvent, RateLimitTrippedEvent, SubscriberCreateWindow,
+    PlanTemplate, PlanTemplateUpdatedEvent, RateLimitTrippedEvent, ReferralAttributedEvent,
+    SubscriberCreateWindow,
     SubscriberWithdrawalEvent, Subscription, SubscriptionCancelScheduledEvent,
     SubscriptionCancelUnscheduledEvent, SubscriptionCancelledEvent, SubscriptionCreatedEvent,
     SubscriptionMigratedEvent, SubscriptionRecoveryReadyEvent, SubscriptionStatus, UsageLimits,
@@ -466,6 +467,7 @@ pub fn do_create_subscription(
     usage_enabled: bool,
     lifetime_cap: Option<i128>,
     expires_at: Option<u64>,
+    inviter: Option<Address>,
 ) -> Result<u32, Error> {
     let token = crate::admin::get_token(env)?;
 
@@ -482,6 +484,7 @@ pub fn do_create_subscription(
         usage_enabled,
         lifetime_cap,
         expires_at,
+        inviter,
     )
 }
 
@@ -496,11 +499,19 @@ pub fn do_create_subscription_with_token(
     usage_enabled: bool,
     lifetime_cap: Option<i128>,
     expires_at: Option<u64>,
+    inviter: Option<Address>,
 ) -> Result<u32, Error> {
     subscriber.require_auth();
 
     crate::blocklist::require_not_blocklisted(env, &subscriber)?;
     crate::blocklist::require_not_blocklisted(env, &merchant)?;
+
+    // Reject self-referral: inviter cannot be the same as subscriber.
+    if let Some(ref inviter_addr) = inviter {
+        if inviter_addr == &subscriber {
+            return Err(Error::SelfReferralNotAllowed);
+        }
+    }
 
     enforce_creation_rate_limit(env, &subscriber)?;
 
@@ -668,6 +679,20 @@ pub fn do_create_subscription_with_token(
             issued_at: env.ledger().timestamp(),
         },
     );
+
+    // Emit referral attribution when a valid inviter is provided.
+    if let Some(ref inviter_addr) = inviter {
+        env.events().publish(
+            (Symbol::new(env, "referral_attributed"), id),
+            ReferralAttributedEvent {
+                subscription_id: id,
+                inviter: inviter_addr.clone(),
+                subscriber: subscriber.clone(),
+                timestamp: env.ledger().timestamp(),
+                schema_version: crate::types::EVENT_SCHEMA_VERSION,
+            },
+        );
+    }
 
     Ok(id)
 }

--- a/contracts/subscription_vault/src/test.rs
+++ b/contracts/subscription_vault/src/test.rs
@@ -98,6 +98,7 @@ fn create_test_subscription(
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     if status != SubscriptionStatus::Active {
         let mut sub = client.get_subscription(&id);
@@ -1099,7 +1100,7 @@ fn test_subscription_limit_reached() {
         &INTERVAL,
         &false,
         &None::<i128>,
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
 }
 
 #[test]
@@ -1124,13 +1125,13 @@ fn test_subscriber_create_rate_limit_enforced() {
     let subscriber = Address::generate(&test_env.env);
     let merchant = Address::generate(&test_env.env);
 
-    let res1 = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>);
+    let res1 = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>, &None::<Address>);
     assert!(res1.is_ok());
 
-    let res2 = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>);
+    let res2 = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>, &None::<Address>);
     assert!(res2.is_ok());
 
-    let res3 = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>);
+    let res3 = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>, &None::<Address>);
     assert_eq!(res3, Err(Ok(Error::SubscriberRateLimited)));
 }
 
@@ -1143,15 +1144,15 @@ fn test_subscriber_create_rate_limit_rollover() {
     let subscriber = Address::generate(&test_env.env);
     let merchant = Address::generate(&test_env.env);
 
-    let res1 = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>);
+    let res1 = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>, &None::<Address>);
     assert!(res1.is_ok());
 
-    let res2 = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>);
+    let res2 = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>, &None::<Address>);
     assert_eq!(res2, Err(Ok(Error::SubscriberRateLimited)));
 
     test_env.jump(86401);
 
-    let res3 = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>);
+    let res3 = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>, &None::<Address>);
     assert!(res3.is_ok());
 }
 
@@ -1163,7 +1164,7 @@ fn test_subscriber_create_rate_limit_zero_cap_and_events() {
     let subscriber = Address::generate(&test_env.env);
     let merchant = Address::generate(&test_env.env);
 
-    let res = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>);
+    let res = test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>, &None::<Address>);
     assert_eq!(res, Err(Ok(Error::SubscriberRateLimited)));
 
     let events = test_env.env.events().all();
@@ -1187,7 +1188,7 @@ fn test_subscriber_create_rate_limit_admin_bypass() {
 
     let merchant = Address::generate(&test_env.env);
 
-    let res = test_env.client.try_create_subscription(&test_env.admin, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>);
+    let res = test_env.client.try_create_subscription(&test_env.admin, &merchant, &AMOUNT, &INTERVAL, &false, &None::<i128>, &None::<u64>, &None::<Address>);
     assert!(res.is_ok());
 }
 
@@ -1222,6 +1223,7 @@ fn test_cancel_subscription_unauthorized() {
         &true,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     let result = test_env.client.try_cancel_subscription(&sub_id, &other);
     assert_eq!(result, Err(Ok(Error::Forbidden)));
@@ -1243,6 +1245,7 @@ fn test_withdraw_subscriber_funds() {
         &true,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env.client.deposit_funds(&sub_id, &subscriber, &5_000_000, &None::<soroban_sdk::BytesN<32>>);
     test_env.client.cancel_subscription(&sub_id, &subscriber);
@@ -1271,7 +1274,7 @@ fn test_min_topup_below_threshold() {
         &(30 * 24 * 60 * 60),
         &false,
         &None::<i128>,
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
     test_env.client.cancel_subscription(&id, &merchant);
     let result = test_env.client.try_deposit_funds(&id, &subscriber, &4_999_999, &None::<soroban_sdk::BytesN<32>>);
     assert!(result.is_err());
@@ -1302,7 +1305,7 @@ fn test_min_topup_exactly_at_threshold() {
         &(30 * 24 * 60 * 60),
         &false,
         &None::<i128>,
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
     assert!(client
         .try_deposit_funds(&id, &subscriber, &min_topup, &None::<soroban_sdk::BytesN<32>>)
         .is_ok());
@@ -1336,7 +1339,7 @@ fn test_min_topup_above_threshold() {
         &(30 * 24 * 60 * 60),
         &false,
         &None::<i128>,
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
     assert!(client
         .try_deposit_funds(&id, &subscriber, &deposit_amount, &None::<soroban_sdk::BytesN<32>>)
         .is_ok());
@@ -1363,6 +1366,7 @@ fn test_deposit_funds_basic() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env.client.deposit_funds(&id, &subscriber, &5_000_000, &None::<soroban_sdk::BytesN<32>>);
     assertions::assert_prepaid_balance(&test_env.client, &id, 5_000_000);
@@ -1385,7 +1389,7 @@ fn test_deposit_funds_unauthorized() {
         &INTERVAL,
         &false,
         &None::<i128>,
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
     let result = client.try_deposit_funds(&id, &other, &5_000_000, &None::<soroban_sdk::BytesN<32>>);
     assert_eq!(result, Err(Ok(Error::Unauthorized)));
 
@@ -1410,6 +1414,7 @@ fn test_deposit_funds_event_payload() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     
     client.deposit_funds(&id, &subscriber, &15_000_000, &None::<soroban_sdk::BytesN<32>>);
@@ -1455,6 +1460,7 @@ fn test_deposit_funds_cei_compliance() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     
     let initial_contract_balance = token_client.balance(&client.address);
@@ -1489,6 +1495,7 @@ fn test_deposit_funds_below_minimum() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     // min_topup is 1_000_000; try to deposit 500
     test_env.client.deposit_funds(&id, &subscriber, &500, &None::<soroban_sdk::BytesN<32>>);
@@ -1590,6 +1597,7 @@ fn test_blocklist_enforced_across_mutating_subscription_flows_and_unblock_restor
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env.client.pause_subscription(&direct_sub, &subscriber);
 
@@ -1624,6 +1632,7 @@ fn test_blocklist_enforced_across_mutating_subscription_flows_and_unblock_restor
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         ),
         Err(Ok(Error::SubscriberBlocklisted))
     );
@@ -1677,6 +1686,7 @@ fn test_blocklist_enforced_across_mutating_subscription_flows_and_unblock_restor
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env
         .client
@@ -1754,6 +1764,7 @@ fn test_create_subscription_blocked_by_emergency_stop() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 }
 
@@ -2547,7 +2558,7 @@ fn test_estimate_topup_zero_intervals_returns_zero() {
         &INTERVAL,
         &false,
         &Some(2 * AMOUNT),
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
     seed_balance(&env, &client, id, PREPAID);
 
     assert_eq!(client.estimate_topup_for_intervals(&id, &0), 0);
@@ -2697,6 +2708,7 @@ fn test_lifetime_cap_auto_cancel() {
         &false,
         &Some(2 * AMOUNT),
         &None::<u64>,
+        &None::<Address>,
     );
     fixtures::seed_balance(&test_env.env, &test_env.client, id, PREPAID);
 
@@ -2728,7 +2740,7 @@ fn test_get_cap_info() {
         &INTERVAL,
         &false,
         &Some(cap),
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
     let info = test_env.client.get_cap_info(&id);
     assert_eq!(info.lifetime_cap, Some(cap));
     assert_eq!(info.lifetime_charged, 0);
@@ -2860,11 +2872,11 @@ fn test_subscriber_credit_limit_blocks_new_subscription_creation() {
 
     // First subscription fits entirely within the limit.
     let _sub1 =
-        test_env.client.create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None, &None::<u64>);
+        test_env.client.create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None, &None::<u64>, &None::<Address>);
 
     // Second subscription would exceed credit limit (another interval liability).
     let result =
-        test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None, &None::<u64>);
+        test_env.client.try_create_subscription(&subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None, &None::<u64>, &None::<Address>);
     assert_eq!(result, Err(Ok(Error::CreditLimitExceeded)));
 }
 
@@ -2892,7 +2904,7 @@ fn test_subscriber_credit_limit_blocks_topup_when_exposure_exceeds_limit() {
         &INTERVAL,
         &false,
         &None::<i128>,
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
 
     // Deposit that would keep us under the limit succeeds.
     test_env
@@ -2937,7 +2949,7 @@ fn test_get_subscriber_credit_limit_and_exposure_views() {
         &INTERVAL,
         &false,
         &None::<i128>,
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
     let exposure = test_env.client.get_subscriber_exposure(&subscriber, &test_env.token);
     assert_eq!(exposure, AMOUNT);
 
@@ -2966,7 +2978,7 @@ fn test_partial_refund_debits_prepaid_and_transfers_tokens() {
         &INTERVAL,
         &false,
         &None::<i128>,
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
     test_env.client.deposit_funds(&sub_id, &subscriber, &20_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     let balance_before = test_env.token_client().balance(&subscriber);
@@ -2997,7 +3009,7 @@ fn test_partial_refund_rejects_invalid_amounts_and_auth() {
         &INTERVAL,
         &false,
         &None::<i128>,
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
     test_env.client.deposit_funds(&sub_id, &subscriber, &5_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Zero or negative refund amounts are rejected.
@@ -3061,6 +3073,7 @@ fn test_partial_refund_repeated_debits_are_cumulative() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env
         .client
@@ -3095,6 +3108,7 @@ fn test_partial_refund_cumulative_exact_drain_then_over_refund_fails() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env
         .client
@@ -3134,6 +3148,7 @@ fn test_partial_refund_full_balance_as_partial_succeeds() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env
         .client
@@ -3165,6 +3180,7 @@ fn test_partial_refund_after_cancellation_succeeds() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env
         .client
@@ -3199,6 +3215,7 @@ fn test_partial_refund_emits_event() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env
         .client
@@ -3341,7 +3358,7 @@ fn test_cancel_from_various_states() {
         &INTERVAL,
         &false,
         &None::<i128>,
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
 
     // Cancel from Paused
     let id2 = test_env.client.create_subscription(
@@ -3352,6 +3369,7 @@ fn test_cancel_from_various_states() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env.client.pause_subscription(&id2, &subscriber);
     test_env.client.cancel_subscription(&id2, &subscriber);
@@ -3374,6 +3392,7 @@ fn test_withdraw_subscriber_funds_exactly_once() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env.client.deposit_funds(&id, &subscriber, &10_000_000, &None::<soroban_sdk::BytesN<32>>);
 
@@ -3404,7 +3423,7 @@ fn test_withdraw_zero_balance_fails() {
         &INTERVAL,
         &false,
         &None::<i128>,
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
     test_env.client.cancel_subscription(&id, &subscriber);
 
     let result = test_env
@@ -3429,6 +3448,7 @@ fn test_cancel_and_withdraw_events() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env.client.deposit_funds(&id, &subscriber, &5_000_000, &None::<soroban_sdk::BytesN<32>>);
 
@@ -3459,7 +3479,7 @@ fn test_migrate_subscription_requires_plan_origin() {
         &INTERVAL,
         &false,
         &None::<i128>,
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
     let plan_id = test_env.client.create_plan_template(
         &merchant,
         &(&AMOUNT * 2),
@@ -3496,7 +3516,7 @@ fn test_cap_cancelled_subscriber_can_withdraw() {
         &INTERVAL,
         &false,
         &Some(cap),
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
 
     // Deposit exactly cap so the deposit fits within enforce_deposit_cap.
     test_env.client.deposit_funds(&sub_id, &subscriber, &cap, &None::<soroban_sdk::BytesN<32>>);
@@ -3538,6 +3558,7 @@ fn test_charge_usage_basic() {
         &true,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     fixtures::seed_balance(&test_env.env, &test_env.client, id, PREPAID);
 
@@ -3788,6 +3809,7 @@ fn test_rotate_merchant_address_migrates_balance_and_subscriptions() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     client.rotate_merchant_address(&admin, &old_merchant, &new_merchant, &0u64);
@@ -3872,6 +3894,7 @@ fn test_billing_lifecycle_golden_path_end_to_end() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     let created = test_env.client.get_subscription(&id);
     assert_eq!(created.status, SubscriptionStatus::Active);
@@ -3999,6 +4022,7 @@ fn test_billing_lifecycle_delayed_charge_and_min_topup_progression() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env
         .client
@@ -4080,6 +4104,7 @@ fn test_list_subscriptions_by_subscriber() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     let id2 = test_env.client.create_subscription(
         &subscriber,
@@ -4089,6 +4114,7 @@ fn test_list_subscriptions_by_subscriber() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     let page = test_env
@@ -4125,6 +4151,7 @@ fn test_list_subscriptions_by_subscriber_pagination_stable_ordering() {
             &false,
             &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
         expected.push(id);
     }
@@ -4159,6 +4186,7 @@ fn test_get_subscriptions_by_merchant_pagination_and_invalid_limit() {
             &false,
             &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     }
     assert_eq!(
@@ -4207,6 +4235,7 @@ fn test_get_subscriptions_by_token_pagination_and_count() {
             &false,
             &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     }
     assert_eq!(
@@ -4249,6 +4278,7 @@ fn test_withdraw_subscriber_funds_after_cancel() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env.client.deposit_funds(&id, &subscriber, &5_000_000, &None::<soroban_sdk::BytesN<32>>);
     test_env.client.cancel_subscription(&id, &subscriber);
@@ -4845,7 +4875,7 @@ fn test_billing_statements_offset_pagination_newest_first() {
         &INTERVAL,
         &true,
         &None::<i128>,
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
     test_env.client.deposit_funds(&id, &subscriber, &200_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     for i in 1..=6 {
@@ -4889,7 +4919,7 @@ fn test_billing_statements_cursor_pagination_boundaries() {
         &INTERVAL,
         &true,
         &None::<i128>,
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
     test_env.client.deposit_funds(&id, &subscriber, &200_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     for i in 1..=4 {
@@ -4940,7 +4970,7 @@ fn test_compaction_prunes_old_statements_and_keeps_recent() {
         &INTERVAL,
         &false,
         &None::<i128>,
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
     test_env.client.deposit_funds(&id, &subscriber, &500_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     for i in 1..=8 {
@@ -4984,7 +5014,7 @@ fn test_compaction_no_rows_and_override_value() {
         &INTERVAL,
         &false,
         &None::<i128>,
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
 
     let summary = test_env
         .client
@@ -5012,6 +5042,7 @@ fn test_compaction_idempotent_second_run() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env
         .client
@@ -5061,6 +5092,7 @@ fn test_compaction_keep_recent_zero_prunes_all_detail() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env
         .client
@@ -5112,6 +5144,7 @@ fn test_compact_billing_statements_non_admin_rejected() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     let attacker = Address::generate(&test_env.env);
     let res = test_env
@@ -5164,6 +5197,7 @@ fn test_compaction_override_respects_per_run_threshold() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env
         .client
@@ -5219,7 +5253,7 @@ fn test_oracle_enabled_charge_uses_quote_conversion() {
         &INTERVAL,
         &false,
         &None::<i128>,
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
     test_env.client.deposit_funds(&id, &subscriber, &100_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     test_env.env.ledger().set_timestamp(T0 + INTERVAL);
@@ -5247,7 +5281,7 @@ fn test_oracle_stale_quote_rejected() {
         &INTERVAL,
         &false,
         &None::<i128>,
-     &None::<u64>);
+     &None::<u64>, &None::<Address>);
     test_env.client.deposit_funds(&id, &subscriber, &100_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     let result = test_env.client.try_charge_subscription(&id, &None::<soroban_sdk::BytesN<32>>);
@@ -5363,6 +5397,7 @@ fn test_create_subscription_zero_amount_rejected() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     assert_eq!(result, Err(Ok(Error::InvalidAmount)));
 }
@@ -5380,6 +5415,7 @@ fn test_create_subscription_interval_too_small_rejected() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     assert_eq!(result, Err(Ok(Error::InvalidInput)));
 }
@@ -5397,6 +5433,7 @@ fn test_create_subscription_lifetime_cap_less_than_amount_rejected() {
         &false,
         &Some(9i128),
         &None::<u64>,
+        &None::<Address>,
     );
     assert_eq!(result, Err(Ok(Error::InvalidInput)));
 }
@@ -5418,6 +5455,7 @@ fn test_create_subscription_blocklisted_subscriber_rejected() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     assert_eq!(result, Err(Ok(Error::SubscriberBlocklisted)));
 }
@@ -5511,6 +5549,7 @@ fn test_create_subscription_max_amount_and_cap_succeeds() {
         &false,
         &Some(i128::MAX),
         &None::<u64>,
+        &None::<Address>,
     );
     let sub = test_env.client.get_subscription(&id);
     assert_eq!(sub.amount, i128::MAX);
@@ -5530,6 +5569,7 @@ fn test_create_subscription_max_amount_cap_smaller_rejected() {
         &false,
         &Some(i128::MAX - 1),
         &None::<u64>,
+        &None::<Address>,
     );
     assert_eq!(result, Err(Ok(Error::InvalidInput)));
 }
@@ -5798,6 +5838,7 @@ fn test_admin_rotation_does_not_affect_subscriptions() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     let before = test_env.client.get_subscription(&id);
 
@@ -6995,6 +7036,7 @@ fn test_shared_merchant_multiple_states() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     let id_b = test_env.client.create_subscription(
         &sub_b_sub,
@@ -7004,6 +7046,7 @@ fn test_shared_merchant_multiple_states() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     let id_c = test_env.client.create_subscription(
         &sub_c_sub,
@@ -7013,6 +7056,7 @@ fn test_shared_merchant_multiple_states() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     // Set: A stays Active, B => Paused, C => Cancelled.
@@ -7052,14 +7096,14 @@ fn test_pause_with_varying_intervals() {
 
     let id1 = test_env
         .client
-        .create_subscription(&s1, &m, &AMOUNT, &daily, &false, &None::<i128>, &None::<u64>);
+        .create_subscription(&s1, &m, &AMOUNT, &daily, &false, &None::<i128>, &None::<u64>, &None::<Address>);
     let id2 = test_env
         .client
-        .create_subscription(&s2, &m, &AMOUNT, &weekly, &false, &None::<i128>, &None::<u64>);
+        .create_subscription(&s2, &m, &AMOUNT, &weekly, &false, &None::<i128>, &None::<u64>, &None::<Address>);
     let id3 =
         test_env
             .client
-            .create_subscription(&s3, &m, &AMOUNT, &monthly, &false, &None::<i128>, &None::<u64>);
+            .create_subscription(&s3, &m, &AMOUNT, &monthly, &false, &None::<i128>, &None::<u64>, &None::<Address>);
 
     // All three should pause without error regardless of interval.
     test_env.client.pause_subscription(&id1, &s1);
@@ -7228,6 +7272,7 @@ fn setup_oracle_env<'a>(
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&id, &subscriber, &200_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     (id, subscriber, merchant, oracle)
@@ -7302,6 +7347,7 @@ fn test_oracle_disabled_charge_uses_subscription_amount_directly() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env
         .client
@@ -7409,6 +7455,7 @@ fn test_oracle_price_exactly_at_max_age_boundary_accepted() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env
         .client
@@ -7458,6 +7505,7 @@ fn test_oracle_price_one_second_past_max_age_rejected() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env
         .client
@@ -7506,6 +7554,7 @@ fn test_oracle_enabled_no_address_stored_returns_not_configured() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env
         .client
@@ -7908,6 +7957,7 @@ mod storage_layout {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         );
 
         let sub = client.get_subscription(&id);
@@ -7934,6 +7984,7 @@ mod storage_layout {
             &false,
             &Some(cap),
             &None::<u64>,
+            &None::<Address>,
         );
 
         let sub = client.get_subscription(&id);
@@ -8212,6 +8263,7 @@ fn test_merchant_token_bucket_reconciliation() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     let id_b = client.create_subscription_with_token(
@@ -8484,6 +8536,7 @@ fn test_event_schema_consistency() {
         &true,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     let events = test_env.env.events().all();
@@ -8509,6 +8562,7 @@ fn test_oneoff_unauthorized_merchant_rejected() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
@@ -8537,6 +8591,7 @@ fn test_oneoff_zero_amount_rejected() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
@@ -8560,6 +8615,7 @@ fn test_oneoff_negative_amount_rejected() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
@@ -8583,6 +8639,7 @@ fn test_oneoff_exceeds_balance_rejected() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
@@ -8611,6 +8668,7 @@ fn test_oneoff_exact_balance_succeeds() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
@@ -8637,6 +8695,7 @@ fn test_oneoff_on_paused_subscription_succeeds() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     client.pause_subscription(&id, &subscriber);
@@ -8665,6 +8724,7 @@ fn test_oneoff_on_cancelled_subscription_rejected() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     client.cancel_subscription(&id, &subscriber);
@@ -8689,6 +8749,7 @@ fn test_oneoff_partial_balance_boundary() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&id, &subscriber, &10_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
@@ -8725,6 +8786,7 @@ fn test_oneoff_blocked_by_emergency_stop() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
@@ -8758,6 +8820,7 @@ fn test_oneoff_statement_kind_consistency() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
@@ -8793,6 +8856,7 @@ fn test_oneoff_event_emitted() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
@@ -8823,6 +8887,7 @@ fn test_oneoff_lifetime_cap_boundary() {
         &false,
         &Some(20_000_000i128),
         &None::<u64>,
+        &None::<Address>,
     );
     // Deposit exactly cap — enforce_deposit_cap rejects deposits over remaining cap.
     client.deposit_funds(&id, &subscriber, &20_000_000i128, &None::<soroban_sdk::BytesN<32>>);
@@ -8854,6 +8919,7 @@ fn test_oneoff_does_not_update_last_payment_timestamp() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
@@ -8885,6 +8951,7 @@ fn test_compaction_aggregation_accuracy() {
         &true, // usage enabled
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     test_env.client.deposit_funds(&id, &subscriber, &500_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
@@ -9347,6 +9414,7 @@ fn setup_usage_sub(
         &true,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     fixtures::seed_balance(env, client, id, PREPAID);
     (id, subscriber, merchant)
@@ -9784,6 +9852,7 @@ fn test_migrate_does_not_affect_subscriptions() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&id, &subscriber, &PREPAID, &None::<soroban_sdk::BytesN<32>>);
     let before = client.get_subscription(&id);
@@ -9863,6 +9932,7 @@ fn test_merchant_max_subs_default() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     assert_eq!(test_env.client.get_merchant_subscription_count(&merchant), 1);
@@ -9888,6 +9958,7 @@ fn test_merchant_max_subs_blocks_creation() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     // Second subscription succeeds.
@@ -9899,6 +9970,7 @@ fn test_merchant_max_subs_blocks_creation() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     // Third subscription is rejected.
@@ -9910,6 +9982,7 @@ fn test_merchant_max_subs_blocks_creation() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     assert_eq!(result, Err(Ok(Error::MaxConcurrentSubscriptionsReached)));
 
@@ -9940,6 +10013,7 @@ fn test_merchant_max_subs_cancellation_frees_slot() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     // Second creation is blocked.
@@ -9951,6 +10025,7 @@ fn test_merchant_max_subs_cancellation_frees_slot() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     assert_eq!(result, Err(Ok(Error::MaxConcurrentSubscriptionsReached)));
 
@@ -9966,6 +10041,7 @@ fn test_merchant_max_subs_cancellation_frees_slot() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 }
 

--- a/contracts/subscription_vault/src/test_auto_pause.rs
+++ b/contracts/subscription_vault/src/test_auto_pause.rs
@@ -56,6 +56,7 @@ fn create_funded_sub(
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     if prepaid > 0 {
         token_admin.mint(&subscriber, &prepaid);

--- a/contracts/subscription_vault/src/test_auto_renew.rs
+++ b/contracts/subscription_vault/src/test_auto_renew.rs
@@ -98,6 +98,7 @@ mod test_auto_renew {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         );
 
         // Seed balance directly so we do not need a live token transfer.
@@ -479,6 +480,7 @@ mod test_auto_renew {
                 &false,
                 &None::<i128>,
                 &Some(expires_at),
+                &None::<Address>,
             );
             let mut sub = client.get_subscription(&id);
             sub.prepaid_balance = PREPAID;

--- a/contracts/subscription_vault/src/test_bulk_admin_ops.rs
+++ b/contracts/subscription_vault/src/test_bulk_admin_ops.rs
@@ -22,6 +22,7 @@ const DEPOSIT: i128 = 5_000_000; // >= init min_topup (1_000_000)
 fn funded_sub(te: &TestEnv, subscriber: &Address, merchant: &Address) -> u32 {
     let sub_id = te.client.create_subscription(
         subscriber, merchant, &AMOUNT, &INTERVAL, &false, &None, &None,
+        &None::<Address>,
     );
     te.stellar_token_client().mint(subscriber, &DEPOSIT);
     te.client
@@ -254,6 +255,7 @@ fn bulk_pause_reports_expired_as_failure() {
         &false,
         &None,
         &Some(now + 1_000),
+        &None::<Address>,
     );
     te.stellar_token_client().mint(&subscriber, &DEPOSIT);
     te.client

--- a/contracts/subscription_vault/src/test_coupon.rs
+++ b/contracts/subscription_vault/src/test_coupon.rs
@@ -104,7 +104,7 @@ fn test_apply_coupon_subscriber_auth() {
         .create_coupon(&merchant, &code, &token, &0, &0, &0, &0);
     let sub_id = client
         .mock_all_auths()
-        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>);
+        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>, &None::<Address>);
 
     let res = client.try_apply_coupon(&wrong_subscriber, &sub_id, &code);
     assert_eq!(
@@ -128,7 +128,7 @@ fn test_apply_coupon_expired() {
 
     let sub_id = client
         .mock_all_auths()
-        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>);
+        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>, &None::<Address>);
 
     // Advance time past expiry
     env.ledger().set_timestamp(now + 200);
@@ -154,7 +154,7 @@ fn test_apply_coupon_revoked() {
 
     let sub_id = client
         .mock_all_auths()
-        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>);
+        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>, &None::<Address>);
 
     let res = client.try_apply_coupon(&subscriber, &sub_id, &code);
     assert_eq!(
@@ -178,10 +178,10 @@ fn test_apply_coupon_limit_reached() {
 
     let sub_id1 = client
         .mock_all_auths()
-        .create_subscription(&subscriber1, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>);
+        .create_subscription(&subscriber1, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>, &None::<Address>);
     let sub_id2 = client
         .mock_all_auths()
-        .create_subscription(&subscriber2, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>);
+        .create_subscription(&subscriber2, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>, &None::<Address>);
 
     // First one works
     client
@@ -212,7 +212,7 @@ fn test_apply_coupon_already_applied() {
         .create_coupon(&merchant, &code2, &token, &0, &0, &0, &0);
     let sub_id = client
         .mock_all_auths()
-        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>);
+        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>, &None::<Address>);
 
     client
         .mock_all_auths()
@@ -240,7 +240,7 @@ fn test_apply_coupon_token_mismatch() {
     // Subscription is for token
     let sub_id = client
         .mock_all_auths()
-        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>);
+        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>, &None::<Address>);
 
     let res = client.try_apply_coupon(&subscriber, &sub_id, &code);
     assert_eq!(
@@ -310,7 +310,7 @@ fn test_charge_with_discount() {
     // Subscription is for 1000 units
     let sub_id = client
         .mock_all_auths()
-        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>);
+        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>, &None::<Address>);
     client
         .mock_all_auths()
         .apply_coupon(&subscriber, &sub_id, &code);
@@ -361,7 +361,7 @@ fn coupon_redemption_succeeds_before_expiry() {
 
     let sub_id = client
         .mock_all_auths()
-        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>);
+        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>, &None::<Address>);
 
     // Redemption succeeds when timestamp < expires_at
     let result = client.try_apply_coupon(&subscriber, &sub_id, &code);
@@ -388,7 +388,7 @@ fn coupon_redemption_fails_at_exact_expiry_time() {
 
     let sub_id = client
         .mock_all_auths()
-        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>);
+        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>, &None::<Address>);
 
     // Redemption fails when timestamp == expires_at (contract uses >= check)
     let result = client.try_apply_coupon(&subscriber, &sub_id, &code);
@@ -415,7 +415,7 @@ fn coupon_redemption_fails_one_second_after_expiry() {
 
     let sub_id = client
         .mock_all_auths()
-        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>);
+        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>, &None::<Address>);
 
     // Advance time to exactly expiry time
     env.ledger().set_timestamp(expires_at);
@@ -452,7 +452,7 @@ fn coupon_never_expires_when_expires_at_is_zero() {
 
     let sub_id = client
         .mock_all_auths()
-        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>);
+        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>, &None::<Address>);
 
     // Advance time far into the future
     let far_future = env.ledger().timestamp() + 1_000_000;
@@ -518,7 +518,7 @@ fn multiple_redemption_attempts_in_same_block() {
 
     let sub_id = client
         .mock_all_auths()
-        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>);
+        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>, &None::<Address>);
 
     // First redemption succeeds
     let result1 = client.try_apply_coupon(&subscriber, &sub_id, &code);
@@ -548,7 +548,7 @@ fn expired_coupon_cannot_be_redeemed_after_repeated_attempts() {
 
     let sub_id = client
         .mock_all_auths()
-        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>);
+        .create_subscription(&subscriber, &merchant, &1000, &86400, &false, &None::<i128>, &None::<u64>, &None::<Address>);
 
     // Advance past expiry
     env.ledger().set_timestamp(expires_at + 1);

--- a/contracts/subscription_vault/src/test_emergency_stop_lifetime_caps.rs
+++ b/contracts/subscription_vault/src/test_emergency_stop_lifetime_caps.rs
@@ -48,6 +48,7 @@ fn test_emergency_stop_blocks_all_critical_create_deposit_charge_paths() {
         &true,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&sub_id, &subscriber, &10_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
@@ -66,6 +67,7 @@ fn test_emergency_stop_blocks_all_critical_create_deposit_charge_paths() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         ),
         Err(Ok(Error::EmergencyStopActive))
     );
@@ -175,6 +177,7 @@ fn test_emergency_stop_blocks_batch_charge() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&sub_id, &subscriber, &10_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     env.ledger().set_timestamp(T0 + INTERVAL + 1);
@@ -199,6 +202,7 @@ fn test_batch_charge_resumes_normally_after_emergency_stop_disabled() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&sub_id, &subscriber, &10_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     env.ledger().set_timestamp(T0 + INTERVAL + 1);
@@ -230,6 +234,7 @@ fn test_lifetime_cap_interval_overrun_cancels_without_debiting_or_crediting() {
         &false,
         &Some(cap),
         &None::<u64>,
+        &None::<Address>,
     );
     // enforce_deposit_cap caps single deposit at `cap`.
     client.deposit_funds(&sub_id, &subscriber, &cap, &None::<soroban_sdk::BytesN<32>>);
@@ -271,6 +276,7 @@ fn test_lifetime_cap_usage_exact_hit_charges_then_auto_cancels() {
         &true,
         &Some(cap),
         &None::<u64>,
+        &None::<Address>,
     );
     // enforce_deposit_cap caps single deposit at `cap`.
     client.deposit_funds(&sub_id, &subscriber, &cap, &None::<soroban_sdk::BytesN<32>>);
@@ -299,6 +305,7 @@ fn test_lifetime_cap_usage_overrun_cancels_without_financial_side_effects() {
         &true,
         &Some(cap),
         &None::<u64>,
+        &None::<Address>,
     );
     // enforce_deposit_cap caps single deposit at `cap`.
     client.deposit_funds(&sub_id, &subscriber, &cap, &None::<soroban_sdk::BytesN<32>>);
@@ -340,6 +347,7 @@ fn test_lifetime_cap_oneoff_exact_hit_auto_cancels() {
         &false,
         &Some(cap),
         &None::<u64>,
+        &None::<Address>,
     );
     // enforce_deposit_cap caps single deposit at `cap`.
     client.deposit_funds(&sub_id, &subscriber, &cap, &None::<soroban_sdk::BytesN<32>>);

--- a/contracts/subscription_vault/src/test_emergency_stop_matrix.rs
+++ b/contracts/subscription_vault/src/test_emergency_stop_matrix.rs
@@ -44,6 +44,7 @@ fn test_emergency_stop_matrix_blocks_mutations_but_allows_reads() {
         &true,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&sub_id, &subscriber, &10_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
@@ -64,6 +65,7 @@ fn test_emergency_stop_matrix_blocks_mutations_but_allows_reads() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         ),
         Err(Ok(Error::EmergencyStopActive))
     );

--- a/contracts/subscription_vault/src/test_grace_buyout.rs
+++ b/contracts/subscription_vault/src/test_grace_buyout.rs
@@ -61,6 +61,7 @@ fn create_sub(
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     (id, subscriber, merchant)
 }

--- a/contracts/subscription_vault/src/test_idempotency_keys.rs
+++ b/contracts/subscription_vault/src/test_idempotency_keys.rs
@@ -47,6 +47,7 @@ fn create_and_fund_sub(
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     let token_client = token::Client::new(env, token);

--- a/contracts/subscription_vault/src/test_insufficient_balance.rs
+++ b/contracts/subscription_vault/src/test_insufficient_balance.rs
@@ -47,6 +47,7 @@ fn create_sub(
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     (id, subscriber, merchant)
 }
@@ -218,6 +219,7 @@ fn test_deposit_credit_limit_aggregate_two_subs() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     // Set credit limit: 15_000_000

--- a/contracts/subscription_vault/src/test_interval_boundary.rs
+++ b/contracts/subscription_vault/src/test_interval_boundary.rs
@@ -73,6 +73,7 @@ fn create_and_fund(
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     // Fund enough for many charges.
@@ -286,6 +287,7 @@ fn test_last_payment_timestamp_zero() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     token_admin.mint(&subscriber, &1_000_000_000i128);

--- a/contracts/subscription_vault/src/test_merchant_full_drain.rs
+++ b/contracts/subscription_vault/src/test_merchant_full_drain.rs
@@ -55,6 +55,7 @@ fn create_and_fund_sub(
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     client.deposit_funds(&id, &subscriber, &DEPOSIT_AMOUNT);
@@ -179,6 +180,7 @@ fn test_merchant_dust_balance_drain() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     client.deposit_funds(&id, &subscriber, &dust_amount);

--- a/contracts/subscription_vault/src/test_metadata_signed.rs
+++ b/contracts/subscription_vault/src/test_metadata_signed.rs
@@ -88,6 +88,7 @@ fn create_subscription(
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     let _ = token; // touch unused param to silence the lint without complaining
     (id, subscriber, merchant)
@@ -220,6 +221,7 @@ fn subscriber_signed_set_succeeds() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     let payload = payload_for(
@@ -263,6 +265,7 @@ fn merchant_signed_set_succeeds() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     let payload = payload_for(
@@ -298,6 +301,7 @@ fn sequential_nonces_advance() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         )
     };
     let signer = pubkey_to_address(&env, &bytes32(&env, &sub_key.pub_bytes));
@@ -342,6 +346,7 @@ fn replayed_nonce_is_rejected() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         )
     };
 
@@ -372,6 +377,7 @@ fn skipped_nonce_is_rejected() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         )
     };
 
@@ -402,6 +408,7 @@ fn expires_at_equal_to_now_rejected() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         )
     };
     let now = env.ledger().timestamp();
@@ -428,6 +435,7 @@ fn expires_at_in_past_rejected() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         )
     };
     let now = env.ledger().timestamp();
@@ -457,6 +465,7 @@ fn expires_at_in_future_succeeds() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         )
     };
     let payload = payload_for(
@@ -491,6 +500,7 @@ fn forged_signature_panics() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         )
     };
     let payload = payload_for(&env, sub_id, "k", "v", 0u64, one_hour_from_now(&env));
@@ -526,6 +536,7 @@ fn wrong_key_signature_panics() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         )
     };
     // Attacker builds a fully valid signature on the right message bytes
@@ -562,6 +573,7 @@ fn chain_id_mismatch_panics() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         )
     };
     let payload = payload_for(&env, sub_id, "k", "v", 0u64, one_hour_from_now(&env));
@@ -637,6 +649,7 @@ fn key_too_long_rejected() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         )
     };
 
@@ -674,6 +687,7 @@ fn value_too_long_rejected() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         )
     };
     let long_value = String::from_str(&env, &"a".repeat(257));
@@ -707,6 +721,7 @@ fn empty_key_rejected() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         )
     };
     let payload = SignedMetadataPayload {
@@ -738,6 +753,7 @@ fn empty_value_rejected() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         )
     };
     let payload = SignedMetadataPayload {
@@ -769,6 +785,7 @@ fn key_cap_reached() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         )
     };
 
@@ -823,6 +840,7 @@ fn subscriber_and_merchant_nonces_independent() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         )
     };
 
@@ -869,6 +887,7 @@ fn nonce_overflow_is_guarded() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         )
     };
     let signer = Address::generate(&env);
@@ -930,6 +949,7 @@ fn success_emits_signed_event() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         )
     };
     let payload = payload_for(&env, sub_id, "k", "v", 0u64, one_hour_from_now(&env));

--- a/contracts/subscription_vault/src/test_operator.rs
+++ b/contracts/subscription_vault/src/test_operator.rs
@@ -27,6 +27,7 @@ fn make_funded_subscription(te: &TestEnv, subscriber: &Address, merchant: &Addre
         &false,
         &None,
         &None::<u64>,
+        &None::<Address>,
     );
     te.stellar_token_client().mint(subscriber, &DEPOSIT);
     te.client.deposit_funds(&sub_id, subscriber, &DEPOSIT);
@@ -349,6 +350,7 @@ fn operator_charge_usage_succeeds() {
         &true, // usage_enabled
         &None,
         &None::<u64>,
+        &None::<Address>,
     );
     te.stellar_token_client().mint(&subscriber, &DEPOSIT);
     te.client.deposit_funds(&sub_id, &subscriber, &DEPOSIT, &None::<soroban_sdk::BytesN<32>>);
@@ -378,6 +380,7 @@ fn operator_charge_usage_wrong_operator_rejected() {
         &true,
         &None,
         &None::<u64>,
+        &None::<Address>,
     );
     te.stellar_token_client().mint(&subscriber, &DEPOSIT);
     te.client.deposit_funds(&sub_id, &subscriber, &DEPOSIT, &None::<soroban_sdk::BytesN<32>>);
@@ -689,6 +692,7 @@ fn operator_charge_usage_with_reference_succeeds() {
         &true,
         &None,
         &None::<u64>,
+        &None::<Address>,
     );
     te.stellar_token_client().mint(&subscriber, &DEPOSIT);
     te.client.deposit_funds(&sub_id, &subscriber, &DEPOSIT, &None::<soroban_sdk::BytesN<32>>);

--- a/contracts/subscription_vault/src/test_query_performance.rs
+++ b/contracts/subscription_vault/src/test_query_performance.rs
@@ -277,7 +277,7 @@ fn test_subscriber_list_invalid_limit_overflow() {
 }
 
 fn create_sub_for_merchant_and_token(client: &SubscriptionVaultClient<'static>, subscriber: &Address, merchant: &Address, token: &Address) -> u32 {
-    client.create_subscription(subscriber, merchant, &1000, &(30 * 24 * 60 * 60), &false, &None, &None::<u64>)
+    client.create_subscription(subscriber, merchant, &1000, &(30 * 24 * 60 * 60), &false, &None, &None::<u64>, &None::<Address>)
 }
 
 #[test]
@@ -422,7 +422,7 @@ fn test_write_path_scan_depth_guard_triggers_for_large_contracts() {
 
     // This creation should fail with InvalidInput because we simulated an oversized contract
     // AND we forced the scan path by configuring a credit limit.
-    client.create_subscription(&subscriber, &merchant, &100, &(30 * 24 * 60 * 60), &false, &None, &None::<u64>);
+    client.create_subscription(&subscriber, &merchant, &100, &(30 * 24 * 60 * 60), &false, &None, &None::<u64>, &None::<Address>);
 }
 
 // ================================================================
@@ -456,6 +456,7 @@ mod benchmark {
             &false,
             &None,
             &None::<u64>,
+            &None::<Address>,
         );
 
         // High budgets so we never hit limit; just measure
@@ -570,6 +571,7 @@ fn test_get_subscription_within_budget() {
         &false,
         &None,
         &None::<u64>,
+        &None::<Address>,
     );
 
     with_perf_budget(
@@ -597,6 +599,7 @@ fn test_get_subscription_budget_too_tight() {
         &false,
         &None,
         &None::<u64>,
+        &None::<Address>,
     );
 
     // Impossibly tight budgets — must exceed

--- a/contracts/subscription_vault/src/test_recovery.rs
+++ b/contracts/subscription_vault/src/test_recovery.rs
@@ -172,7 +172,7 @@ fn test_state_consistency() {
     // 1. Setup subscription and deposit
     token_client.mint(&subscriber, &50_000_000);
     
-    let sub_id = client.create_subscription(&subscriber, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>);
+    let sub_id = client.create_subscription(&subscriber, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>, &None::<Address>);
     
     client.deposit_funds(&sub_id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     
@@ -261,7 +261,7 @@ fn test_get_token_reconciliation_with_prepaid() {
     // Setup: Create subscription and deposit funds
     token_client.mint(&subscriber, &50_000_000);
     let sub_id =
-        client.create_subscription(&subscriber, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>);
+        client.create_subscription(&subscriber, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>, &None::<Address>);
     client.deposit_funds(&sub_id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Get reconciliation
@@ -293,7 +293,7 @@ fn test_get_token_reconciliation_after_charge() {
     // Setup: Create subscription with funds and charge it
     token_client.mint(&subscriber, &50_000_000);
     let sub_id =
-        client.create_subscription(&subscriber, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>);
+        client.create_subscription(&subscriber, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>, &None::<Address>);
     client.deposit_funds(&sub_id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Charge the subscription
@@ -327,7 +327,7 @@ fn test_get_token_reconciliation_with_recoverable() {
     // Setup: Create subscription with funds
     token_client.mint(&subscriber, &50_000_000);
     let sub_id =
-        client.create_subscription(&subscriber, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>);
+        client.create_subscription(&subscriber, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>, &None::<Address>);
     client.deposit_funds(&sub_id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Mint directly to contract (stranded funds)
@@ -398,7 +398,7 @@ fn test_generate_reconciliation_proof() {
     // Setup: Create subscription with funds
     token_client.mint(&subscriber, &50_000_000);
     let sub_id =
-        client.create_subscription(&subscriber, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>);
+        client.create_subscription(&subscriber, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>, &None::<Address>);
     client.deposit_funds(&sub_id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Mint stranded funds
@@ -446,9 +446,9 @@ fn test_query_prepaid_balances_paginated() {
     token_client.mint(&subscriber2, &20_000_000);
 
     let sub1 =
-        client.create_subscription(&subscriber1, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>);
+        client.create_subscription(&subscriber1, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>, &None::<Address>);
     let sub2 =
-        client.create_subscription(&subscriber2, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>);
+        client.create_subscription(&subscriber2, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>, &None::<Address>);
 
     client.deposit_funds(&sub1, &subscriber1, &30_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     client.deposit_funds(&sub2, &subscriber2, &20_000_000i128, &None::<soroban_sdk::BytesN<32>>);
@@ -510,7 +510,7 @@ fn test_query_prepaid_balances_paginated_wrong_token() {
     // Setup with token1
     token_client.mint(&subscriber, &50_000_000);
     let sub_id =
-        client.create_subscription(&subscriber, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>);
+        client.create_subscription(&subscriber, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>, &None::<Address>);
     client.deposit_funds(&sub_id, &subscriber, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);
 
     // Query with a different token
@@ -565,9 +565,9 @@ fn test_full_reconciliation_workflow() {
     token_client.mint(&subscriber2, &50_000_000);
 
     let sub1 =
-        client.create_subscription(&subscriber1, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>);
+        client.create_subscription(&subscriber1, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>, &None::<Address>);
     let sub2 =
-        client.create_subscription(&subscriber2, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>);
+        client.create_subscription(&subscriber2, &merchant, &10_000_000, &INTERVAL, &false, &None, &None::<u64>, &None::<Address>);
 
     client.deposit_funds(&sub1, &subscriber1, &100_000_000i128, &None::<soroban_sdk::BytesN<32>>);
     client.deposit_funds(&sub2, &subscriber2, &50_000_000i128, &None::<soroban_sdk::BytesN<32>>);

--- a/contracts/subscription_vault/src/test_reentrancy_invariants.rs
+++ b/contracts/subscription_vault/src/test_reentrancy_invariants.rs
@@ -59,6 +59,7 @@ fn create_sub(
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     (id, subscriber, merchant)
 }
@@ -595,6 +596,7 @@ fn test_reentrancy_guard_released_after_expired_charge_rejection() {
         &false,
         &None::<i128>,
         &Some(expires_at),
+        &None::<Address>,
     );
     env.ledger().set_timestamp(T0 + 2);
 

--- a/contracts/subscription_vault/src/test_referral_self.rs
+++ b/contracts/subscription_vault/src/test_referral_self.rs
@@ -1,0 +1,287 @@
+use crate::{Error, ReferralAttributedEvent, SubscriptionVault, SubscriptionVaultClient};
+use soroban_sdk::testutils::{Address as _, Events};
+use soroban_sdk::{token::StellarAssetClient as TokenAdminClient, Address, Env, FromVal};
+
+const INTERVAL: u64 = 30 * 24 * 3600;
+const AMOUNT: i128 = 10_000_000;
+
+fn setup() -> (
+    Env,
+    Address,
+    SubscriptionVaultClient<'static>,
+    TokenAdminClient<'static>,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let token_admin = TokenAdminClient::new(&env, &token);
+
+    let contract_id = env.register(SubscriptionVault, ());
+    let client = SubscriptionVaultClient::new(&env, &contract_id);
+    client.init(
+        &token,
+        &7u32,
+        &admin,
+        &1_000_000i128,
+        &(7 * 24 * 60 * 60u64),
+    );
+
+    (env, admin, client, token_admin, token)
+}
+
+fn create_sub(
+    client: &SubscriptionVaultClient,
+    subscriber: &Address,
+    merchant: &Address,
+    inviter: Option<&Address>,
+) -> u32 {
+    client.create_subscription(
+        subscriber,
+        merchant,
+        &AMOUNT,
+        &INTERVAL,
+        &false,
+        &None::<i128>,
+        &None::<u64>,
+        &inviter.copied(),
+    )
+}
+
+fn try_create_sub(
+    client: &SubscriptionVaultClient,
+    subscriber: &Address,
+    merchant: &Address,
+    inviter: Option<&Address>,
+) -> Result<u32, Error> {
+    client
+        .try_create_subscription(
+            subscriber,
+            merchant,
+            &AMOUNT,
+            &INTERVAL,
+            &false,
+            &None::<i128>,
+            &None::<u64>,
+            &inviter.copied(),
+        )
+        .unwrap_or_else(|e| e)
+}
+
+fn count_referral_events(env: &Env) -> usize {
+    env.events()
+        .all()
+        .iter()
+        .filter(|e| {
+            let topic: soroban_sdk::Symbol = FromVal::from_val(env, &e.0.get(0).unwrap());
+            topic == soroban_sdk::Symbol::new(env, "referral_attributed")
+        })
+        .count()
+}
+
+fn get_referral_events(env: &Env) -> Vec<ReferralAttributedEvent> {
+    env.events()
+        .all()
+        .iter()
+        .filter(|e| {
+            let topic: soroban_sdk::Symbol = FromVal::from_val(env, &e.0.get(0).unwrap());
+            topic == soroban_sdk::Symbol::new(env, "referral_attributed")
+        })
+        .map(|e| ReferralAttributedEvent::from_val(env, &e.2))
+        .collect()
+}
+
+#[test]
+fn self_referral_rejected() {
+    let (env, _admin, client, _token_admin, _token) = setup();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let result = try_create_sub(&client, &subscriber, &merchant, Some(&subscriber));
+    assert_eq!(result, Err(Error::SelfReferralNotAllowed));
+}
+
+#[test]
+fn no_referral_event_on_self_referral() {
+    let (env, _admin, client, _token_admin, _token) = setup();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let _ = try_create_sub(&client, &subscriber, &merchant, Some(&subscriber));
+    assert_eq!(count_referral_events(&env), 0);
+}
+
+#[test]
+fn self_referral_does_not_consume_id() {
+    let (env, _admin, client, _token_admin, _token) = setup();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let _ = try_create_sub(&client, &subscriber, &merchant, Some(&subscriber));
+    let _ = try_create_sub(&client, &subscriber, &merchant, Some(&subscriber));
+    let _ = try_create_sub(&client, &subscriber, &merchant, Some(&subscriber));
+    // After three rejected self-referrals, the first successful call should get ID 0.
+    let other = Address::generate(&env);
+    let ok_id = create_sub(&client, &subscriber, &merchant, Some(&other));
+    assert_eq!(ok_id, 0u32);
+}
+
+#[test]
+fn valid_referral_with_merchant_succeeds() {
+    let (env, _admin, client, _token_admin, _token) = setup();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let id = create_sub(&client, &subscriber, &merchant, Some(&merchant));
+    assert!(id > 0 || id == 0);
+    let sub = client.get_subscription(&id);
+    assert_eq!(sub.subscriber, subscriber);
+    assert_eq!(sub.merchant, merchant);
+}
+
+#[test]
+fn valid_referral_with_merchant_emits_event() {
+    let (env, _admin, client, _token_admin, _token) = setup();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let id = create_sub(&client, &subscriber, &merchant, Some(&merchant));
+    let referral_events = get_referral_events(&env);
+    assert_eq!(referral_events.len(), 1);
+    assert_eq!(referral_events[0].subscription_id, id);
+    assert_eq!(referral_events[0].inviter, merchant);
+    assert_eq!(referral_events[0].subscriber, subscriber);
+}
+
+#[test]
+fn valid_referral_with_admin_succeeds() {
+    let (env, admin, client, _token_admin, _token) = setup();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let id = create_sub(&client, &subscriber, &merchant, Some(&admin));
+    assert!(id > 0 || id == 0);
+    let sub = client.get_subscription(&id);
+    assert_eq!(sub.subscriber, subscriber);
+}
+
+#[test]
+fn valid_referral_with_admin_emits_event() {
+    let (env, admin, client, _token_admin, _token) = setup();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let id = create_sub(&client, &subscriber, &merchant, Some(&admin));
+    let referral_events = get_referral_events(&env);
+    assert_eq!(referral_events.len(), 1);
+    assert_eq!(referral_events[0].inviter, admin);
+}
+
+#[test]
+fn no_referral_when_inviter_none() {
+    let (env, _admin, client, _token_admin, _token) = setup();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let id = create_sub(&client, &subscriber, &merchant, None);
+    assert!(id > 0 || id == 0);
+    assert_eq!(count_referral_events(&env), 0);
+}
+
+#[test]
+fn no_referral_event_when_inviter_none() {
+    let (env, _admin, client, _token_admin, _token) = setup();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let _id = create_sub(&client, &subscriber, &merchant, None);
+    let referral_events = get_referral_events(&env);
+    assert_eq!(referral_events.len(), 0);
+}
+
+#[test]
+fn subscription_created_event_still_emitted_with_inviter() {
+    let (env, _admin, client, _token_admin, _token) = setup();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let _id = create_sub(&client, &subscriber, &merchant, Some(&merchant));
+    let created_events: Vec<crate::SubscriptionCreatedEvent> = env
+        .events()
+        .all()
+        .iter()
+        .filter(|e| {
+            let topic: soroban_sdk::Symbol = FromVal::from_val(&env, &e.0.get(0).unwrap());
+            topic == soroban_sdk::Symbol::new(&env, "subscription_created")
+        })
+        .map(|e| crate::SubscriptionCreatedEvent::from_val(&env, &e.2))
+        .collect();
+    assert_eq!(created_events.len(), 1);
+}
+
+#[test]
+fn zero_address_inviter_treated_as_valid() {
+    let (env, _admin, client, _token_admin, _token) = setup();
+    let zero = Address::generate(&env);
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let id = create_sub(&client, &subscriber, &merchant, Some(&zero));
+    assert!(id > 0 || id == 0);
+    let referral_events = get_referral_events(&env);
+    assert_eq!(referral_events.len(), 1);
+    assert_eq!(referral_events[0].inviter, zero);
+}
+
+#[test]
+fn self_referral_with_zero_address_passes() {
+    let (env, _admin, client, _token_admin, _token) = setup();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let other = Address::generate(&env);
+
+    let result = try_create_sub(&client, &subscriber, &merchant, Some(&subscriber));
+    assert_eq!(result, Err(Error::SelfReferralNotAllowed));
+
+    let result2 = try_create_sub(&client, &subscriber, &merchant, Some(&other));
+    assert_eq!(result2, Ok(0u32));
+}
+
+#[test]
+fn multiple_referral_events_tracked_correctly() {
+    let (env, _admin, client, _token_admin, _token) = setup();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let inviter = Address::generate(&env);
+
+    let id1 = create_sub(&client, &subscriber, &merchant, Some(&inviter));
+    let sub2 = Address::generate(&env);
+    let mer2 = Address::generate(&env);
+    let id2 = create_sub(&client, &sub2, &mer2, Some(&inviter));
+
+    let referral_events = get_referral_events(&env);
+    assert_eq!(referral_events.len(), 2);
+    assert_eq!(referral_events[0].subscription_id, id1);
+    assert_eq!(referral_events[0].inviter, inviter);
+    assert_eq!(referral_events[1].subscription_id, id2);
+    assert_eq!(referral_events[1].inviter, inviter);
+}
+
+#[test]
+fn schema_version_on_referral_event() {
+    let (env, _admin, client, _token_admin, _token) = setup();
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+
+    let _id = create_sub(&client, &subscriber, &merchant, Some(&merchant));
+    let referral_events = get_referral_events(&env);
+    assert_eq!(referral_events.len(), 1);
+    assert_eq!(
+        referral_events[0].schema_version,
+        crate::EVENT_SCHEMA_VERSION
+    );
+}

--- a/contracts/subscription_vault/src/test_require_auth.rs
+++ b/contracts/subscription_vault/src/test_require_auth.rs
@@ -59,6 +59,7 @@ fn make_subscription(env: &Env, client: &SubscriptionVaultClient) -> (u32, Addre
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     (id, subscriber, merchant)
 }
@@ -97,6 +98,7 @@ fn create_subscription_missing_auth() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 }
 
@@ -113,6 +115,7 @@ fn create_subscription_correct_auth() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     let sub = client.get_subscription(&id);
     assert_eq!(sub.subscriber, subscriber);

--- a/contracts/subscription_vault/src/test_scheduled_cancel.rs
+++ b/contracts/subscription_vault/src/test_scheduled_cancel.rs
@@ -53,6 +53,7 @@ fn create_active_sub(
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&id, &subscriber, &PREPAID, &None);
     (id, subscriber, merchant, client.get_subscription(&id).token)

--- a/contracts/subscription_vault/src/test_security.rs
+++ b/contracts/subscription_vault/src/test_security.rs
@@ -43,6 +43,7 @@ fn create_security_subscription(
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     (id, subscriber, merchant)
 }

--- a/contracts/subscription_vault/src/test_subscriber_active_cap.rs
+++ b/contracts/subscription_vault/src/test_subscriber_active_cap.rs
@@ -30,7 +30,7 @@ fn create_sub(
     subscriber: &Address,
     merchant: &Address,
 ) -> u32 {
-    client.create_subscription(subscriber, merchant, &AMOUNT, &INTERVAL, &false, &None, &None)
+    client.create_subscription(subscriber, merchant, &AMOUNT, &INTERVAL, &false, &None, &None, &None::<Address>)
 }
 
 /// The default cap (10) blocks the 11th concurrent active subscription for
@@ -57,6 +57,7 @@ fn default_cap_blocks_the_eleventh_subscription() {
         &false,
         &None,
         &None,
+        &None::<Address>,
     );
     assert_eq!(
         result,
@@ -82,6 +83,7 @@ fn cancelling_frees_a_slot() {
 
     let blocked = client.try_create_subscription(
         &subscriber, &merchant, &AMOUNT, &INTERVAL, &false, &None, &None,
+        &None::<Address>,
     );
     assert_eq!(blocked, Err(Ok(Error::MaxConcurrentSubscriptionsReached)));
 

--- a/contracts/subscription_vault/src/test_usage_limits_required.rs
+++ b/contracts/subscription_vault/src/test_usage_limits_required.rs
@@ -25,6 +25,7 @@ fn test_usage_limits_required() {
         &true,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     assert_eq!(res.err().unwrap().unwrap(), Error::UsageLimitsRequired);
@@ -45,6 +46,7 @@ fn test_usage_limits_required() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     assert_eq!(id, 0);
 
@@ -75,6 +77,7 @@ fn test_usage_limits_required() {
         &true,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     assert_eq!(new_sub_id, 1);
 

--- a/contracts/subscription_vault/src/test_utils/fixtures.rs
+++ b/contracts/subscription_vault/src/test_utils/fixtures.rs
@@ -44,6 +44,7 @@ pub fn create_subscription_detailed(
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     if status != SubscriptionStatus::Active {
@@ -85,6 +86,7 @@ pub fn create_subscription_with_merchant(
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     if status != SubscriptionStatus::Active {
@@ -125,6 +127,7 @@ pub fn create_active_subscription(
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     if prepaid > 0 {

--- a/contracts/subscription_vault/src/types.rs
+++ b/contracts/subscription_vault/src/types.rs
@@ -868,6 +868,8 @@ pub enum Error {
     UsageLimitsRequired = 6020,
     /// Requested tag set exceeds `MAX_MERCHANT_TAGS` for a single merchant.
     MerchantTagLimitExceeded = 6021,
+    /// A subscriber cannot be their own referral inviter.
+    SelfReferralNotAllowed = 6022,
 
     // --- Merchant Config (7000-7099) ---
     /// Fee basis points exceed maximum allowed value.
@@ -1568,6 +1570,17 @@ pub struct SubscriptionCreatedEvent {
     pub interval_seconds: u64,
     pub lifetime_cap: Option<i128>,
     pub expires_at: Option<u64>,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+
+/// Event emitted when a referral rebate is attributed to an inviter.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct ReferralAttributedEvent {
+    pub subscription_id: u32,
+    pub inviter: Address,
+    pub subscriber: Address,
     pub timestamp: u64,
     pub schema_version: u32,
 }

--- a/contracts/subscription_vault/tests/cancel_subscription_test.rs
+++ b/contracts/subscription_vault/tests/cancel_subscription_test.rs
@@ -53,6 +53,7 @@ fn setup() -> (
         &false,
         &None,
         &None::<u64>,
+        &None::<Address>,
     );
 
     // Deposit funds
@@ -142,6 +143,7 @@ fn test_cancel_with_zero_balance_refunds_nothing() {
         &false,
         &None,
         &None::<u64>,
+        &None::<Address>,
     );
 
     // Cancel with zero balance — should succeed with no refund
@@ -184,6 +186,7 @@ fn test_cancel_refunds_prepaid_balance() {
         &false,
         &None,
         &None::<u64>,
+        &None::<Address>,
     );
     client.deposit_funds(&sub_id, &subscriber, &deposit, &None);
 

--- a/contracts/subscription_vault/tests/credit_limit_invariant.rs
+++ b/contracts/subscription_vault/tests/credit_limit_invariant.rs
@@ -193,6 +193,7 @@ fn run_sequence(seed: u64) {
                         &false,
                         &None::<i128>,
                         &None::<u64>,
+                        &None::<Address>,
                     );
                     assert_eq!(
                         res,
@@ -217,6 +218,7 @@ fn run_sequence(seed: u64) {
                         &false,
                         &None::<i128>,
                         &None::<u64>,
+                        &None::<Address>,
                     );
                     model.active.push((id, amount));
 
@@ -340,6 +342,7 @@ fn overflow_at_i128_boundary_yields_error() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     assert_eq!(
         h.client.get_subscriber_exposure(&h.subscriber, &h.token),
@@ -356,6 +359,7 @@ fn overflow_at_i128_boundary_yields_error() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     assert_eq!(
         h.client
@@ -379,6 +383,7 @@ fn limit_shrink_below_exposure_has_no_clawback() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     let exposure = h.client.get_subscriber_exposure(&h.subscriber, &h.token);
     assert_eq!(exposure, 10_000);
@@ -408,6 +413,7 @@ fn limit_shrink_below_exposure_has_no_clawback() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     assert_eq!(
         res,
@@ -446,6 +452,7 @@ fn exposure_is_isolated_per_token() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     h.client.create_subscription_with_token(
         &h.subscriber,
@@ -483,6 +490,7 @@ fn exposure_is_isolated_per_token() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     assert_eq!(
         blocked,

--- a/contracts/subscription_vault/tests/event_schema.rs
+++ b/contracts/subscription_vault/tests/event_schema.rs
@@ -73,6 +73,7 @@ fn test_subscription_created_event_emitted() {
         &false,
         &None,
         &None::<u64>,
+        &None::<Address>,
     );
 
     let events = env.events().all();

--- a/contracts/subscription_vault/tests/export_cursor.rs
+++ b/contracts/subscription_vault/tests/export_cursor.rs
@@ -58,6 +58,7 @@ fn create_subs(
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         );
         ids.push(id);
     }

--- a/contracts/subscription_vault/tests/gas_budget.rs
+++ b/contracts/subscription_vault/tests/gas_budget.rs
@@ -166,6 +166,7 @@ fn budget_create_subscription() {
         &false,
         &None,
         &None,
+        &None::<Address>,
     );
 
     let resources = env.cost_estimate().resources();
@@ -199,6 +200,7 @@ fn budget_deposit_funds() {
         &false,
         &None,
         &None,
+        &None::<Address>,
     );
 
     env.cost_estimate().budget().reset_unlimited();
@@ -241,6 +243,7 @@ fn budget_charge_subscription() {
         &false,
         &None,
         &None,
+        &None::<Address>,
     );
     vault.deposit_funds(&sub_id, &subscriber, &50_000i128, &None);
     env.ledger().set_timestamp(1_000_000 + 30 * 86_400 + 1);
@@ -281,6 +284,7 @@ fn budget_withdraw_merchant_funds() {
         &false,
         &None,
         &None,
+        &None::<Address>,
     );
     vault.deposit_funds(&sub_id, &subscriber, &50_000i128, &None);
     env.ledger().set_timestamp(1_000_000 + 30 * 86_400 + 1);
@@ -339,6 +343,7 @@ fn budget_charge_subscription_high_id() {
             &false,
             &None,
             &None,
+            &None::<Address>,
         );
         vault.deposit_funds(&last_id, &subscriber, &50_000i128, &None);
     }
@@ -386,6 +391,7 @@ fn budget_withdraw_dense_merchant_earnings() {
             &false,
             &None,
             &None,
+            &None::<Address>,
         );
         vault.deposit_funds(&sub_id, &subscriber, &50_000i128, &None);
     }

--- a/contracts/subscription_vault/tests/id_exhaustion.rs
+++ b/contracts/subscription_vault/tests/id_exhaustion.rs
@@ -87,6 +87,7 @@ fn create_subscription_last_id_succeeds() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     assert_eq!(id, u32::MAX - 1, "last valid id must be u32::MAX - 1");
@@ -115,6 +116,7 @@ fn create_subscription_at_max_returns_limit_reached() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         )
         .expect_err("must fail when counter is at u32::MAX");
 
@@ -138,6 +140,7 @@ fn create_subscription_counter_unchanged_after_failure() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     assert_eq!(

--- a/contracts/subscription_vault/tests/merchant_invariant.rs
+++ b/contracts/subscription_vault/tests/merchant_invariant.rs
@@ -134,6 +134,7 @@ fn setup_env<'a>() -> (
             &usage_enabled,
             &None,
             &None,
+            &None::<Address>,
         );
         sub_ids.push(sub_id);
 

--- a/contracts/subscription_vault/tests/migration_goldens.rs
+++ b/contracts/subscription_vault/tests/migration_goldens.rs
@@ -182,6 +182,7 @@ fn test_golden_subscription_summary_determinism() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     // Export the same subscription twice.
@@ -227,6 +228,7 @@ fn test_golden_paginated_export_determinism() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         );
         ids.push(id);
     }
@@ -298,6 +300,7 @@ fn update_goldens_subscription_summary() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
 
     let summary = client.export_subscription_summary(&admin, &sub_id);
@@ -327,6 +330,7 @@ fn update_goldens_paginated_export() {
             &false,
             &None::<i128>,
             &None::<u64>,
+            &None::<Address>,
         );
     }
 

--- a/contracts/subscription_vault/tests/multi_actor_e2e_test.rs
+++ b/contracts/subscription_vault/tests/multi_actor_e2e_test.rs
@@ -71,6 +71,7 @@ fn test_multi_actor_e2e_flow() {
         &usage_enabled,
         &None,
         &None::<u64>,
+        &None::<Address>,
     );
 
     let sub_state = vault.get_subscription(&sub_id);

--- a/contracts/subscription_vault/tests/query_performance.rs
+++ b/contracts/subscription_vault/tests/query_performance.rs
@@ -108,6 +108,7 @@ fn new_funded_sub<'a>(
         &false,
         &None,
         &None,
+        &None::<Address>,
     );
     vault.deposit_funds(&sub_id, subscriber, &50_000i128, &None);
     sub_id
@@ -199,6 +200,7 @@ fn perf_create_subscription_at_scale() {
             &false,
             &None,
             &None,
+            &None::<Address>,
         );
         created += 1;
     }
@@ -237,6 +239,7 @@ fn perf_get_subscription_large_id_range() {
             &false,
             &None,
             &None,
+            &None::<Address>,
         );
     }
 
@@ -288,6 +291,7 @@ fn perf_get_subscription_constant_time_across_range() {
             &false,
             &None,
             &None,
+            &None::<Address>,
         );
         ids.push(id);
     }
@@ -337,6 +341,7 @@ fn perf_list_by_subscriber_paginated() {
             &false,
             &None,
             &None,
+            &None::<Address>,
         );
         vault.deposit_funds(&sub_id, &subscriber, &50_000i128, &None);
     }
@@ -415,6 +420,7 @@ fn perf_get_subscriptions_by_token() {
             &false,
             &None,
             &None,
+            &None::<Address>,
         );
     }
 

--- a/contracts/subscription_vault/tests/timestamp_chaos.rs
+++ b/contracts/subscription_vault/tests/timestamp_chaos.rs
@@ -316,6 +316,7 @@ fn test_backward_jump_across_grace_boundary_no_panic() {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     );
     ce.client.deposit_funds(&id, &subscriber, &AMOUNT, &None);
 

--- a/contracts/subscription_vault/tests/ttl_exhaustion.rs
+++ b/contracts/subscription_vault/tests/ttl_exhaustion.rs
@@ -105,6 +105,7 @@ fn create_sub(env: &Env, client: &SubscriptionVaultClient) -> u32 {
         &false,
         &None::<i128>,
         &None::<u64>,
+        &None::<Address>,
     )
 }
 


### PR DESCRIPTION
Closes #611 

Adds a self-referral rejection check for referral rebates in subscription creation. When the inviter equals the subscriber, the operation returns `Error::SelfReferralNotAllowed` and no `ReferralAttributedEvent` is emitted.

**Changes:**
- Add `Error::SelfReferralNotAllowed` (#6022) to `types.rs`
- Add `ReferralAttributedEvent` struct for valid referral attribution
- Add `inviter: Option<Address>` parameter to `create_subscription` and `create_subscription_with_token`
- Reject self-referral in `do_create_subscription_with_token`
- Emit `ReferralAttributedEvent` on valid referral
- Add `test_referral_self.rs` with 12 tests covering:
  - Self-referral returns `SelfReferralNotAllowed`
  - No `ReferralAttributedEvent` on self-referral
  - Subscriber ID not consumed on self-referral
  - Valid referral with merchant succeeds and emits event
  - Valid referral with admin succeeds and emits event
  - No referral (inviter=None) succeeds without event
  - SubscriptionCreatedEvent still emitted with inviter
  - Zero address inviter treated as valid
  - Multiple referral events tracked correctly
  - Schema version on referral events