### PR TITLE
refactor: DataKey feature sub-enums

### DIFF
--- a/contracts/subscription_vault/tests/data_key_feature_groups.rs
+++ b/contracts/subscription_vault/tests/data_key_feature_groups.rs
@@ -1,0 +1,346 @@
+//! Feature-scoped `DataKey` sub-enums plus a cross-version discriminant
+//! snapshot (issue #647).
+//!
+//! ## Why this is additive rather than a rewrite
+//!
+//! `DataKey` in `types.rs` is one flat enum whose variant *declaration order*
+//! **is** the on-chain wire format: the Soroban `#[contracttype]` macro
+//! serialises each variant by its 0-indexed position. Reordering, removing, or
+//! re-numbering an arm silently repoints live storage.
+//!
+//! So instead of physically splitting the enum, this module adds a
+//! feature-scoped *view* over it. Each domain gets its own `#[repr(u32)]`
+//! sub-enum whose variants carry the frozen discriminant of the corresponding
+//! `DataKey` arm, and each sub-enum knows how to wrap itself back into a real
+//! `DataKey` via `representative_data_key`. Every mapping is then asserted
+//! against `DataKey::canonical_discriminant()`, so the grouping can never
+//! disagree with the canonical registry: if the two ever diverge, these tests
+//! fail instead of storage corrupting in production.
+//!
+//! Nothing existing is touched — no type, variant, storage tier, or test is
+//! modified, which is what guarantees "no discriminant drift" for this change.
+//!
+//! ## Deliberate exclusions
+//!
+//! Two families of arms are intentionally left out of the groups below:
+//!
+//! * `DataKey::TransferIntent` — the registry currently reports discriminant
+//!   `54` for **both** `PendingTreasuryChange` and `TransferIntent`. Only
+//!   `PendingTreasuryChange` is grouped here so the disjointness test asserts a
+//!   true invariant; the collision itself is a pre-existing registry question
+//!   for the maintainers and is deliberately not "fixed" by this PR.
+//! * Arms whose payload types are not constructible from a bare `Env` without
+//!   pulling in unrelated fixtures.
+
+#![cfg(test)]
+
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env, String as SorobanString};
+use subscription_vault::types::{is_known_instance_discriminant, DataKey};
+
+/// Subscription-domain storage keys: per-subscription lifecycle, metering,
+/// metadata, and per-subscriber caps.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+enum SubscriptionKey {
+    Sub = 6,
+    ChargedPeriod = 7,
+    IdemKey = 8,
+    UsageLimits = 19,
+    UsageState = 20,
+    SubPlan = 28,
+    CreditLimit = 30,
+    SubscriberSubs = 32,
+    Blocklist = 34,
+    Metadata = 39,
+    MetadataKeys = 40,
+    SubscriberCreateCap = 60,
+    SubscriberCreateWindow = 61,
+    ChargeSalt = 64,
+    SubCoupon = 68,
+    SubscriberActiveCount = 70,
+    SubscriberActiveCapOverride = 71,
+    CancellationEscrow = 75,
+}
+
+impl SubscriptionKey {
+    const ALL: [Self; 18] = [
+        Self::Sub,
+        Self::ChargedPeriod,
+        Self::IdemKey,
+        Self::UsageLimits,
+        Self::UsageState,
+        Self::SubPlan,
+        Self::CreditLimit,
+        Self::SubscriberSubs,
+        Self::Blocklist,
+        Self::Metadata,
+        Self::MetadataKeys,
+        Self::SubscriberCreateCap,
+        Self::SubscriberCreateWindow,
+        Self::ChargeSalt,
+        Self::SubCoupon,
+        Self::SubscriberActiveCount,
+        Self::SubscriberActiveCapOverride,
+        Self::CancellationEscrow,
+    ];
+
+    /// Frozen discriminant this sub-enum variant claims for its `DataKey` arm.
+    const fn claimed_discriminant(self) -> u32 {
+        self as u32
+    }
+
+    /// Wraps this sub-enum variant back into the top-level `DataKey`.
+    fn representative_data_key(self, env: &Env) -> DataKey {
+        let address = Address::generate(env);
+        match self {
+            Self::Sub => DataKey::Sub(1),
+            Self::ChargedPeriod => DataKey::ChargedPeriod(1),
+            Self::IdemKey => DataKey::IdemKey(1),
+            Self::UsageLimits => DataKey::UsageLimits(1),
+            Self::UsageState => DataKey::UsageState(1),
+            Self::SubPlan => DataKey::SubPlan(1),
+            Self::CreditLimit => DataKey::CreditLimit(address.clone(), address),
+            Self::SubscriberSubs => DataKey::SubscriberSubs(address),
+            Self::Blocklist => DataKey::Blocklist(address),
+            Self::Metadata => DataKey::Metadata(1, SorobanString::from_str(env, "plan")),
+            Self::MetadataKeys => DataKey::MetadataKeys(1),
+            Self::SubscriberCreateCap => DataKey::SubscriberCreateCap,
+            Self::SubscriberCreateWindow => DataKey::SubscriberCreateWindow(address),
+            Self::ChargeSalt => DataKey::ChargeSalt(1),
+            Self::SubCoupon => DataKey::SubCoupon(1),
+            Self::SubscriberActiveCount => DataKey::SubscriberActiveCount(address),
+            Self::SubscriberActiveCapOverride => DataKey::SubscriberActiveCapOverride(address),
+            Self::CancellationEscrow => DataKey::CancellationEscrow(1),
+        }
+    }
+}
+
+/// Merchant-domain storage keys: merchant config, earnings, payout, and
+/// compliance tagging.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+enum MerchantKey {
+    MerchantSubs = 0,
+    MerchantPaused = 10,
+    MerchantConfig = 16,
+    MerchantEarnings = 17,
+    MerchantTokens = 18,
+    MerchantBalance = 33,
+    MerchantMaxSubs = 45,
+    PayoutSchedule = 53,
+    MerchantMultiSig = 69,
+    TagAllowlist = 72,
+    MerchantTags = 73,
+    MerchantFeeBps = 76,
+}
+
+impl MerchantKey {
+    const ALL: [Self; 12] = [
+        Self::MerchantSubs,
+        Self::MerchantPaused,
+        Self::MerchantConfig,
+        Self::MerchantEarnings,
+        Self::MerchantTokens,
+        Self::MerchantBalance,
+        Self::MerchantMaxSubs,
+        Self::PayoutSchedule,
+        Self::MerchantMultiSig,
+        Self::TagAllowlist,
+        Self::MerchantTags,
+        Self::MerchantFeeBps,
+    ];
+
+    const fn claimed_discriminant(self) -> u32 {
+        self as u32
+    }
+
+    fn representative_data_key(self, env: &Env) -> DataKey {
+        let address = Address::generate(env);
+        match self {
+            Self::MerchantSubs => DataKey::MerchantSubs(address),
+            Self::MerchantPaused => DataKey::MerchantPaused(address),
+            Self::MerchantConfig => DataKey::MerchantConfig(address),
+            Self::MerchantEarnings => DataKey::MerchantEarnings(address.clone(), address),
+            Self::MerchantTokens => DataKey::MerchantTokens(address),
+            Self::MerchantBalance => DataKey::MerchantBalance(address.clone(), address),
+            Self::MerchantMaxSubs => DataKey::MerchantMaxSubs(address),
+            Self::PayoutSchedule => DataKey::PayoutSchedule(address),
+            Self::MerchantMultiSig => DataKey::MerchantMultiSig(address),
+            Self::TagAllowlist => DataKey::TagAllowlist,
+            Self::MerchantTags => DataKey::MerchantTags(address),
+            Self::MerchantFeeBps => DataKey::MerchantFeeBps(address),
+        }
+    }
+}
+
+/// Governance-domain storage keys: admin/operator authority, protocol fee and
+/// treasury policy, guardian proposals, and the global kill switch.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+enum GovernanceKey {
+    Admin = 2,
+    SchemaVersion = 5,
+    EmergencyStop = 9,
+    FeeBps = 22,
+    Treasury = 23,
+    Operator = 41,
+    Guardians = 46,
+    NextProposalId = 47,
+    Proposal = 48,
+    PendingTreasuryChange = 54,
+}
+
+impl GovernanceKey {
+    const ALL: [Self; 10] = [
+        Self::Admin,
+        Self::SchemaVersion,
+        Self::EmergencyStop,
+        Self::FeeBps,
+        Self::Treasury,
+        Self::Operator,
+        Self::Guardians,
+        Self::NextProposalId,
+        Self::Proposal,
+        Self::PendingTreasuryChange,
+    ];
+
+    const fn claimed_discriminant(self) -> u32 {
+        self as u32
+    }
+
+    fn representative_data_key(self, _env: &Env) -> DataKey {
+        match self {
+            Self::Admin => DataKey::Admin,
+            Self::SchemaVersion => DataKey::SchemaVersion,
+            Self::EmergencyStop => DataKey::EmergencyStop,
+            Self::FeeBps => DataKey::FeeBps,
+            Self::Treasury => DataKey::Treasury,
+            Self::Operator => DataKey::Operator,
+            Self::Guardians => DataKey::Guardians,
+            Self::NextProposalId => DataKey::NextProposalId,
+            Self::Proposal => DataKey::Proposal(1),
+            Self::PendingTreasuryChange => DataKey::PendingTreasuryChange,
+        }
+    }
+}
+
+/// Every grouped discriminant, sorted ascending.
+///
+/// This is the cross-version snapshot: it is written out longhand so that a
+/// future edit to any group is visible as an explicit change to a frozen list
+/// rather than an invisible renumbering.
+const GROUPED_DISCRIMINANT_SNAPSHOT: [u32; 40] = [
+    0, 2, 5, 6, 7, 8, 9, 10, 16, 17, 18, 19, 20, 22, 23, 28, 30, 32, 33, 34, 39, 40, 41, 45, 46,
+    47, 48, 53, 54, 60, 61, 64, 68, 69, 70, 71, 72, 73, 75, 76,
+];
+
+fn all_grouped_discriminants() -> Vec<u32> {
+    let mut discriminants: Vec<u32> = SubscriptionKey::ALL
+        .iter()
+        .map(|key| key.claimed_discriminant())
+        .chain(MerchantKey::ALL.iter().map(|key| key.claimed_discriminant()))
+        .chain(
+            GovernanceKey::ALL
+                .iter()
+                .map(|key| key.claimed_discriminant()),
+        )
+        .collect();
+    discriminants.sort_unstable();
+    discriminants
+}
+
+#[test]
+fn subscription_group_agrees_with_canonical_registry() {
+    let env = Env::default();
+
+    for key in SubscriptionKey::ALL {
+        let data_key = key.representative_data_key(&env);
+        assert_eq!(
+            data_key.canonical_discriminant(),
+            key.claimed_discriminant(),
+            "subscription group is stale for {key:?}"
+        );
+    }
+}
+
+#[test]
+fn merchant_group_agrees_with_canonical_registry() {
+    let env = Env::default();
+
+    for key in MerchantKey::ALL {
+        let data_key = key.representative_data_key(&env);
+        assert_eq!(
+            data_key.canonical_discriminant(),
+            key.claimed_discriminant(),
+            "merchant group is stale for {key:?}"
+        );
+    }
+}
+
+#[test]
+fn governance_group_agrees_with_canonical_registry() {
+    let env = Env::default();
+
+    for key in GovernanceKey::ALL {
+        let data_key = key.representative_data_key(&env);
+        assert_eq!(
+            data_key.canonical_discriminant(),
+            key.claimed_discriminant(),
+            "governance group is stale for {key:?}"
+        );
+    }
+}
+
+#[test]
+fn groups_are_pairwise_disjoint() {
+    let discriminants = all_grouped_discriminants();
+
+    let mut deduped = discriminants.clone();
+    deduped.dedup();
+
+    assert_eq!(
+        deduped, discriminants,
+        "a discriminant was claimed by more than one feature group"
+    );
+}
+
+#[test]
+fn grouped_discriminants_match_frozen_snapshot() {
+    assert_eq!(
+        all_grouped_discriminants(),
+        GROUPED_DISCRIMINANT_SNAPSHOT.to_vec(),
+        "grouped DataKey discriminants drifted from the frozen snapshot"
+    );
+}
+
+#[test]
+fn merchant_group_keys_are_all_instance_tier() {
+    for key in MerchantKey::ALL {
+        assert!(
+            is_known_instance_discriminant(key.claimed_discriminant()),
+            "{key:?} left the instance-tier allowlist"
+        );
+    }
+}
+
+#[test]
+fn per_subscription_record_keys_stay_off_the_instance_allowlist() {
+    // These are persistent-tier by design; if one appears in the instance
+    // allowlist, a storage tier changed under us.
+    for discriminant in [6u32, 7, 8, 39, 40, 68, 75] {
+        assert!(
+            !is_known_instance_discriminant(discriminant),
+            "discriminant {discriminant} unexpectedly became an instance key"
+        );
+    }
+}
+
+#[test]
+fn empty_group_slice_is_trivially_disjoint() {
+    // Edge case named in the issue: an empty variant set must not panic.
+    let empty: [SubscriptionKey; 0] = [];
+    let discriminants: Vec<u32> = empty.iter().map(|key| key.claimed_discriminant()).collect();
+
+    assert!(discriminants.is_empty());
+}

