### PR TITLE
#618 Precompute event topics as consts to avoid Symbol::new_from_str …

### DIFF
--- a/contracts/subscription_vault/src/admin.rs
+++ b/contracts/subscription_vault/src/admin.rs
@@ -8,7 +8,8 @@ use crate::types::{
     AcceptedToken, AdminConfigChangedEvent, AdminProposal, AdminProposalCancelledEvent,
     AdminProposalClaimedEvent, AdminProposalCreatedEvent, AdminRotatedEvent, BatchChargeResult,
     DataKey, Error, FeeTokenConfiguredEvent, PendingTreasuryChange, RecoveryEvent, RecoveryReason,
-    TreasuryChangeExecutedEvent, TreasuryChangeQueuedEvent, SUB_TTL_EXTEND_TO, SUB_TTL_THRESHOLD,
+    TreasuryChangeExecutedEvent, TreasuryChangeQueuedEvent, TOPIC_RECOVERY, SUB_TTL_EXTEND_TO,
+    SUB_TTL_THRESHOLD,
 };
 use crate::{
     charge_core::{charge_one, charge_usage_one},
@@ -575,7 +576,7 @@ pub fn do_recover_stranded_funds(
     };
 
     env.events().publish(
-        (Symbol::new(env, "recovery"), admin.clone()),
+        (TOPIC_RECOVERY, admin.clone()),
         recovery_event,
     );
 

--- a/contracts/subscription_vault/src/charge_core.rs
+++ b/contracts/subscription_vault/src/charge_core.rs
@@ -40,11 +40,11 @@ use crate::types::{
     BillingChargeKind, BillingPeriodSnapshot, ChargeExecutionResult, ChargeFailureEvent, DataKey,
     Error, FeeConvertedEvent, GracePeriodEnteredEvent, LifetimeCapReachedEvent,
     SubscriptionAutoPausedEvent, SubscriptionCancelledEvent, SubscriptionChargeFailedEvent,
-    SubscriptionChargedEvent, SubscriptionStatus, UsageChargeRejectedEvent, UsageChargeResult,
+    SubscriptionChargedEvent, SubscriptionStatus, TOPIC_CHARGED, UsageChargeRejectedEvent, UsageChargeResult,
     UsageLimits, UsageState, UsageStatementEvent, SNAPSHOT_FLAG_CLOSED,
     SNAPSHOT_FLAG_INTERVAL_CHARGED, SNAPSHOT_FLAG_USAGE_CHARGED,
 };
-use soroban_sdk::{symbol_short, Address, Env, String, Symbol};
+use soroban_sdk::{Address, Env, String, Symbol};
 
 /// Resolve the effective fee rate in basis points for a charge to `merchant`.
 ///
@@ -611,7 +611,7 @@ pub fn charge_one(
             }
 
             env.events().publish(
-                (symbol_short!("charged"),),
+                (TOPIC_CHARGED,),
                 SubscriptionChargedEvent {
                     subscription_id,
                     subscriber: sub.subscriber.clone(),

--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -1395,7 +1395,7 @@ impl SubscriptionVault {
         )?;
         let token: Address = admin::read_config(&env, &DataKey::Token).ok_or(Error::NotFound)?;
         env.events().publish(
-            (Symbol::new(&env, "created"), sub_id),
+            (types::TOPIC_CREATED, sub_id),
             SubscriptionCreatedEvent {
                 subscription_id: sub_id,
                 subscriber,
@@ -1462,7 +1462,7 @@ impl SubscriptionVault {
 
         let token: Address = admin::read_config(&env, &DataKey::Token).ok_or(Error::NotFound)?;
         env.events().publish(
-            (Symbol::new(&env, "created"), sub_id),
+            (types::TOPIC_CREATED, sub_id),
             SubscriptionCreatedEvent {
                 subscription_id: sub_id,
                 subscriber,
@@ -1566,7 +1566,7 @@ impl SubscriptionVault {
             expires_at_ledger,
         )?;
         env.events().publish(
-            (Symbol::new(&env, "created"), sub_id),
+            (types::TOPIC_CREATED, sub_id),
             SubscriptionCreatedEvent {
                 subscription_id: sub_id,
                 subscriber,
@@ -1603,7 +1603,7 @@ impl SubscriptionVault {
         )?;
         let sub = queries::get_subscription(&env, subscription_id)?;
         env.events().publish(
-            (Symbol::new(&env, "deposited"), subscription_id),
+            (types::TOPIC_DEPOSITED, subscription_id),
             FundsDepositedEvent {
                 subscription_id,
                 subscriber,
@@ -2213,7 +2213,7 @@ impl SubscriptionVault {
         let _period_end = timestamp;
 
         env.events().publish(
-            (Symbol::new(&env, "charged"),),
+            (types::TOPIC_CHARGED,),
             SubscriptionChargedEvent {
                 subscription_id,
                 subscriber: old_sub.subscriber,
@@ -2299,7 +2299,7 @@ impl SubscriptionVault {
         let token: Address = admin::read_config(&env, &DataKey::Token).ok_or(Error::NotFound)?;
         env.events().publish(
             (
-                Symbol::new(&env, "withdrawn"),
+                types::TOPIC_WITHDRAWN,
                 merchant.clone(),
                 token.clone(),
             ),

--- a/contracts/subscription_vault/src/merchant.rs
+++ b/contracts/subscription_vault/src/merchant.rs
@@ -28,7 +28,7 @@ use crate::types::{
     MerchantPausedEvent, MerchantRevokedEvent, MerchantUnpausedEvent, MerchantWhitelistModeEvent,
     MerchantWithdrawalEvent, PayoutSchedule, PlanDeprecatedEvent, PlanRegisteredEvent,
     PlanTemplate, ScheduledPayoutEvent, TokenEarnings, TokenReconciliationSnapshot, MAX_FEE_BIPS,
-    is_valid_allowed_operations, OP_CHARGE,
+    is_valid_allowed_operations, OP_CHARGE, TOPIC_WITHDRAWN,
 };
 use soroban_sdk::{token, Address, Env, String, Symbol, Vec};
 
@@ -807,7 +807,7 @@ pub fn withdraw_merchant_funds_for_token(
 
     env.events().publish(
         (
-            Symbol::new(env, "withdrawn"),
+            TOPIC_WITHDRAWN,
             merchant.clone(),
             token_addr.clone(),
         ),
@@ -1001,7 +1001,7 @@ fn flush_merchant_token(
 
     env.events().publish(
         (
-            Symbol::new(env, "withdrawn"),
+            TOPIC_WITHDRAWN,
             merchant.clone(),
             token.clone(),
         ),

--- a/contracts/subscription_vault/src/subscription.rs
+++ b/contracts/subscription_vault/src/subscription.rs
@@ -73,9 +73,10 @@ use crate::types::{
     Subscription, SubscriptionCancelScheduledEvent, SubscriptionCancelUnscheduledEvent,
     SubscriptionCancelledEvent, SubscriptionCreatedEvent, SubscriptionMigratedEvent,
     SubscriptionRecoveryReadyEvent, SubscriptionStatus, UsageLimits, UsageLimitsConfiguredEvent,
+    TOPIC_CAP_REACH, TOPIC_CHARGED, TOPIC_CREATED, TOPIC_DEPOSITED, TOPIC_ONE_OFF_CHARGED,
     BATCH_MAX_SIZE, SUB_TTL_EXTEND_TO, SUB_TTL_THRESHOLD,
 };
-use soroban_sdk::{symbol_short, Address, Env, Symbol, Vec};
+use soroban_sdk::{Address, Env, Symbol, Vec};
 
 const MIN_SUBSCRIPTION_INTERVAL_SECONDS: u64 = 60;
 /// Hard upper bound on billing interval: 365 days (31 536 000 s).
@@ -839,7 +840,7 @@ pub fn do_deposit_funds(
     crate::accounting::add_total_accounted(env, &token_addr, amount)?;
 
     env.events().publish(
-        (Symbol::new(env, "deposited"), subscription_id),
+        (TOPIC_DEPOSITED, subscription_id),
         FundsDepositedEvent {
             subscription_id,
             subscriber: subscriber.clone(),
@@ -1016,7 +1017,7 @@ pub fn do_grace_buyout(
 
     // Emit standard charged event for indexer compatibility.
     env.events().publish(
-        (symbol_short!("charged"),),
+        (TOPIC_CHARGED,),
         crate::types::SubscriptionChargedEvent {
             subscription_id,
             subscriber: sub.subscriber.clone(),
@@ -1887,7 +1888,7 @@ fn bulk_deposit_one(
 
     // Emit per-subscription deposited event.
     env.events().publish(
-        (Symbol::new(env, "deposited"), subscription_id),
+        (TOPIC_DEPOSITED, subscription_id),
         crate::types::FundsDepositedEvent {
             subscription_id,
             subscriber: sub.subscriber.clone(),
@@ -2159,7 +2160,7 @@ pub fn do_charge_one_off(
 
         if let Some(cap) = sub.lifetime_cap {
             env.events().publish(
-                (symbol_short!("cap_reach"), subscription_id),
+                (TOPIC_CAP_REACH, subscription_id),
                 LifetimeCapReachedEvent {
                     subscription_id,
                     lifetime_cap: cap,
@@ -2181,7 +2182,7 @@ pub fn do_charge_one_off(
     )?;
 
     env.events().publish(
-        (symbol_short!("oneoff_ch"), subscription_id),
+        (TOPIC_ONE_OFF_CHARGED, subscription_id),
         crate::types::OneOffChargedEvent {
             subscription_id,
             subscriber: sub.subscriber.clone(),
@@ -2845,7 +2846,7 @@ pub fn do_create_subscription_from_plan(
     env.storage().instance().set(&token_key, &token_ids);
 
     env.events().publish(
-        (symbol_short!("created"), id),
+        (TOPIC_CREATED, id),
         SubscriptionCreatedEvent {
             subscription_id: id,
             subscriber: subscriber.clone(),

--- a/contracts/subscription_vault/src/types.rs
+++ b/contracts/subscription_vault/src/types.rs
@@ -3,7 +3,9 @@
 //! Kept in a separate module to reduce merge conflicts when editing state machine
 //! or contract entrypoints.
 
-use soroban_sdk::{contracterror, contracttype, Address, Bytes, BytesN, Env, String, Vec};
+use soroban_sdk::{
+    contracterror, contracttype, symbol_short, Address, Bytes, BytesN, Env, String, Symbol, Vec,
+};
 
 /// Current schema version for contract events.
 pub const EVENT_SCHEMA_VERSION: u32 = 2;
@@ -1642,6 +1644,12 @@ pub enum RecoveryReason {
     AccidentalTransfer = 4,
 }
 
+/// Short topic for [`RecoveryEvent`].
+///
+/// This fits Soroban's nine-character `symbol_short!` limit and therefore does
+/// not need host-side symbol interning when it is emitted.
+pub const TOPIC_RECOVERY: Symbol = symbol_short!("recovery");
+
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct RecoveryEvent {
@@ -1653,6 +1661,12 @@ pub struct RecoveryEvent {
     pub timestamp: u64,
     pub schema_version: u32,
 }
+
+/// Legacy short topic for [`SubscriptionCreatedEvent`] emitters.
+///
+/// The longer `"subscription_created"` topic intentionally remains a
+/// `Symbol::new` at its emit sites because it exceeds `symbol_short!` capacity.
+pub const TOPIC_CREATED: Symbol = symbol_short!("created");
 
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -1695,6 +1709,9 @@ pub struct SubscriberCapReachedEvent {
     pub schema_version: u32,
 }
 
+/// Short topic for [`FundsDepositedEvent`].
+pub const TOPIC_DEPOSITED: Symbol = symbol_short!("deposited");
+
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct FundsDepositedEvent {
@@ -1706,6 +1723,9 @@ pub struct FundsDepositedEvent {
     pub timestamp: u64,
     pub schema_version: u32,
 }
+
+/// Short topic for [`SubscriptionChargedEvent`].
+pub const TOPIC_CHARGED: Symbol = symbol_short!("charged");
 
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -1947,6 +1967,9 @@ pub struct ScheduledPayoutEvent {
     pub schema_version: u32,
 }
 
+/// Legacy short topic shared by merchant and subscriber withdrawal events.
+pub const TOPIC_WITHDRAWN: Symbol = symbol_short!("withdrawn");
+
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct MerchantWithdrawalEvent {
@@ -1992,6 +2015,9 @@ pub struct SubscriberEmergencyWithdrawEvent {
     pub schema_version: u32,
 }
 
+/// Legacy short topic for [`OneOffChargedEvent`].
+pub const TOPIC_ONE_OFF_CHARGED: Symbol = symbol_short!("oneoff_ch");
+
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct OneOffChargedEvent {
@@ -2004,6 +2030,12 @@ pub struct OneOffChargedEvent {
     pub timestamp: u64,
     pub schema_version: u32,
 }
+
+/// Legacy short topic for [`LifetimeCapReachedEvent`] in the one-off path.
+///
+/// Other paths use the longer `"lifetime_cap_reached"` topic, which must keep
+/// using `Symbol::new` because it is longer than nine characters.
+pub const TOPIC_CAP_REACH: Symbol = symbol_short!("cap_reach");
 
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -2569,5 +2601,65 @@ pub struct PrepaidQueryResult {
 }
 
 
-#[contracttype]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg(test)]
+mod event_topic_tests {
+    use super::{
+        TOPIC_CAP_REACH, TOPIC_CHARGED, TOPIC_CREATED, TOPIC_DEPOSITED, TOPIC_ONE_OFF_CHARGED,
+        TOPIC_RECOVERY, TOPIC_WITHDRAWN,
+    };
+    use soroban_sdk::{Env, FromVal, Symbol, ToXdr};
+
+    /// The emitted wire representation is part of the indexer-facing contract.
+    /// Publish every cached short topic in one transaction and compare each
+    /// emitted topic to the `Symbol::new` representation used before caching.
+    #[test]
+    fn cached_event_topics_are_bytewise_compatible_and_keep_order() {
+        let env = Env::default();
+        let topics = [
+            ("recovery", TOPIC_RECOVERY),
+            ("created", TOPIC_CREATED),
+            ("deposited", TOPIC_DEPOSITED),
+            ("charged", TOPIC_CHARGED),
+            ("withdrawn", TOPIC_WITHDRAWN),
+            ("cap_reach", TOPIC_CAP_REACH),
+            ("oneoff_ch", TOPIC_ONE_OFF_CHARGED),
+        ];
+
+        for (_, topic) in topics.iter() {
+            env.events().publish((topic,), ());
+        }
+
+        let emitted_events = env.events().all();
+        assert_eq!(emitted_events.len(), topics.len() as u32);
+        for (index, (name, expected_topic)) in topics.iter().enumerate() {
+            let emitted = emitted_events.get(index as u32).unwrap();
+            let emitted_topic = Symbol::from_val(&env, &emitted.1.get(0).unwrap());
+            let legacy_topic = Symbol::new(&env, name);
+
+            assert_eq!(
+                emitted_topic.to_xdr(&env),
+                legacy_topic.to_xdr(&env),
+                "event topic {name} changed its wire representation"
+            );
+            assert_eq!(
+                expected_topic.to_xdr(&env),
+                legacy_topic.to_xdr(&env),
+                "cached topic {name} differs from Symbol::new"
+            );
+        }
+    }
+
+    /// `symbol_short!` supports at most nine characters. Longer event topics
+    /// are deliberately constructed with `Symbol::new` at their emit sites.
+    #[test]
+    fn long_event_topics_keep_the_runtime_symbol_representation() {
+        let env = Env::default();
+        let long_topic = Symbol::new(&env, "subscription_created");
+
+        assert_eq!(
+            long_topic.to_xdr(&env),
+            Symbol::new(&env, "subscription_created").to_xdr(&env)
+        );
+        assert_ne!(long_topic.to_xdr(&env), TOPIC_CREATED.to_xdr(&env));
+    }
+}


### PR DESCRIPTION
### Findings

1. Production event emit paths repeatedly constructed symbols with:
   ```rust
   Symbol::new(env, "topic")
   ```
   even when the topic was a fixed, short literal.

2. Soroban’s `symbol_short!` supports symbols up to **9 characters** and creates a compile-time constant representation, avoiding runtime symbol interning.

3. Eligible repeated short topics found in the event paths were:

   ```text
   recovery
   created
   deposited
   charged
   withdrawn
   cap_reach
   oneoff_ch
   ```

4. Most other event topics are longer than nine characters, for example:

   ```text
   subscription_created
   subscription_cancelled
   lifetime_cap_reached
   dispute_opened
   merchant_paused
   ```

   These correctly remain `Symbol::new(...)` because they cannot safely use `symbol_short!`.

---

### Fix Features

- Added documented shared constants beside their related event definitions in `types.rs`:

  ```rust
  pub const TOPIC_RECOVERY: Symbol = symbol_short!("recovery");
  pub const TOPIC_CREATED: Symbol = symbol_short!("created");
  pub const TOPIC_DEPOSITED: Symbol = symbol_short!("deposited");
  pub const TOPIC_CHARGED: Symbol = symbol_short!("charged");
  pub const TOPIC_WITHDRAWN: Symbol = symbol_short!("withdrawn");
  pub const TOPIC_CAP_REACH: Symbol = symbol_short!("cap_reach");
  pub const TOPIC_ONE_OFF_CHARGED: Symbol = symbol_short!("oneoff_ch");
  ```

- Replaced **16 production hot-path event topic constructions** with these constants.

- Preserved:
  - emitted topic names;
  - tuple topic order;
  - payload values and schema versions;
  - authorization and accounting behavior;
  - all long-topic `Symbol::new(...)` fallbacks.

- Added regression coverage for:
  - byte-for-byte/XDR compatibility between cached constants and legacy `Symbol::new(...)` topics;
  - multiple event emissions in one transaction;
  - long topic behavior remaining runtime-symbol based.

- Verified via a production-path scan that no `Symbol::new(...)` topic literals of 9 characters or fewer remain in event emission paths.

- Fix committed as:

  ```text
  a03ddc8 perf: precompute event topics as consts
  ```

CLOSE #618 