### PR TITLE
feat: merchant sub-accounts with isolated ledgers (#575)

### DIFF
--- a/contracts/subscription_vault/src/admin.rs
+++ b/contracts/subscription_vault/src/admin.rs
@@ -779,6 +779,35 @@ pub fn rewrite_subscriptions_for_ledger_expiration(env: &Env) -> u32 {
     touched
 }
 
+/// v4 → v5 migration: rewrite every `DataKey::Sub(id)` record so the new
+/// `sub_account_label: Option<Symbol>` field deserializes cleanly for
+/// subscriptions created before STORAGE_VERSION 5.  The in-memory struct
+/// already carries `sub_account_label: None` after the deserialization
+/// round-trip, so this just needs to read-write each record.
+pub fn rewrite_subscriptions_for_sub_account_label(env: &Env) -> u32 {
+    let next_id: u32 = read_config(env, &DataKey::NextId).unwrap_or(0);
+    let mut touched = 0u32;
+    for id in 0..next_id {
+        let key = DataKey::Sub(id);
+        if let Some(sub) = env
+            .storage()
+            .persistent()
+            .get::<_, crate::types::Subscription>(&key)
+        {
+            // Round-trip: deserialise populates `sub_account_label: None`,
+            // then write back so XDR encoding includes the new field.
+            env.storage().persistent().set(&key, &sub);
+            env.storage().persistent().extend_ttl(
+                &key,
+                SUB_TTL_THRESHOLD,
+                SUB_TTL_EXTEND_TO,
+            );
+            touched = touched.saturating_add(1);
+        }
+    }
+    touched
+}
+
 pub fn do_migrate_config_to_persistent_internal(env: &Env) -> Result<(), Error> {
     let instance = env.storage().instance();
     let persistent = env.storage().persistent();
@@ -939,6 +968,13 @@ pub fn do_migrate(
             (3, _) => {
                 rewrite_subscriptions_for_ledger_expiration(env);
                 current = 4;
+            }
+            // v4 → v5: rewrite every `DataKey::Sub(id)` record so the new
+            // `sub_account_label: Option<Symbol>` field deserializes cleanly
+            // for subscriptions created before STORAGE_VERSION 5.
+            (4, _) => {
+                rewrite_subscriptions_for_sub_account_label(env);
+                current = 5;
             }
             _ => {
                 current += 1;

--- a/contracts/subscription_vault/src/charge_core.rs
+++ b/contracts/subscription_vault/src/charge_core.rs
@@ -189,6 +189,12 @@ pub fn charge_one(
     crate::blocklist::require_not_blocklisted(env, &sub.merchant)
         .map_err(|e| charge_fail(env, subscription_id, e, 0, now))?;
 
+    // Validate sub-account label exists before any state mutation
+    if let Some(ref label) = sub.sub_account_label {
+        crate::merchant::require_sub_account_exists(env, &sub.merchant, label)
+            .map_err(|e| charge_fail(env, subscription_id, e, 0, now))?;
+    }
+
     // Expiration guard
     if sub.is_expired(now, env.ledger().sequence()) {
         if sub.status != SubscriptionStatus::Expired {
@@ -458,6 +464,16 @@ pub fn charge_one(
                 merchant_amount,
                 BillingChargeKind::Interval,
             )?;
+
+            // Route merchant amount to sub-account if subscription has one
+            if let Some(ref label) = sub.sub_account_label {
+                crate::merchant::credit_sub_account(env, &sub.merchant, label, &sub.token, merchant_amount)?;
+                // Deduct from parent balance (parent earnings stay for roll-up reporting)
+                let parent_bal = crate::merchant::get_merchant_balance_by_token(env, &sub.merchant, &sub.token);
+                let new_parent_bal = crate::safe_math::safe_sub(parent_bal, merchant_amount)?;
+                crate::merchant::set_merchant_balance(env, &sub.merchant, &sub.token, &new_parent_bal);
+            }
+
             let conversion = if fee_amount > 0 {
                 Some(convert_fee(env, &sub.token, fee_amount))
             } else {
@@ -764,6 +780,12 @@ pub fn charge_usage_one(
     crate::blocklist::require_not_blocklisted(env, &sub.merchant)
         .map_err(|e| charge_fail(env, subscription_id, e, 0, env.ledger().timestamp()))?;
 
+    // Validate sub-account label exists before any state mutation
+    if let Some(ref label) = sub.sub_account_label {
+        crate::merchant::require_sub_account_exists(env, &sub.merchant, label)
+            .map_err(|e| charge_fail(env, subscription_id, e, 0, env.ledger().timestamp()))?;
+    }
+
     let now = env.ledger().timestamp();
     // Expiration guard
     if sub.is_expired(now, env.ledger().sequence()) {
@@ -1029,6 +1051,16 @@ pub fn charge_usage_one(
                 merchant_amount,
                 BillingChargeKind::Usage,
             )?;
+
+            // Route merchant amount to sub-account if subscription has one
+            if let Some(ref label) = sub.sub_account_label {
+                crate::merchant::credit_sub_account(env, &sub.merchant, label, &sub.token, merchant_amount)?;
+                // Deduct from parent balance (parent earnings stay for roll-up reporting)
+                let parent_bal = crate::merchant::get_merchant_balance_by_token(env, &sub.merchant, &sub.token);
+                let new_parent_bal = crate::safe_math::safe_sub(parent_bal, merchant_amount)?;
+                crate::merchant::set_merchant_balance(env, &sub.merchant, &sub.token, &new_parent_bal);
+            }
+
             let conversion = if fee_amount > 0 {
                 Some(convert_fee(env, &sub.token, fee_amount))
             } else {

--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -640,7 +640,8 @@ pub use types::{
     MigrationExportEvent, NextChargeInfo, OneOffChargedEvent, OperatorRemovedEvent,
     OperatorSetEvent, OracleConfig, OracleLivenessEvent, OraclePrice, PartialRefundEvent,
     PayoutSchedule, PlanTemplate, PlanTemplateUpdatedEvent, PrepaidQueryRequest,
-    PrepaidQueryResult, ProtocolFeeChargedEvent, ReconciliationProof, ReconciliationSummaryPage,
+    PrepaidQueryResult, ProtocolFeeChargedEvent, ReconciliationProof,
+    ReconciliationSummaryPage, SubAccountCreatedEvent, SubAccountWithdrawEvent,
     RecoveryEvent, RecoveryReason, ScheduledPayoutEvent, SchemaMigratedEvent,
     SignedMetadataPayload, SnapshotExportedEvent, SnapshotRestoredEvent, SubscriberWithdrawalEvent,
     Subscription, SubscriptionCancelledEvent, SubscriptionChargeFailedEvent,
@@ -664,7 +665,7 @@ pub const MAX_SUBSCRIPTION_ID: u32 = u32::MAX;
 /// field. Existing live `DataKey::Sub(id)` records were serialized without this
 /// trailing field; the `v3 → v4` step in [`admin::do_migrate`] walks every
 /// subscription record and rewrites it so the new field deserializes cleanly.
-const STORAGE_VERSION: u32 = 4;
+const STORAGE_VERSION: u32 = 5;
 
 /// Hard upper bound on the number of subscriptions that may be exported in a single call.
 const MAX_EXPORT_LIMIT: u32 = 100;
@@ -1378,6 +1379,7 @@ impl SubscriptionVault {
         lifetime_cap: Option<i128>,
         expires_at: Option<u64>,
         expires_at_ledger: Option<u32>,
+        sub_account_label: Option<Symbol>,
     ) -> Result<u32, Error> {
         require_not_emergency_stop(&env)?;
         let sub_id = subscription::do_create_subscription(
@@ -1390,6 +1392,7 @@ impl SubscriptionVault {
             lifetime_cap,
             expires_at,
             expires_at_ledger,
+            sub_account_label,
         )?;
         let token: Address = admin::read_config(&env, &DataKey::Token).ok_or(Error::NotFound)?;
         env.events().publish(
@@ -1424,6 +1427,7 @@ impl SubscriptionVault {
         lifetime_cap: Option<i128>,
         expires_at: Option<u64>,
         expires_at_ledger: Option<u32>,
+        sub_account_label: Option<Symbol>,
     ) -> Result<u32, Error> {
         require_not_emergency_stop(&env)?;
         let sub_id = subscription::do_create_subscription_with_token(
@@ -1437,6 +1441,7 @@ impl SubscriptionVault {
             lifetime_cap,
             expires_at,
             expires_at_ledger,
+            sub_account_label,
         )?;
         env.events().publish(
             (Symbol::new(&env, "created"), sub_id),
@@ -1554,9 +1559,10 @@ impl SubscriptionVault {
         env: Env,
         subscriber: Address,
         plan_template_id: u32,
+        sub_account_label: Option<Symbol>,
     ) -> Result<u32, Error> {
         require_not_emergency_stop(&env)?;
-        subscription::do_create_subscription_from_plan(&env, subscriber, plan_template_id)
+        subscription::do_create_subscription_from_plan(&env, subscriber, plan_template_id, sub_account_label)
     }
 
     /// Retrieve a plan template.
@@ -2285,6 +2291,79 @@ impl SubscriptionVault {
     /// Get payout schedule.
     pub fn get_payout_schedule(env: Env, merchant: Address) -> PayoutSchedule {
         merchant::get_payout_schedule(&env, &merchant)
+    }
+
+    // ── Sub-Accounts (#575) ────────────────────────────────────────────────────
+
+    /// Register a new labelled sub-account (department) for a merchant.
+    ///
+    /// Sub-accounts provide isolated ledgers within one merchant identity.
+    /// Subscriptions can route charges to a specific sub-account by setting
+    /// `sub_account_label` at creation time.
+    ///
+    /// # Arguments
+    /// * `merchant` — The merchant address; must authorise the call.
+    /// * `label` — A unique label for the sub-account (e.g. `"sales"` or `"engineering"`).
+    ///
+    /// # Errors
+    /// * [`Error::NotFound`] — Merchant config not initialised.
+    /// * [`Error::InvalidInput`] — Label is empty or already registered.
+    ///
+    /// # Events
+    /// Emits [`SubAccountCreatedEvent`] with topic `("sub_account_created", merchant, label)`.
+    pub fn register_sub_account(
+        env: Env,
+        merchant: Address,
+        label: Symbol,
+    ) -> Result<(), Error> {
+        merchant::register_sub_account(&env, merchant, label)
+    }
+
+    /// Withdraw funds from a merchant sub-account.
+    ///
+    /// Funds are transferred to the merchant's address (must authorise).
+    /// Sub-account balances are independent from the parent merchant balance
+    /// but roll up to the parent in earnings reporting.
+    ///
+    /// # Arguments
+    /// * `merchant` — The merchant address; must authorise the call.
+    /// * `label` — The sub-account label to withdraw from.
+    /// * `token` — The token to withdraw.
+    /// * `amount` — Amount to withdraw (must be positive and ≤ sub-account balance).
+    ///
+    /// # Errors
+    /// * [`Error::NotFound`] — Sub-account does not exist or balance is zero.
+    /// * [`Error::InvalidAmount`] — Amount is zero or negative.
+    /// * [`Error::InsufficientBalance`] — Sub-account balance or vault balance is insufficient.
+    ///
+    /// # Events
+    /// Emits [`SubAccountWithdrawEvent`] with topic `("sub_account_withdrawn", merchant, label)`.
+    pub fn withdraw_sub_account_funds(
+        env: Env,
+        merchant: Address,
+        label: Symbol,
+        token: Address,
+        amount: i128,
+    ) -> Result<(), Error> {
+        let _guard = crate::reentrancy::ReentrancyGuard::lock(&env, "withdraw_sub_account_funds")?;
+        merchant::withdraw_sub_account_funds(&env, merchant, label, token, amount)
+    }
+
+    /// Get the current balance of a merchant sub-account.
+    pub fn get_sub_account_balance(
+        env: Env,
+        merchant: Address,
+        label: Symbol,
+    ) -> i128 {
+        merchant::get_sub_account_balance(&env, &merchant, &label)
+    }
+
+    /// Get the list of registered sub-account labels for a merchant.
+    pub fn get_sub_account_list(
+        env: Env,
+        merchant: Address,
+    ) -> Vec<Symbol> {
+        merchant::get_sub_account_list(&env, &merchant)
     }
 
     // ── Dispute / Chargeback ──────────────────────────────────────────────────
@@ -3128,3 +3207,6 @@ mod test_merchant_tags;
 
 #[cfg(test)]
 mod test_referral_self;
+
+#[cfg(test)]
+mod test_merchant_sub_accounts;

--- a/contracts/subscription_vault/src/merchant.rs
+++ b/contracts/subscription_vault/src/merchant.rs
@@ -788,8 +788,6 @@ pub fn withdraw_merchant_funds_for_token(
 
     // ─────────────── EFFECTS ───────────────
     set_merchant_balance(env, &merchant, &token_addr, &new_balance);
-    // EFFECTS
-    set_merchant_balance(env, &merchant, &token_addr, &new_balance);
 
     let mut earnings = get_merchant_token_earnings(env, &merchant, &token_addr);
     earnings.refunds = earnings
@@ -1550,6 +1548,228 @@ pub fn do_deprecate_plan(
             schema_version: crate::types::EVENT_SCHEMA_VERSION,
         },
     );
+
+    Ok(())
+}
+
+// ── Merchant Sub-Accounts (#575) ─────────────────────────────────────────────
+//
+// Let a merchant declare labelled sub-accounts (departments) so subscriptions
+// can route to specific ledgers within one merchant identity.
+//
+// Each sub-account has an isolated balance stored under
+// `DataKey::MerchantSubAccount(merchant, label)`.  Sub-account balances
+// withdraw independently but roll up to the parent for reporting — parent
+// `MerchantEarnings` reflect all charges including sub-account-routed ones.
+//
+// Security invariants:
+// 1. Only the merchant address may register or withdraw from their sub-accounts.
+// 2. Duplicate labels are rejected at registration time.
+// 3. Unknown (unregistered) sub-account labels are rejected at charge time.
+// 4. Withdrawals follow CEI (Checks-Effects-Interactions).
+
+/// Return `Ok(())` if `label` is a registered sub-account for `merchant`.
+pub fn require_sub_account_exists(env: &Env, merchant: &Address, label: &Symbol) -> Result<(), Error> {
+    let key = DataKey::MerchantSubAccount(merchant.clone(), label.clone());
+    if !env.storage().instance().has(&key) {
+        return Err(Error::NotFound);
+    }
+    Ok(())
+}
+
+/// Return the current balance of a merchant sub-account.
+pub fn get_sub_account_balance(env: &Env, merchant: &Address, label: &Symbol) -> i128 {
+    let key = DataKey::MerchantSubAccount(merchant.clone(), label.clone());
+    env.storage().instance().get(&key).unwrap_or(0i128)
+}
+
+/// Return the list of registered sub-account labels for `merchant`.
+pub fn get_sub_account_list(env: &Env, merchant: &Address) -> Vec<Symbol> {
+    let key = DataKey::MerchantSubAccountList(merchant.clone());
+    env.storage().instance().get(&key).unwrap_or(Vec::new(env))
+}
+
+/// Register a new labelled sub-account for the merchant.
+///
+/// # Arguments
+/// - `merchant` — Address that will own the sub-account; must authorise.
+/// - `label` — Unique label identifying the sub-account (e.g. `"sales"`).
+///
+/// # Errors
+/// - [`Error::Unauthorized`] if `merchant` does not authorise the call.
+/// - [`Error::NotFound`] if the merchant has not initialized their config.
+/// - [`Error::InvalidInput`] if `label` is empty or already registered.
+///
+/// # Events
+/// Emits [`SubAccountCreatedEvent`] with topics `("sub_account_created", merchant, label)`.
+pub fn register_sub_account(
+    env: &Env,
+    merchant: Address,
+    label: Symbol,
+) -> Result<(), Error> {
+    merchant.require_auth();
+
+    // Reject empty labels
+    let label_str: soroban_sdk::String = label.to_string();
+    if label_str.len() == 0 {
+        return Err(Error::InvalidInput);
+    }
+
+    // Ensure merchant config exists (merchant must be initialized)
+    let _config = get_merchant_config(env, merchant.clone()).ok_or(Error::NotFound)?;
+
+    // Reject duplicate
+    let list_key = DataKey::MerchantSubAccountList(merchant.clone());
+    let mut labels: Vec<Symbol> = env.storage().instance().get(&list_key).unwrap_or(Vec::new(env));
+    if labels.contains(&label) {
+        return Err(Error::InvalidInput);
+    }
+
+    // Register the sub-account with zero balance
+    let bal_key = DataKey::MerchantSubAccount(merchant.clone(), label.clone());
+    env.storage().instance().set(&bal_key, &0i128);
+
+    // Update the label index
+    labels.push_back(label.clone());
+    env.storage().instance().set(&list_key, &labels);
+
+    // Emit event
+    env.events().publish(
+        (
+            Symbol::new(env, "sub_account_created"),
+            merchant.clone(),
+            label.clone(),
+        ),
+        crate::types::SubAccountCreatedEvent {
+            merchant: merchant.clone(),
+            label: label.clone(),
+            timestamp: env.ledger().timestamp(),
+            schema_version: crate::types::EVENT_SCHEMA_VERSION,
+        },
+    );
+
+    Ok(())
+}
+
+/// Credit the given `amount` (in `token`) to a merchant sub-account.
+///
+/// Called internally by the charge engine when a subscription has a
+/// `sub_account_label`.  The parent `MerchantEarnings` are unaffected
+/// (they are already credited by `credit_merchant_balance_for_token`)
+/// so that roll-up reporting still sees the total.
+///
+/// # Errors
+/// - [`Error::NotFound`] if the sub-account has not been registered.
+/// - [`Error::Overflow`] if the new balance exceeds `i128::MAX`.
+pub fn credit_sub_account(
+    env: &Env,
+    merchant: &Address,
+    label: &Symbol,
+    _token: &Address,
+    amount: i128,
+) -> Result<(), Error> {
+    if amount <= 0 {
+        return Err(Error::InvalidAmount);
+    }
+
+    require_sub_account_exists(env, merchant, label)?;
+
+    let bal_key = DataKey::MerchantSubAccount(merchant.clone(), label.clone());
+    let current: i128 = env.storage().instance().get(&bal_key).unwrap_or(0i128);
+    let new_balance = current.checked_add(amount).ok_or(Error::Overflow)?;
+    env.storage().instance().set(&bal_key, &new_balance);
+
+    Ok(())
+}
+
+/// Withdraw funds from a merchant sub-account to the merchant's payout address.
+///
+/// # Arguments
+/// - `merchant` — Must authorise the call.
+/// - `label` — Which sub-account to withdraw from.
+/// - `token_addr` — The token to withdraw.
+/// - `amount` — Amount to withdraw (must be positive and ≤ sub-account balance).
+///
+/// # Errors
+/// - [`Error::Unauthorized`] — caller does not match `merchant`.
+/// - [`Error::NotFound`] — sub-account does not exist.
+/// - [`Error::InvalidAmount`] — `amount` ≤ 0.
+/// - [`Error::InsufficientBalance`] — sub-account balance < `amount`.
+///
+/// # Events
+/// Emits [`SubAccountWithdrawEvent`] with topics `("sub_account_withdrawn", merchant, label)`.
+pub fn withdraw_sub_account_funds(
+    env: &Env,
+    merchant: Address,
+    label: Symbol,
+    token_addr: Address,
+    amount: i128,
+) -> Result<(), Error> {
+    merchant.require_auth();
+
+    if amount <= 0 {
+        return Err(Error::InvalidAmount);
+    }
+
+    require_sub_account_exists(env, &merchant, &label)?;
+
+    // Checks: read sub-account balance first (before any external calls)
+    let bal_key = DataKey::MerchantSubAccount(merchant.clone(), label.clone());
+    let current: i128 = env.storage().instance().get(&bal_key).unwrap_or(0i128);
+
+    if current == 0 {
+        return Err(Error::NotFound);
+    }
+    if amount > current {
+        return Err(Error::InsufficientBalance);
+    }
+
+    // Vault balance check (external call, after storage checks per CEI)
+    let token_client = token::Client::new(env, &token_addr);
+    let contract = env.current_contract_address();
+
+    if token_client.balance(&contract) < amount {
+        return Err(Error::InsufficientBalance);
+    }
+
+    let new_balance = current.checked_sub(amount).ok_or(Error::Underflow)?;
+
+    // EFFECTS: Update sub-account balance
+    env.storage().instance().set(&bal_key, &new_balance);
+
+    // EFFECTS: Update parent earnings (withdrawal tracked at parent level)
+    let mut earnings = get_merchant_token_earnings(env, &merchant, &token_addr);
+    earnings.withdrawals = earnings
+        .withdrawals
+        .checked_add(amount)
+        .ok_or(Error::Overflow)?;
+    set_merchant_token_earnings(env, &merchant, &token_addr, &earnings);
+    crate::accounting::sub_total_accounted(env, &token_addr, amount)?;
+
+    // EFFECTS: Emit event
+    env.events().publish(
+        (
+            Symbol::new(env, "sub_account_withdrawn"),
+            merchant.clone(),
+            label.clone(),
+        ),
+        crate::types::SubAccountWithdrawEvent {
+            merchant: merchant.clone(),
+            label: label.clone(),
+            token: token_addr.clone(),
+            amount,
+            remaining_balance: new_balance,
+            timestamp: env.ledger().timestamp(),
+            schema_version: crate::types::EVENT_SCHEMA_VERSION,
+        },
+    );
+
+    // INTERACTION: Transfer tokens to merchant
+    token_client.transfer(&contract, &merchant, &amount);
+
+    // INVARIANT (test/CI only)
+    #[cfg(any(test, feature = "invariants"))]
+    crate::invariants::assert_token_balance_invariant(env, &token_addr)?;
 
     Ok(())
 }

--- a/contracts/subscription_vault/src/merchant.rs
+++ b/contracts/subscription_vault/src/merchant.rs
@@ -1622,7 +1622,7 @@ pub fn register_sub_account(
     merchant.require_auth();
 
     // Reject empty labels
-    let label_str: soroban_sdk::String = label.to_string();
+    let label_str = label.to_str(env);
     if label_str.len() == 0 {
         return Err(Error::InvalidInput);
     }

--- a/contracts/subscription_vault/src/merchant_api.rs
+++ b/contracts/subscription_vault/src/merchant_api.rs
@@ -79,9 +79,10 @@ pub use crate::merchant::{
     do_flush_payouts, do_set_payout_schedule, get_merchant_balance, get_merchant_balance_by_token,
     get_merchant_config, get_merchant_multisig_config, get_merchant_paused,
     get_merchant_token_earnings, get_merchant_total_earnings, get_payout_schedule,
-    get_reconciliation_snapshot, initialize_merchant_config, merchant_refund, pause_merchant,
+    get_reconciliation_snapshot, get_sub_account_balance, get_sub_account_list,
+    initialize_merchant_config, merchant_refund, pause_merchant, register_sub_account,
     set_merchant_config, set_merchant_multisig, unpause_merchant, update_merchant_config,
-    withdraw_merchant_funds, withdraw_merchant_funds_for_token,
+    withdraw_merchant_funds, withdraw_merchant_funds_for_token, withdraw_sub_account_funds,
 };
 pub use crate::queries::{
     generate_reconciliation_proof, get_contract_reconciliation_summary,

--- a/contracts/subscription_vault/src/subscription.rs
+++ b/contracts/subscription_vault/src/subscription.rs
@@ -491,6 +491,7 @@ pub fn do_create_subscription(
     lifetime_cap: Option<i128>,
     expires_at: Option<u64>,
     expires_at_ledger: Option<u32>,
+    sub_account_label: Option<Symbol>,
 ) -> Result<u32, Error> {
     let token = crate::admin::get_token(env)?;
 
@@ -508,6 +509,7 @@ pub fn do_create_subscription(
         lifetime_cap,
         expires_at,
         expires_at_ledger,
+        sub_account_label,
     )
 }
 
@@ -523,6 +525,7 @@ pub fn do_create_subscription_with_token(
     lifetime_cap: Option<i128>,
     expires_at: Option<u64>,
     expires_at_ledger: Option<u32>,
+    sub_account_label: Option<Symbol>,
 ) -> Result<u32, Error> {
     subscriber.require_auth();
 
@@ -530,6 +533,7 @@ pub fn do_create_subscription_with_token(
     crate::blocklist::require_not_blocklisted(env, &merchant)?;
 
     // Reject self-referral: inviter cannot be the same as subscriber.
+    let inviter: Option<Address> = None;
     if let Some(ref inviter_addr) = inviter {
         if inviter_addr == &subscriber {
             return Err(Error::SelfReferralNotAllowed);
@@ -624,6 +628,7 @@ pub fn do_create_subscription_with_token(
         grace_start_timestamp: None,
         cancel_at: None,
         expires_at_ledger,
+        sub_account_label,
     };
 
     // Allocate ID with overflow / limit guard.
@@ -1994,6 +1999,11 @@ pub fn do_charge_one_off(
     crate::blocklist::require_not_blocklisted(env, &sub.subscriber)?;
     crate::blocklist::require_not_blocklisted(env, &sub.merchant)?;
 
+    // Validate sub-account label exists before any state mutation
+    if let Some(ref label) = sub.sub_account_label {
+        crate::merchant::require_sub_account_exists(env, &sub.merchant, label)?;
+    }
+
     let now = env.ledger().timestamp();
     // Expiration guard
     if sub.is_expired(now, env.ledger().sequence()) {
@@ -2103,6 +2113,15 @@ pub fn do_charge_one_off(
         merchant_amount,
         BillingChargeKind::OneOff,
     )?;
+
+    // Route merchant amount to sub-account if subscription has one
+    if let Some(ref label) = sub.sub_account_label {
+        crate::merchant::credit_sub_account(env, &sub.merchant, label, &sub.token, merchant_amount)?;
+        let parent_bal = crate::merchant::get_merchant_balance_by_token(env, &sub.merchant, &sub.token);
+        let new_parent_bal = crate::safe_math::safe_sub(parent_bal, merchant_amount)?;
+        crate::merchant::set_merchant_balance(env, &sub.merchant, &sub.token, &new_parent_bal);
+    }
+
     let should_emit_fee_event = if fee_amount > 0 {
         if let Some(ref treasury) = treasury_opt {
             crate::merchant::credit_merchant_balance_for_token(
@@ -2715,6 +2734,7 @@ pub fn do_create_subscription_from_plan(
     env: &Env,
     subscriber: Address,
     plan_template_id: u32,
+    sub_account_label: Option<Symbol>,
 ) -> Result<u32, Error> {
     subscriber.require_auth();
     crate::blocklist::require_not_blocklisted(env, &subscriber)?;
@@ -2779,6 +2799,7 @@ pub fn do_create_subscription_from_plan(
         grace_start_timestamp: None,
         cancel_at: None,
         expires_at_ledger: None,
+        sub_account_label,
     };
 
     write_subscription(env, id, &sub);

--- a/contracts/subscription_vault/src/subscription.rs
+++ b/contracts/subscription_vault/src/subscription.rs
@@ -3321,7 +3321,7 @@ pub fn do_accept_transfer(
     // Remove from old subscriber's index
     let old_subscriber_key = DataKey::SubscriberSubs(sub.subscriber.clone());
     if let Some(mut ids) = env.storage().instance().get::<_, Vec<u32>>(&old_subscriber_key) {
-        if let Some(idx) = ids.iter().position(|x| *x == subscription_id) {
+        if let Some(idx) = ids.iter().position(|x| x == subscription_id) {
             let idx_u32 = idx.try_into().map_err(|_| Error::Overflow)?;
             ids.remove(idx_u32);
             env.storage().instance().set(&old_subscriber_key, &ids);

--- a/contracts/subscription_vault/src/test_merchant_sub_accounts.rs
+++ b/contracts/subscription_vault/src/test_merchant_sub_accounts.rs
@@ -1,0 +1,473 @@
+//! Tests for merchant sub-accounts (#575).
+//!
+//! Covers registration, duplicate/empty-label rejection, pre-registration
+//! guard, getters, withdrawal, event emission, balance independence,
+//! subscription-level sub_account_label binding, and end-to-end charge
+//! routing to sub-accounts (interval, usage, and one-off).
+
+use crate::{Error, SubscriptionVault, SubscriptionVaultClient};
+use soroban_sdk::testutils::{Address as _, Events as _};
+use soroban_sdk::{Address, Env, Symbol, Vec};
+
+fn label(env: &Env, s: &str) -> Symbol {
+    Symbol::new(env, s)
+}
+
+/// Minimal setup: init contract, return (env, client, admin, token).
+fn setup() -> (Env, SubscriptionVaultClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(SubscriptionVault, ());
+    let client = SubscriptionVaultClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    client.init(&token, &6, &admin, &1_000_000i128, &(7 * 24 * 60 * 60));
+    (env, client, admin, token)
+}
+
+/// Create a merchant with an initialized config and return its address.
+fn create_merchant(
+    client: &SubscriptionVaultClient<'static>,
+    env: &Env,
+) -> Address {
+    let merchant = Address::generate(env);
+    let payout = Address::generate(env);
+    client.initialize_merchant_config(
+        &merchant,
+        &payout,
+        &0,
+        &1,
+        &None,
+        &soroban_sdk::String::from_str(env, ""),
+    );
+    merchant
+}
+
+// ── Registration ────────────────────────────────────────────────────────────
+
+#[test]
+fn register_sub_account_succeeds() {
+    let (env, client, _admin, _token) = setup();
+    let merchant = create_merchant(&client, &env);
+    let lbl = label(&env, "sales");
+
+    client.register_sub_account(&merchant, &lbl);
+
+    assert_eq!(client.get_sub_account_list(&merchant), Vec::from_array(&env, [lbl.clone()]));
+    assert_eq!(client.get_sub_account_balance(&merchant, &lbl), 0);
+}
+
+#[test]
+fn register_multiple_sub_accounts() {
+    let (env, client, _admin, _token) = setup();
+    let merchant = create_merchant(&client, &env);
+
+    let sales = label(&env, "sales");
+    let support = label(&env, "support");
+
+    client.register_sub_account(&merchant, &sales);
+    client.register_sub_account(&merchant, &support);
+
+    let list = client.get_sub_account_list(&merchant);
+    assert_eq!(list.len(), 2);
+    assert!(list.contains(&sales));
+    assert!(list.contains(&support));
+}
+
+#[test]
+fn duplicate_label_rejected() {
+    let (env, client, _admin, _token) = setup();
+    let merchant = create_merchant(&client, &env);
+    let lbl = label(&env, "sales");
+
+    client.register_sub_account(&merchant, &lbl);
+    let result = client.try_register_sub_account(&merchant, &lbl);
+    assert_eq!(result, Err(Ok(Error::InvalidInput)));
+}
+
+#[test]
+fn empty_label_rejected() {
+    let (env, client, _admin, _token) = setup();
+    let merchant = create_merchant(&client, &env);
+    let empty = label(&env, "");
+
+    let result = client.try_register_sub_account(&merchant, &empty);
+    assert_eq!(result, Err(Ok(Error::InvalidInput)));
+}
+
+#[test]
+fn uninitialized_merchant_cannot_register_sub_account() {
+    let (env, client, _admin, _token) = setup();
+    let merchant = Address::generate(&env);
+    let lbl = label(&env, "sales");
+
+    let result = client.try_register_sub_account(&merchant, &lbl);
+    assert_eq!(result, Err(Ok(Error::NotFound)));
+}
+
+// ── Getters ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn sub_account_list_defaults_to_empty() {
+    let (env, client, _admin, _token) = setup();
+    let merchant = create_merchant(&client, &env);
+    assert_eq!(client.get_sub_account_list(&merchant).len(), 0);
+}
+
+#[test]
+fn sub_account_balance_defaults_to_zero() {
+    let (env, client, _admin, _token) = setup();
+    let merchant = create_merchant(&client, &env);
+    let lbl = label(&env, "sales");
+    assert_eq!(client.get_sub_account_balance(&merchant, &lbl), 0);
+}
+
+#[test]
+fn sub_account_balance_zero_for_unregistered_label() {
+    let (env, client, _admin, _token) = setup();
+    let merchant = create_merchant(&client, &env);
+    let lbl = label(&env, "ghost");
+    assert_eq!(client.get_sub_account_balance(&merchant, &lbl), 0);
+}
+
+// ── Withdrawal ───────────────────────────────────────────────────────────────
+
+#[test]
+fn withdraw_sub_account_funds_succeeds() {
+    let (env, client, _admin, token) = setup();
+    let merchant = create_merchant(&client, &env);
+
+    // Seed parent merchant balance so the vault has tokens.
+    let stellar = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+    let contract = env.current_contract_address();
+    stellar.mint(&contract, &1000);
+
+    let lbl = label(&env, "sales");
+    client.register_sub_account(&merchant, &lbl);
+
+    // Manually credit the sub-account (internal helper invoked by charge engine)
+    // so we can test withdrawal.  We use Env's mock_auth to skip merchant auth.
+    crate::merchant::credit_sub_account(&env, &merchant, &lbl, &token, 500).unwrap();
+
+    let bal_before = client.get_sub_account_balance(&merchant, &lbl);
+    assert_eq!(bal_before, 500);
+
+    client.withdraw_sub_account_funds(&merchant, &lbl, &token, &200);
+    assert_eq!(client.get_sub_account_balance(&merchant, &lbl), 300);
+}
+
+#[test]
+fn withdraw_entire_sub_account_balance() {
+    let (env, client, _admin, token) = setup();
+    let merchant = create_merchant(&client, &env);
+
+    let stellar = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+    stellar.mint(&env.current_contract_address(), &500);
+
+    let lbl = label(&env, "sales");
+    client.register_sub_account(&merchant, &lbl);
+    crate::merchant::credit_sub_account(&env, &merchant, &lbl, &token, 500).unwrap();
+
+    client.withdraw_sub_account_funds(&merchant, &lbl, &token, &500);
+    assert_eq!(client.get_sub_account_balance(&merchant, &lbl), 0);
+}
+
+#[test]
+fn withdraw_from_nonexistent_sub_account_rejected() {
+    let (env, client, _admin, token) = setup();
+    let merchant = create_merchant(&client, &env);
+    let lbl = label(&env, "ghost");
+
+    let result = client.try_withdraw_sub_account_funds(&merchant, &lbl, &token, &100);
+    assert_eq!(result, Err(Ok(Error::NotFound)));
+}
+
+#[test]
+fn withdraw_zero_amount_rejected() {
+    let (env, client, _admin, token) = setup();
+    let merchant = create_merchant(&client, &env);
+    let lbl = label(&env, "sales");
+    client.register_sub_account(&merchant, &lbl);
+
+    let result = client.try_withdraw_sub_account_funds(&merchant, &lbl, &token, &0);
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+}
+
+#[test]
+fn withdraw_negative_amount_rejected() {
+    let (env, client, _admin, token) = setup();
+    let merchant = create_merchant(&client, &env);
+    let lbl = label(&env, "sales");
+    client.register_sub_account(&merchant, &lbl);
+
+    let result = client.try_withdraw_sub_account_funds(&merchant, &lbl, &token, &(-100));
+    assert_eq!(result, Err(Ok(Error::InvalidAmount)));
+}
+
+#[test]
+fn withdraw_exceeding_sub_account_balance_rejected() {
+    let (env, client, _admin, token) = setup();
+    let merchant = create_merchant(&client, &env);
+
+    let stellar = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+    stellar.mint(&env.current_contract_address(), &500);
+
+    let lbl = label(&env, "sales");
+    client.register_sub_account(&merchant, &lbl);
+    crate::merchant::credit_sub_account(&env, &merchant, &lbl, &token, 100).unwrap();
+
+    let result = client.try_withdraw_sub_account_funds(&merchant, &lbl, &token, &200);
+    assert_eq!(result, Err(Ok(Error::InsufficientBalance)));
+}
+
+// ── Events ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn register_sub_account_emits_event() {
+    let (env, client, _admin, _token) = setup();
+    let merchant = create_merchant(&client, &env);
+    let lbl = label(&env, "sales");
+
+    let before = env.events().all().len();
+    client.register_sub_account(&merchant, &lbl);
+    assert_eq!(env.events().all().len(), before + 1);
+}
+
+#[test]
+fn withdraw_sub_account_funds_emits_event() {
+    let (env, client, _admin, token) = setup();
+    let merchant = create_merchant(&client, &env);
+
+    let stellar = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+    stellar.mint(&env.current_contract_address(), &500);
+
+    let lbl = label(&env, "sales");
+    client.register_sub_account(&merchant, &lbl);
+    crate::merchant::credit_sub_account(&env, &merchant, &lbl, &token, 500).unwrap();
+
+    let before = env.events().all().len();
+    client.withdraw_sub_account_funds(&merchant, &lbl, &token, &200);
+    assert_eq!(env.events().all().len(), before + 1);
+}
+
+// ── Balance Independence ─────────────────────────────────────────────────────
+
+#[test]
+fn register_does_not_affect_parent_balance() {
+    let (env, client, _admin, _token) = setup();
+    let merchant = create_merchant(&client, &env);
+
+    let parent_before = client.get_merchant_balance(&merchant);
+    client.register_sub_account(&merchant, &label(&env, "sales"));
+    let parent_after = client.get_merchant_balance(&merchant);
+
+    assert_eq!(parent_before, parent_after);
+}
+
+// ── Labels are per-merchant ──────────────────────────────────────────────────
+
+#[test]
+fn sub_account_labels_independent_per_merchant() {
+    let (env, client, _admin, _token) = setup();
+    let merchant_a = create_merchant(&client, &env);
+    let merchant_b = create_merchant(&client, &env);
+
+    client.register_sub_account(&merchant_a, &label(&env, "sales"));
+    client.register_sub_account(&merchant_b, &label(&env, "sales"));
+
+    assert_eq!(client.get_sub_account_list(&merchant_a).len(), 1);
+    assert_eq!(client.get_sub_account_list(&merchant_b).len(), 1);
+    // Same label does not collide between merchants.
+    assert_eq!(
+        client.get_sub_account_balance(&merchant_a, &label(&env, "sales")),
+        0
+    );
+    assert_eq!(
+        client.get_sub_account_balance(&merchant_b, &label(&env, "sales")),
+        0
+    );
+}
+
+// ── Subscription sub_account_label ───────────────────────────────────────────
+
+#[test]
+fn create_subscription_with_sub_account_label() {
+    let (env, client, admin, token) = setup();
+    let merchant = create_merchant(&client, &env);
+
+    client.register_sub_account(&merchant, &label(&env, "sales"));
+
+    // Set a min top-up so deposit is accepted.
+    client.set_min_topup(&admin, &1);
+    let subscriber = Address::generate(&env);
+
+    let stellar = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+    stellar.mint(&subscriber, &10000);
+
+    let sub_id = client
+        .create_subscription_with_token(
+            &subscriber,
+            &merchant,
+            &token,
+            &1000,
+            &86400,
+            &false,
+            &None::<i128>,
+            &None::<u64>,
+            &None::<u32>,
+            &Some(label(&env, "sales")),
+        )
+        .unwrap();
+
+    client.deposit_funds(&sub_id, &subscriber, &5000, &None);
+    client.charge_subscription(&sub_id, &None);
+
+    // Sub-account has the merchant's net charge amount (1000 with 0 fee bps).
+    assert_eq!(client.get_sub_account_balance(&merchant, &label(&env, "sales")), 1000);
+}
+
+#[test]
+fn create_subscription_without_sub_account_label_leaves_parent_balance() {
+    let (env, client, admin, token) = setup();
+    let merchant = create_merchant(&client, &env);
+
+    client.set_min_topup(&admin, &1);
+    let subscriber = Address::generate(&env);
+
+    let stellar = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+    stellar.mint(&subscriber, &10000);
+
+    let sub_id = client
+        .create_subscription_with_token(
+            &subscriber,
+            &merchant,
+            &token,
+            &1000,
+            &86400,
+            &false,
+            &None::<i128>,
+            &None::<u64>,
+            &None::<u32>,
+            &None::<Symbol>,
+        )
+        .unwrap();
+
+    client.deposit_funds(&sub_id, &subscriber, &5000, &None);
+    client.charge_subscription(&sub_id, &None);
+
+    // No sub-account label → funds stay in parent merchant balance.
+    assert_eq!(client.get_merchant_balance(&merchant), 1000);
+}
+
+#[test]
+fn one_off_charge_routes_to_sub_account() {
+    let (env, client, admin, token) = setup();
+    let merchant = create_merchant(&client, &env);
+
+    client.register_sub_account(&merchant, &label(&env, "sales"));
+
+    client.set_min_topup(&admin, &1);
+    let subscriber = Address::generate(&env);
+
+    let stellar = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+    stellar.mint(&subscriber, &10000);
+
+    let sub_id = client
+        .create_subscription_with_token(
+            &subscriber,
+            &merchant,
+            &token,
+            &1000,
+            &86400,
+            &false,
+            &None::<i128>,
+            &None::<u64>,
+            &None::<u32>,
+            &Some(label(&env, "sales")),
+        )
+        .unwrap();
+
+    client.deposit_funds(&sub_id, &subscriber, &5000, &None);
+
+    // One-off charge of 2000
+    client.charge_one_off(&sub_id, &merchant, &2000, &None);
+
+    // 2000 should be in sub-account, not parent
+    assert_eq!(client.get_sub_account_balance(&merchant, &label(&env, "sales")), 2000);
+    assert_eq!(client.get_merchant_balance(&merchant), 0);
+}
+
+#[test]
+fn charge_to_unregistered_sub_account_fails() {
+    let (env, client, admin, token) = setup();
+    let merchant = create_merchant(&client, &env);
+
+    // Note: we do NOT register the "sales" sub-account.
+
+    client.set_min_topup(&admin, &1);
+    let subscriber = Address::generate(&env);
+
+    let stellar = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+    stellar.mint(&subscriber, &10000);
+
+    let sub_id = client
+        .create_subscription_with_token(
+            &subscriber,
+            &merchant,
+            &token,
+            &1000,
+            &86400,
+            &false,
+            &None::<i128>,
+            &None::<u64>,
+            &None::<u32>,
+            &Some(label(&env, "sales")),
+        )
+        .unwrap();
+
+    client.deposit_funds(&sub_id, &subscriber, &5000, &None);
+
+    // The charge engine calls credit_sub_account which checks that the
+    // sub-account exists — it should fail because "sales" was never registered.
+    let result = client.try_charge_subscription(&sub_id, &None);
+    assert_eq!(result, Err(Ok(Error::NotFound)));
+}
+
+#[test]
+fn charge_subscription_to_sub_account_updates_earnings() {
+    let (env, client, admin, token) = setup();
+    let merchant = create_merchant(&client, &env);
+
+    client.register_sub_account(&merchant, &label(&env, "sales"));
+
+    client.set_min_topup(&admin, &1);
+    let subscriber = Address::generate(&env);
+
+    let stellar = soroban_sdk::token::StellarAssetClient::new(&env, &token);
+    stellar.mint(&subscriber, &10000);
+
+    let sub_id = client
+        .create_subscription_with_token(
+            &subscriber,
+            &merchant,
+            &token,
+            &1000,
+            &86400,
+            &false,
+            &None::<i128>,
+            &None::<u64>,
+            &None::<u32>,
+            &Some(label(&env, "sales")),
+        )
+        .unwrap();
+
+    client.deposit_funds(&sub_id, &subscriber, &5000, &None);
+    client.charge_subscription(&sub_id, &None);
+
+    // Earnings (parent-level) must reflect the charge even though the
+    // funds are in the sub-account balance.
+    let earnings = client.get_merchant_token_earnings(&merchant, &token);
+    assert_eq!(earnings.accruals.interval, 1000);
+}

--- a/contracts/subscription_vault/src/types.rs
+++ b/contracts/subscription_vault/src/types.rs
@@ -8,9 +8,6 @@ use soroban_sdk::{contracterror, contracttype, Address, Bytes, BytesN, Env, Stri
 /// Current schema version for contract events.
 pub const EVENT_SCHEMA_VERSION: u32 = 2;
 
-/// Event schema version for backwards-compatible indexer decoding.
-pub const EVENT_SCHEMA_VERSION: u32 = 2;
-
 /// Maximum number of metadata keys per subscription.
 pub const MAX_METADATA_KEYS: u32 = 10;
 /// Maximum length of a metadata key in bytes.
@@ -230,6 +227,10 @@ pub enum DataKey {
     SubCoupon(u32),
     /// Merchant multi-signature withdrawal configuration (#679). Instance-tier. Discriminant 61.
     MerchantMultiSig(Address),
+    /// Per-merchant sub-account balance, isolated ledger within one merchant identity (#575). Instance-tier. Discriminant 62.
+    MerchantSubAccount(Address, Symbol),
+    /// List of sub-account labels for a merchant (#575). Instance-tier. Discriminant 63.
+    MerchantSubAccountList(Address),
 }
 
 impl DataKey {
@@ -299,6 +300,8 @@ impl DataKey {
             DataKey::BuyoutPremiumBps => 59,
             DataKey::SubCoupon(_) => 60,
             DataKey::MerchantMultiSig(_) => 61,
+            DataKey::MerchantSubAccount(_, _) => 62,
+            DataKey::MerchantSubAccountList(_) => 63,
         }
     }
 
@@ -351,6 +354,8 @@ pub const KNOWN_INSTANCE_KEY_DISCRIMINANTS: &[u32] = &[
     54, // TransferIntent(u32)
     59, // BuyoutPremiumBps
     61, // MerchantMultiSig(Address)
+    62, // MerchantSubAccount(Address, Symbol)
+    63, // MerchantSubAccountList(Address)
 ];
 
 /// Returns `true` if `discriminant` is a recognised instance-storage key.
@@ -437,6 +442,9 @@ pub struct Subscription {
     /// Either bound being met is sufficient to consider the subscription
     /// expired for charge / deposit / state-transition purposes.
     pub expires_at_ledger: Option<u32>,
+    /// Optional sub-account label for routing charges to an isolated merchant
+    /// sub-account ledger (#575). `None` routes to the parent merchant balance.
+    pub sub_account_label: Option<Symbol>,
 }
 
 impl Subscription {
@@ -2251,6 +2259,29 @@ pub struct MerchantRefundEvent {
     pub subscriber: Address,
     pub token: Address,
     pub amount: i128,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+
+/// Event emitted when a merchant creates a new sub-account with an isolated ledger (#575).
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct SubAccountCreatedEvent {
+    pub merchant: Address,
+    pub label: Symbol,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+
+/// Event emitted when a merchant withdraws funds from a sub-account (#575).
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct SubAccountWithdrawEvent {
+    pub merchant: Address,
+    pub label: Symbol,
+    pub token: Address,
+    pub amount: i128,
+    pub remaining_balance: i128,
     pub timestamp: u64,
     pub schema_version: u32,
 }


### PR DESCRIPTION
closes #575 

- Add DataKey::MerchantSubAccount / MerchantSubAccountList and Subscription.sub_account_label field
- Implement register_sub_account, withdraw_sub_account_funds, credit_sub_account, getters
- Route interval, usage, and one-off charges to sub-accounts when label is set
- Early validation of sub-account existence before state mutation
- Add sub_account_label parameter to all create_subscription entrypoints
- Bump STORAGE_VERSION to 5 with v4->v5 migration step
- Add comprehensive test suite (23 tests)