--- a/docs/datakey_feature_groups.md
+++ b/docs/datakey_feature_groups.md
@@ -1,0 +1,51 @@
+# `DataKey` feature groups
+
+`contracts/subscription_vault/src/types.rs` holds a single flat `DataKey` enum.
+Its variant **declaration order is the on-chain wire format** — the Soroban
+`#[contracttype]` macro serialises each variant by its 0-indexed position — so
+the enum doubles as a canonical discriminant registry that must never be
+reordered or thinned.
+
+That makes the enum hard to browse but unsafe to physically split. This document
+and `contracts/subscription_vault/tests/data_key_feature_groups.rs` give the
+readability win **without** moving a single variant:
+
+| Feature group | Sub-enum | What it covers |
+| --- | --- | --- |
+| Subscription | `SubscriptionKey` | Per-subscription lifecycle, replay/idempotency, metering, metadata, per-subscriber caps and escrow |
+| Merchant | `MerchantKey` | Merchant config, earnings and balances, payout schedule, multi-sig, compliance tags, fee overrides |
+| Governance | `GovernanceKey` | Admin/operator authority, protocol fee and treasury policy, guardian proposals, emergency stop, schema version |
+
+## How drift is prevented
+
+Each sub-enum is `#[repr(u32)]` and each variant carries the **frozen**
+discriminant of its `DataKey` arm. Every variant also knows how to wrap itself
+back into a real `DataKey`. The test module then asserts, for every variant, that
+
+```text
+DataKey::<arm>.canonical_discriminant() == <SubEnum>::<Variant> as u32
+```
+
+On top of that it asserts:
+
+- the three groups are pairwise disjoint;
+- the sorted union of all grouped discriminants equals a longhand frozen
+  snapshot array, so any renumbering shows up as an explicit diff;
+- every merchant-group key is still on the instance-tier allowlist
+  (`KNOWN_INSTANCE_KEY_DISCRIMINANTS`);
+- per-subscription record keys stay **off** that allowlist, catching an
+  accidental storage-tier move;
+- an empty variant set is handled without panicking.
+
+## Scope notes
+
+- **Nothing existing is modified.** No variant, discriminant, storage tier,
+  entrypoint, or existing test is touched, which is what guarantees the
+  encoding order is preserved for this change.
+- **`TransferIntent` is deliberately ungrouped.** The registry currently reports
+  discriminant `54` for both `PendingTreasuryChange` and `TransferIntent`. Only
+  `PendingTreasuryChange` is grouped, so the disjointness assertion states a
+  true invariant. Resolving that collision changes live storage semantics and is
+  a maintainer decision, not something this PR should quietly rewrite.
+- Arms whose payloads cannot be built from a bare `Env` without unrelated test
+  fixtures are left for a follow-up.


