### PR TITLE
perf: remove redundant require_auth in helpers (#622)

### DIFF
--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -1016,7 +1016,8 @@ impl SubscriptionVault {
     ) -> Result<Vec<crate::types::BulkDepositResult>, Error> {
         require_not_emergency_stop(&env)?;
         let _guard = crate::reentrancy::ReentrancyGuard::lock(&env, "bulk_deposit_funds")?;
-        caller.require_auth();
+        // Auth already performed by subscription::bulk_precheck →
+        // admin::require_admin_or_operator_auth (deduplicated from this entrypoint).
         subscription::do_bulk_deposit_funds(&env, caller, &entries, nonce)
     }
 

--- a/contracts/subscription_vault/src/subscription.rs
+++ b/contracts/subscription_vault/src/subscription.rs
@@ -4,6 +4,30 @@
 //!
 //! **PRs that only change subscription lifecycle or billing should edit this file only.**
 //!
+//! # Auth Ownership
+//!
+//! Every `require_auth()` call in this module lives in a `pub fn do_*` entrypoint.
+//! Internal helpers never call `require_auth()` — they inherit auth from their
+//! caller. The table below maps each helper to the entrypoint that owns auth.
+//!
+//! | Helper function | Auth-owning entrypoint | Auth mechanism |
+//! |---|---|---|
+//! | `apply_cancellation` | `do_cancel_subscription` | `authorizer.require_auth()` + identity |
+//! | `apply_cancellation` | `do_bulk_cancel_subscriptions` → `bulk_precheck` | `require_admin_or_operator_auth` |
+//! | `apply_pause` | `do_pause_subscription` | `authorizer.require_auth()` + identity |
+//! | `apply_pause` | `do_bulk_pause_subscriptions` → `bulk_precheck` | `require_admin_or_operator_auth` |
+//! | `bulk_pause_one` | `do_bulk_pause_subscriptions` → `bulk_precheck` | `require_admin_or_operator_auth` |
+//! | `bulk_cancel_one` | `do_bulk_cancel_subscriptions` → `bulk_precheck` | `require_admin_or_operator_auth` |
+//! | `bulk_deposit_one` | `do_bulk_deposit_funds` → `bulk_precheck` | `require_admin_or_operator_auth` |
+//! | `bulk_precheck` | `do_bulk_*` entrypoints | `require_admin_or_operator_auth` (self-owned) |
+//!
+//! `bulk_precheck` is the only private helper that performs auth; it is called
+//! from `do_bulk_pause_subscriptions`, `do_bulk_cancel_subscriptions`, and
+//! `do_bulk_deposit_funds`. None of those callers duplicate the check — the
+//! public entrypoint in `lib.rs` for `bulk_deposit_funds` formerly had a
+//! redundant `caller.require_auth()` that was removed in favour of the
+//! check inside `bulk_precheck`.
+//!
 //! # Reentrancy Protection
 //!
 //! This module contains two critical external calls to the token contract:

--- a/contracts/subscription_vault/src/test_require_auth.rs
+++ b/contracts/subscription_vault/src/test_require_auth.rs
@@ -496,3 +496,43 @@ fn get_min_topup_returns_stored_value_unchanged() {
     client.set_min_topup(&admin, &new_topup);
     assert_eq!(client.get_min_topup(), new_topup);
 }
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 8. bulk_deposit_funds — admin or operator must authorize
+//
+// Auth is performed by `bulk_precheck` → `require_admin_or_operator_auth`.
+// The lib.rs entrypoint no longer has its own `require_auth()` call — it relies
+// entirely on the helper path for auth (perf/dedup-require-auth #622).
+// ═════════════════════════════════════════════════════════════════════════════
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1001)")] // Error::Unauthorized
+fn bulk_deposit_funds_unauthorized_caller() {
+    let (env, client, token, _) = setup();
+    let (id, subscriber, _) = make_subscription(&env, &client);
+    // Fund the subscription so the deposit could succeed.
+    soroban_sdk::token::StellarAssetClient::new(&env, &token).mint(&subscriber, &DEPOSIT);
+    client.deposit_funds(&id, &subscriber, &DEPOSIT, &None::<soroban_sdk::BytesN<32>>, &None::<soroban_sdk::BytesN<32>>);
+
+    // A random non-admin, non-operator caller.
+    let random_caller = Address::generate(&env);
+    let mut entries = Vec::new(&env);
+    entries.push_back((id, MIN_TOPUP));
+
+    // mock_all_auths satisfies require_auth() for any address, but the identity
+    // check in require_admin_or_operator_auth rejects a non-admin/operator caller.
+    let res = client.try_bulk_deposit_funds(&random_caller, &entries, &0u64);
+    assert!(res.is_err());
+}
+
+#[test]
+fn bulk_deposit_funds_empty_vector_no_op() {
+    // An empty entries list is a no-op that does NOT consume a nonce and does
+    // NOT require admin/operator auth — it returns early before bulk_precheck.
+    let (env, client, _, _admin) = setup();
+    let empty: Vec<(u32, i128)> = Vec::new(&env);
+    // Even a non-admin can call with empty entries — it's a no-op.
+    let random = Address::generate(&env);
+    let results = client.bulk_deposit_funds(&random, &empty, &0u64);
+    assert_eq!(results.len(), 0);
+}


### PR DESCRIPTION
closes #622 

Remove duplicate caller.require_auth() from lib.rs bulk_deposit_funds entrypoint. Auth is already performed by bulk_precheck -> require_admin_or_operator_auth. Add auth-ownership table to subscription.rs module docs. Add negative auth-boundary test confirming non-admin caller is rejected.