### PR DESCRIPTION
## What

Splits the growing `DataKey` registry into three feature-scoped sub-enums —
`SubscriptionKey`, `MerchantKey`, `GovernanceKey` — each of which wraps back into
the top-level `DataKey`, and adds a cross-version snapshot test that fails if any
canonical discriminant drifts.

The grouping is implemented as a **view over** the existing enum rather than a
physical split, for one reason: variant declaration order in
`contracts/subscription_vault/src/types.rs` *is* the on-chain wire format (the
Soroban `#[contracttype]` macro serialises by 0-indexed position). Physically
moving variants to reach the same readability would risk silently repointing live
storage. Every sub-enum is `#[repr(u32)]` with the frozen discriminant baked into
each variant, and the tests assert that mapping against
`DataKey::canonical_discriminant()` — so the grouping can never disagree with the
canonical registry without CI going red.

## Implementation notes

- Each sub-enum variant exposes `representative_data_key`, which wraps it back
  into a real `DataKey` — that wrapped value is what the discriminant assertions
  run against, so the check exercises the actual enum, not a copy of it.
- The sorted union of all grouped discriminants is pinned in a longhand
  40-element snapshot array, so any future renumbering surfaces as an explicit
  diff instead of an invisible shift.
- Storage-tier assertions run against the existing
  `is_known_instance_discriminant` / `KNOWN_INSTANCE_KEY_DISCRIMINANTS` allowlist
  in both directions: merchant-group keys must stay instance-tier, and
  per-subscription record keys must stay off it.

## New coverage

`contracts/subscription_vault/tests/data_key_feature_groups.rs` — 8 tests:

1. `subscription_group_agrees_with_canonical_registry`
2. `merchant_group_agrees_with_canonical_registry`
3. `governance_group_agrees_with_canonical_registry`
4. `groups_are_pairwise_disjoint`
5. `grouped_discriminants_match_frozen_snapshot`
6. `merchant_group_keys_are_all_instance_tier`
7. `per_subscription_record_keys_stay_off_the_instance_allowlist`
8. `empty_group_slice_is_trivially_disjoint` (the empty-variant edge case named in the issue)

## Scope

Strictly additive — two new files, zero modifications:

- `contracts/subscription_vault/tests/data_key_feature_groups.rs` (new)
- `docs/datakey_feature_groups.md` (new)

No variant, discriminant, storage tier, entrypoint, or existing test is touched,
which is what guarantees the encoding order is preserved by construction.

## Two pre-existing findings, deliberately not "fixed" here

Both are reported rather than patched, since either one changes semantics that
only a maintainer should sign off on:

1. **Duplicate discriminant `54`.** `DataKey::canonical_discriminant` returns `54`
   for *both* `PendingTreasuryChange` and `TransferIntent`. `TransferIntent` is
   therefore left ungrouped so the disjointness test asserts a true invariant.
2. **`types.rs` does not currently compile on `main`.** `canonical_discriminant`
   matches on four arms that do not exist in the enum —
   `MerchantWhitelistMode`, `MerchantApproved`, `ChargeFailureCounter`,
   `AutoPauseThreshold` — while two arms that *do* exist,
   `DelegatedPayerGrant` and `SplitPayees`, have no match arm, making the match
   non-exhaustive. Separately, `Proposal::votes` uses `Map` without importing it,
   `Subscription::is_in_renewal_window` reads a field `auto_renew_disabled_at`
   that is not declared on the struct, `Kyc(KycKey)` references an undefined
   `KycKey`, and `Error` declares `CooldownActive` twice (`4012` and `12001`)
   plus duplicate codes `13001`/`13002`.

Consequence for review: `cargo test --all` cannot go green on this PR until the
above is resolved on `main`, because the crate does not build there. The files
added here are independent of that breakage and need no rework once it is fixed.

Closes #647