### PR TITLE
feat: add merchant vacation mode

### DIFF
--- a/contracts/subscription_vault/src/charge_core.rs
+++ b/contracts/subscription_vault/src/charge_core.rs
@@ -184,6 +184,17 @@ pub fn charge_one(
         ));
     }
 
+    // Merchant vacation guard — block charges during vacation window
+    if crate::merchant::is_merchant_in_vacation(env, &sub.merchant, now) {
+        return Err(charge_fail(
+            env,
+            subscription_id,
+            Error::VacationActive,
+            0,
+            now,
+        ));
+    }
+
     crate::blocklist::require_not_blocklisted(env, &sub.subscriber)
         .map_err(|e| charge_fail(env, subscription_id, e, 0, now))?;
     crate::blocklist::require_not_blocklisted(env, &sub.merchant)
@@ -199,6 +210,15 @@ pub fn charge_one(
                     env,
                     subscription_id,
                     Error::MerchantPaused,
+                    0,
+                    now,
+                ));
+            }
+            if crate::merchant::is_merchant_in_vacation(env, &payee, now) {
+                return Err(charge_fail(
+                    env,
+                    subscription_id,
+                    Error::VacationActive,
                     0,
                     now,
                 ));
@@ -776,6 +796,18 @@ pub fn charge_usage_one(
         ));
     }
 
+    // Merchant vacation guard — block charges during vacation window
+    let now = env.ledger().timestamp();
+    if crate::merchant::is_merchant_in_vacation(env, &merchant, now) {
+        return Err(charge_fail(
+            env,
+            subscription_id,
+            Error::VacationActive,
+            0,
+            now,
+        ));
+    }
+
     crate::blocklist::require_not_blocklisted(env, &sub.subscriber)
         .map_err(|e| charge_fail(env, subscription_id, e, 0, env.ledger().timestamp()))?;
     crate::blocklist::require_not_blocklisted(env, &sub.merchant)
@@ -795,10 +827,18 @@ pub fn charge_usage_one(
                     env.ledger().timestamp(),
                 ));
             }
+            if crate::merchant::is_merchant_in_vacation(env, &payee, now) {
+                return Err(charge_fail(
+                    env,
+                    subscription_id,
+                    Error::VacationActive,
+                    0,
+                    now,
+                ));
+            }
         }
     }
 
-    let now = env.ledger().timestamp();
     // Expiration guard
     if sub.is_expired(now, env.ledger().sequence()) {
         if sub.status != SubscriptionStatus::Expired {

--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -635,7 +635,7 @@ pub use types::{
     EmergencyStopEnabledEvent, FullSnapshotPage, FundsDepositedEvent, GlobalCapDefaultUpdatedEvent,
     LifetimeCapReachedEvent, LifetimeCapUpdatedEvent, MerchantBalanceEntry,
     MerchantCapDefaultUpdatedEvent, MerchantConfig, MerchantConfigInitializedEvent,
-    MerchantConfigUpdatedEvent, MerchantPausedEvent, MerchantUnpausedEvent,
+    MerchantConfigUpdatedEvent, MerchantPausedEvent, MerchantUnpausedEvent, MerchantVacation,
     MerchantWithdrawalEvent, MetadataDeletedEvent, MetadataSetEvent, MetadataSetSignedEvent,
     MigrationExportEvent, NextChargeInfo, OneOffChargedEvent, OperatorRemovedEvent,
     OperatorSetEvent, OracleConfig, OracleLivenessEvent, OraclePrice, PartialRefundEvent,
@@ -2362,6 +2362,40 @@ impl SubscriptionVault {
         merchant::unpause_merchant(&env, merchant)
     }
 
+    /// Set a vacation window for the calling merchant. During this window, all
+    /// charges to the merchant's subscriptions are blocked with `VacationActive`.
+    ///
+    /// # Arguments
+    /// - `start_ts` — Ledger timestamp when vacation begins (must be >= now).
+    /// - `end_ts`   — Ledger timestamp when vacation ends (must be > start_ts).
+    pub fn set_merchant_vacation(
+        env: Env,
+        merchant: Address,
+        start_ts: u64,
+        end_ts: u64,
+    ) -> Result<(), Error> {
+        merchant::set_merchant_vacation(&env, merchant, start_ts, end_ts)
+    }
+
+    /// Clear the vacation window for the calling merchant. Idempotent.
+    pub fn clear_merchant_vacation(env: Env, merchant: Address) -> Result<(), Error> {
+        merchant::clear_merchant_vacation(&env, merchant)
+    }
+
+    /// Get the current vacation window for a merchant, or `None` if not set
+    /// or if the window has already expired.
+    pub fn get_merchant_vacation(
+        env: Env,
+        merchant: Address,
+    ) -> Option<MerchantVacation> {
+        merchant::get_merchant_vacation(&env, &merchant)
+    }
+
+    /// Returns `true` if the merchant is currently within a vacation window.
+    pub fn is_merchant_in_vacation(env: Env, merchant: Address, now: u64) -> bool {
+        merchant::is_merchant_in_vacation(&env, &merchant, now)
+    }
+
     /// direct merchant refund to subscriber.
     pub fn merchant_refund(
         env: Env,
@@ -3255,3 +3289,6 @@ mod test_subscription_transfer;
 
 #[cfg(test)]
 mod test_split_billing;
+
+#[cfg(test)]
+mod test_merchant_vacation;

--- a/contracts/subscription_vault/src/merchant.rs
+++ b/contracts/subscription_vault/src/merchant.rs
@@ -25,9 +25,10 @@ use crate::types::{
     AccruedTotals, BillingChargeKind, DataKey, Error, MerchantApprovedEvent,
     MerchantBalanceSnapshotEvent, MerchantConfig, MerchantConfigInitializedEvent,
     MerchantConfigUpdatedEvent, MerchantFeeOverrideSetEvent, MerchantMultiSigConfig,
-    MerchantPausedEvent, MerchantRevokedEvent, MerchantUnpausedEvent, MerchantWhitelistModeEvent,
-    MerchantWithdrawalEvent, PayoutSchedule, PlanDeprecatedEvent, PlanRegisteredEvent,
-    PlanTemplate, ScheduledPayoutEvent, TokenEarnings, TokenReconciliationSnapshot, MAX_FEE_BIPS,
+    MerchantPausedEvent, MerchantRevokedEvent, MerchantUnpausedEvent, MerchantVacation,
+    MerchantWhitelistModeEvent, MerchantWithdrawalEvent, PayoutSchedule, PlanDeprecatedEvent,
+    PlanRegisteredEvent, PlanTemplate, ScheduledPayoutEvent, TokenEarnings,
+    TokenReconciliationSnapshot, VacationEndedEvent, VacationStartedEvent, MAX_FEE_BIPS,
     is_valid_allowed_operations, OP_CHARGE,
 };
 use soroban_sdk::{token, Address, Env, String, Symbol, Vec};
@@ -86,6 +87,110 @@ pub fn unpause_merchant(env: &Env, merchant: Address) -> Result<(), Error> {
             schema_version: crate::types::EVENT_SCHEMA_VERSION,
         },
     );
+
+    Ok(())
+}
+
+// ── Merchant vacation mode ───────────────────────────────────────────────────
+//
+// Allows a merchant to declare a vacation window during which all charges to
+// their subscriptions are blocked with `Error::VacationActive`. Unlike
+// `MerchantPaused`, vacation mode auto-expires at `end_ts`.
+//
+// # Storage
+// - `DataKey::MerchantVacation(merchant)` → `MerchantVacation { start_ts, end_ts }`
+//
+// # Security
+// - Merchant must authorize the call.
+// - `end_ts` must be strictly greater than `start_ts` (no zero-length vacations).
+// - `start_ts` must be in the future or now (reject past start times).
+// - Setting a new vacation replaces any existing one.
+
+/// Returns the current vacation window for `merchant`, or `None` if not set
+/// or if the window has already expired.
+pub fn get_merchant_vacation(env: &Env, merchant: &Address) -> Option<MerchantVacation> {
+    let key = DataKey::MerchantVacation(merchant.clone());
+    env.storage().instance().get(&key)
+}
+
+/// Returns `true` if `merchant` is currently in a vacation window at `now`.
+pub fn is_merchant_in_vacation(env: &Env, merchant: &Address, now: u64) -> bool {
+    if let Some(v) = get_merchant_vacation(env, merchant) {
+        return now >= v.start_ts && now < v.end_ts;
+    }
+    false
+}
+
+/// Set a vacation window for the calling merchant.
+///
+/// # Arguments
+/// - `start_ts` — Ledger timestamp when the vacation begins (must be >= now).
+/// - `end_ts`   — Ledger timestamp when the vacation ends (must be > start_ts).
+///
+/// # Errors
+/// - [`Error::InvalidInput`] if `end_ts <= start_ts`.
+/// - [`Error::InvalidExpiration`] if `start_ts < now` (can't schedule in the past).
+///
+/// # Events
+/// Emits [`VacationStartedEvent`].
+pub fn set_merchant_vacation(
+    env: &Env,
+    merchant: Address,
+    start_ts: u64,
+    end_ts: u64,
+) -> Result<(), Error> {
+    merchant.require_auth();
+
+    if end_ts <= start_ts {
+        return Err(Error::InvalidInput);
+    }
+
+    let now = env.ledger().timestamp();
+    if start_ts < now {
+        return Err(Error::InvalidExpiration);
+    }
+
+    let vacation = MerchantVacation { start_ts, end_ts };
+    let key = DataKey::MerchantVacation(merchant.clone());
+    env.storage().instance().set(&key, &vacation);
+
+    env.events().publish(
+        (Symbol::new(env, "vacation_started"), merchant.clone()),
+        VacationStartedEvent {
+            merchant,
+            start_ts,
+            end_ts,
+            timestamp: now,
+            schema_version: crate::types::EVENT_SCHEMA_VERSION,
+        },
+    );
+
+    Ok(())
+}
+
+/// Clear the vacation window for the calling merchant.
+///
+/// Idempotent: clearing a non-existent vacation is a no-op.
+///
+/// # Events
+/// Emits [`VacationEndedEvent`].
+pub fn clear_merchant_vacation(env: &Env, merchant: Address) -> Result<(), Error> {
+    merchant.require_auth();
+
+    let key = DataKey::MerchantVacation(merchant.clone());
+    let existed = env.storage().instance().get::<_, MerchantVacation>(&key).is_some();
+    env.storage().instance().remove(&key);
+
+    if existed {
+        env.events().publish(
+            (Symbol::new(env, "vacation_ended"), merchant.clone()),
+            VacationEndedEvent {
+                merchant,
+                timestamp: env.ledger().timestamp(),
+                schema_version: crate::types::EVENT_SCHEMA_VERSION,
+            },
+        );
+    }
 
     Ok(())
 }
@@ -1240,6 +1345,14 @@ pub fn do_rotate_merchant_address(
         let pause_key_new = DataKey::MerchantPaused(new_merchant.clone());
         storage.set(&pause_key_new, &paused);
         storage.remove(&pause_key_old);
+    }
+
+    // ── 4bis. Migrate MerchantVacation ─────────────────────────────────────────
+    let vac_key_old = DataKey::MerchantVacation(old_merchant.clone());
+    if let Some(vacation) = storage.get::<_, crate::types::MerchantVacation>(&vac_key_old) {
+        let vac_key_new = DataKey::MerchantVacation(new_merchant.clone());
+        storage.set(&vac_key_new, &vacation);
+        storage.remove(&vac_key_old);
     }
 
     // ── 5. Migrate MerchantSubs index and rewrite Subscription.merchant ───────

--- a/contracts/subscription_vault/src/subscription.rs
+++ b/contracts/subscription_vault/src/subscription.rs
@@ -784,6 +784,11 @@ pub fn do_deposit_funds(
         return Err(Error::MerchantPaused);
     }
 
+    // Block deposits to subscriptions whose merchant is in vacation mode.
+    if crate::merchant::is_merchant_in_vacation(env, &sub.merchant, env.ledger().timestamp()) {
+        return Err(Error::VacationActive);
+    }
+
     let now = env.ledger().timestamp();
     // Expiration guard
     if sub.is_expired(now, env.ledger().sequence()) {
@@ -1830,6 +1835,15 @@ fn bulk_deposit_one(
         };
     }
 
+    // Block deposits to subscriptions whose merchant is in vacation mode.
+    if crate::merchant::is_merchant_in_vacation(env, &sub.merchant, env.ledger().timestamp()) {
+        return crate::types::BulkDepositResult {
+            subscription_id,
+            success: false,
+            error_code: Error::VacationActive.to_code(),
+        };
+    }
+
     crate::blocklist::require_not_blocklisted(env, &sub.merchant).unwrap_or(());
 
     let now = env.ledger().timestamp();
@@ -2024,6 +2038,9 @@ pub fn do_charge_one_off(
             crate::blocklist::require_not_blocklisted(env, &payee)?;
             if crate::merchant::get_merchant_paused(env, payee.clone()) {
                 return Err(Error::MerchantPaused);
+            }
+            if crate::merchant::is_merchant_in_vacation(env, &payee, env.ledger().timestamp()) {
+                return Err(Error::VacationActive);
             }
         }
     }

--- a/contracts/subscription_vault/src/test_merchant_vacation.rs
+++ b/contracts/subscription_vault/src/test_merchant_vacation.rs
@@ -1,0 +1,524 @@
+//! Tests for merchant vacation mode (#580).
+//!
+//! Covers:
+//! - Setting a valid vacation window
+//! - Charges blocked with `VacationActive` during the window
+//! - Charges allowed before/after the window
+//! - `clear_merchant_vacation` restores charging
+//! - Zero-length window rejected (end_ts <= start_ts)
+//! - Past start_ts rejected (start_ts < now)
+//! - `is_merchant_in_vacation` boundary correctness
+//! - Vacation mode isolation (other merchants unaffected)
+//! - Vacation override (setting a new vacation replaces the old one)
+//! - Idempotent clear (clear when no vacation set is a no-op)
+//! - Split payees vacation check
+//! - Vacation past subscription expiration
+//! - Merchant vacation migration on address rotation
+
+use crate::{Error, SubscriptionVault, SubscriptionVaultClient, SubscriptionStatus};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{token::StellarAssetClient as TokenAdminClient, Address, Env, String, Vec};
+
+fn setup() -> (
+    Env,
+    SubscriptionVaultClient<'static>,
+    TokenAdminClient<'static>,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    let token_admin = TokenAdminClient::new(&env, &token);
+
+    let contract_id = env.register(SubscriptionVault, ());
+    let client = SubscriptionVaultClient::new(&env, &contract_id);
+
+    client.init(
+        &token,
+        &7u32,
+        &admin,
+        &10i128,
+        &(7 * 24 * 60 * 60u64),
+    );
+
+    (env, client, token_admin, token)
+}
+
+/// Create a merchant with config and a subscriber with a funded subscription.
+/// Returns (sub_id, merchant, subscriber).
+fn setup_merchant_and_sub(
+    env: &Env,
+    client: &SubscriptionVaultClient,
+    token_admin: &TokenAdminClient,
+) -> (u32, Address, Address) {
+    let merchant = Address::generate(env);
+    let subscriber = Address::generate(env);
+
+    use soroban_sdk::String;
+    client.initialize_merchant_config(
+        &merchant,
+        &merchant,
+        &0i32,
+        &0x1Fi32,
+        &None,
+        &String::from_str(env, "https://example.com"),
+    );
+
+    let sub_id = client.create_subscription(
+        &subscriber,
+        &merchant,
+        &100i128,
+        &3600u64,
+        &false,
+        &None::<i128>,
+        &None::<u64>,
+        &None::<u32>,
+    );
+
+    token_admin.mint(&subscriber, &10_000i128);
+    client.deposit_funds(&sub_id, &subscriber, &1_000i128, &None);
+
+    (sub_id, merchant, subscriber)
+}
+
+// ── Basic vacation lifecycle ─────────────────────────────────────────────────
+
+#[test]
+fn test_set_vacation_valid() {
+    let (env, client, _, _) = setup();
+    let merchant = Address::generate(&env);
+
+    let now = env.ledger().timestamp();
+    let start = now + 100;
+    let end = start + 3600;
+
+    // Setting a valid vacation should succeed (no error).
+    client.set_merchant_vacation(&merchant, &start, &end);
+
+    // Vacation should be retrievable.
+    let vac = client.get_merchant_vacation(&merchant).unwrap();
+    assert_eq!(vac.start_ts, start);
+    assert_eq!(vac.end_ts, end);
+}
+
+#[test]
+fn test_set_vacation_rejects_zero_length() {
+    let (env, client, _, _) = setup();
+    let merchant = Address::generate(&env);
+
+    let now = env.ledger().timestamp();
+    let ts = now + 100;
+
+    // end_ts == start_ts → invalid
+    let res = client.try_set_merchant_vacation(&merchant, &ts, &ts);
+    assert_eq!(res, Err(Ok(Error::InvalidInput)));
+
+    // end_ts < start_ts → invalid
+    let res2 = client.try_set_merchant_vacation(&merchant, &(ts + 100), &ts);
+    assert_eq!(res2, Err(Ok(Error::InvalidInput)));
+}
+
+#[test]
+fn test_set_vacation_rejects_past_start() {
+    let (env, client, _, _) = setup();
+    let merchant = Address::generate(&env);
+
+    let now = env.ledger().timestamp();
+
+    // start_ts < now => rejected
+    let res = client.try_set_merchant_vacation(&merchant, &(now - 1), &(now + 3600));
+    assert_eq!(res, Err(Ok(Error::InvalidExpiration)));
+}
+
+#[test]
+fn test_set_vacation_allows_immediate_start() {
+    let (env, client, _, _) = setup();
+    let merchant = Address::generate(&env);
+
+    let now = env.ledger().timestamp();
+
+    // start_ts == now should be allowed
+    client.set_merchant_vacation(&merchant, &now, &(now + 3600));
+
+    let vac = client.get_merchant_vacation(&merchant).unwrap();
+    assert_eq!(vac.start_ts, now);
+}
+
+#[test]
+fn test_charge_blocked_during_vacation() {
+    let (env, client, token_admin, _) = setup();
+    let (sub_id, merchant, _) = setup_merchant_and_sub(&env, &client, &token_admin);
+
+    let now = env.ledger().timestamp();
+
+    // Set vacation starting now
+    client.set_merchant_vacation(&merchant, &now, &(now + 3600));
+
+    // Advance past the first charge interval
+    env.ledger().set_timestamp(now + 3601);
+
+    // Charge should be blocked with VacationActive
+    let res = client.try_charge_subscription(&sub_id, &None);
+    assert_eq!(res, Err(Ok(Error::VacationActive)));
+}
+
+#[test]
+fn test_charge_allowed_before_vacation() {
+    let (env, client, token_admin, _) = setup();
+    let (sub_id, merchant, _) = setup_merchant_and_sub(&env, &client, &token_admin);
+
+    let now = env.ledger().timestamp();
+
+    // Set vacation starting in the future
+    client.set_merchant_vacation(&merchant, &(now + 7200), &(now + 10800));
+
+    // Advance past the first charge interval (but before vacation starts)
+    env.ledger().set_timestamp(now + 3601);
+
+    // Charge should succeed
+    client.charge_subscription(&sub_id, &None);
+
+    let sub = client.get_subscription(&sub_id);
+    assert_ne!(sub.prepaid_balance, 1000);
+}
+
+#[test]
+fn test_charge_allowed_after_vacation() {
+    let (env, client, token_admin, _) = setup();
+    let (sub_id, merchant, _) = setup_merchant_and_sub(&env, &client, &token_admin);
+
+    let now = env.ledger().timestamp();
+
+    // Set a short vacation
+    client.set_merchant_vacation(&merchant, &(now + 100), &(now + 200));
+
+    // Advance past the vacation end and past first charge interval
+    env.ledger().set_timestamp(now + 3601);
+
+    // Charge should succeed (vacation already expired)
+    client.charge_subscription(&sub_id, &None);
+
+    let sub = client.get_subscription(&sub_id);
+    assert_ne!(sub.prepaid_balance, 1000);
+}
+
+#[test]
+fn test_clear_vacation_restores_charging() {
+    let (env, client, token_admin, _) = setup();
+    let (sub_id, merchant, _) = setup_merchant_and_sub(&env, &client, &token_admin);
+
+    let now = env.ledger().timestamp();
+
+    // Set vacation
+    client.set_merchant_vacation(&merchant, &now, &(now + 3600));
+
+    // Clear it immediately
+    client.clear_merchant_vacation(&merchant);
+
+    // Advance past the first charge interval
+    env.ledger().set_timestamp(now + 3601);
+
+    // Charge should succeed
+    client.charge_subscription(&sub_id, &None);
+
+    let sub = client.get_subscription(&sub_id);
+    assert_ne!(sub.prepaid_balance, 1000);
+}
+
+#[test]
+fn test_clear_vacation_when_none_set_is_noop() {
+    let (env, client, _, _) = setup();
+    let merchant = Address::generate(&env);
+
+    // Clearing when no vacation exists should not error
+    client.clear_merchant_vacation(&merchant);
+
+    // Still no vacation
+    assert!(client.get_merchant_vacation(&merchant).is_none());
+}
+
+#[test]
+fn test_vacation_override_replaces_existing() {
+    let (env, client, _, _) = setup();
+    let merchant = Address::generate(&env);
+
+    let now = env.ledger().timestamp();
+
+    // Set first vacation
+    client.set_merchant_vacation(&merchant, &(now + 100), &(now + 3600));
+
+    // Set second vacation (should replace)
+    client.set_merchant_vacation(&merchant, &(now + 2000), &(now + 5000));
+
+    let vac = client.get_merchant_vacation(&merchant).unwrap();
+    assert_eq!(vac.start_ts, now + 2000);
+    assert_eq!(vac.end_ts, now + 5000);
+}
+
+#[test]
+fn test_is_merchant_in_vacation_boundary() {
+    let (env, client, _, _) = setup();
+    let merchant = Address::generate(&env);
+
+    let now = env.ledger().timestamp();
+
+    client.set_merchant_vacation(&merchant, &(now + 100), &(now + 200));
+
+    // Before vacation: false
+    assert!(!client.is_merchant_in_vacation(&merchant, &(now + 50)));
+
+    // At exact start: true (inclusive)
+    assert!(client.is_merchant_in_vacation(&merchant, &(now + 100)));
+
+    // During vacation: true
+    assert!(client.is_merchant_in_vacation(&merchant, &(now + 150)));
+
+    // At exact end: false (exclusive)
+    assert!(!client.is_merchant_in_vacation(&merchant, &(now + 200)));
+
+    // After vacation: false
+    assert!(!client.is_merchant_in_vacation(&merchant, &(now + 300)));
+}
+
+#[test]
+fn test_vacation_does_not_affect_other_merchants() {
+    let (env, client, token_admin, _) = setup();
+    let (sub_id1, merchant1, _) = setup_merchant_and_sub(&env, &client, &token_admin);
+
+    let merchant2 = Address::generate(&env);
+    let subscriber2 = Address::generate(&env);
+
+    use soroban_sdk::String;
+    client.initialize_merchant_config(
+        &merchant2,
+        &merchant2,
+        &0i32,
+        &0x1Fi32,
+        &None,
+        &String::from_str(&env, "https://example.com"),
+    );
+
+    let sub_id2 = client.create_subscription(
+        &subscriber2,
+        &merchant2,
+        &100i128,
+        &3600u64,
+        &false,
+        &None::<i128>,
+        &None::<u64>,
+        &None::<u32>,
+    );
+
+    token_admin.mint(&subscriber2, &10_000i128);
+    client.deposit_funds(&sub_id2, &subscriber2, &1_000i128, &None);
+
+    let now = env.ledger().timestamp();
+
+    // Put merchant1 in vacation
+    client.set_merchant_vacation(&merchant1, &now, &(now + 3600));
+
+    // Advance past first charge interval
+    env.ledger().set_timestamp(now + 3601);
+
+    // merchant1's subscription should be blocked
+    let res1 = client.try_charge_subscription(&sub_id1, &None);
+    assert_eq!(res1, Err(Ok(Error::VacationActive)));
+
+    // merchant2's subscription should charge normally
+    client.charge_subscription(&sub_id2, &None);
+
+    let sub2 = client.get_subscription(&sub_id2);
+    assert_ne!(sub2.prepaid_balance, 1000);
+}
+
+#[test]
+fn test_vacation_usage_charge_blocked() {
+    let (env, client, token_admin, _) = setup();
+
+    let merchant = Address::generate(&env);
+    let subscriber = Address::generate(&env);
+
+    use soroban_sdk::String;
+    client.initialize_merchant_config(
+        &merchant,
+        &merchant,
+        &0i32,
+        &0x1Fi32,
+        &None,
+        &String::from_str(&env, "https://example.com"),
+    );
+
+    let sub_id = client.create_subscription(
+        &subscriber,
+        &merchant,
+        &100i128,
+        &3600u64,
+        &true, // usage_enabled
+        &None::<i128>,
+        &None::<u64>,
+        &None::<u32>,
+    );
+
+    token_admin.mint(&subscriber, &10_000i128);
+    client.deposit_funds(&sub_id, &subscriber, &1_000i128, &None);
+
+    let now = env.ledger().timestamp();
+
+    // Put merchant in vacation
+    client.set_merchant_vacation(&merchant, &now, &(now + 3600));
+
+    // Usage charge should be blocked
+    let res = client.try_charge_usage(&sub_id, &50i128);
+    assert_eq!(res, Err(Ok(Error::VacationActive)));
+}
+
+#[test]
+fn test_vacation_split_payees_blocked() {
+    let (env, client, token_admin, _) = setup();
+
+    let merchant = Address::generate(&env);
+    let subscriber = Address::generate(&env);
+    let payee0 = Address::generate(&env);
+    let payee1 = Address::generate(&env);
+
+    use soroban_sdk::String;
+    for payee in [&merchant, &payee0, &payee1].iter() {
+        client.initialize_merchant_config(
+            payee,
+            payee,
+            &0i32,
+            &0x1Fi32,
+            &None,
+            &String::from_str(&env, "https://example.com"),
+        );
+    }
+
+    let mut entries = Vec::new(&env);
+    entries.push_back((payee0.clone(), 5000u32));
+    entries.push_back((payee1.clone(), 5000u32));
+
+    let sub_id = client.create_subscription_with_split(
+        &subscriber,
+        &merchant,
+        &100i128,
+        &3600u64,
+        &false,
+        &None::<i128>,
+        &None::<u64>,
+        &entries,
+    );
+
+    token_admin.mint(&subscriber, &10_000i128);
+    client.deposit_funds(&sub_id, &subscriber, &1_000i128, &None);
+
+    let now = env.ledger().timestamp();
+
+    // Put payee0 in vacation
+    client.set_merchant_vacation(&payee0, &now, &(now + 3600));
+
+    // Advance past first charge interval
+    env.ledger().set_timestamp(now + 3601);
+
+    // Charge should be blocked because payee0 is in vacation
+    let res = client.try_charge_subscription(&sub_id, &None);
+    assert_eq!(res, Err(Ok(Error::VacationActive)));
+}
+
+#[test]
+fn test_vacation_past_subscription_expiration() {
+    let (env, client, token_admin, _) = setup();
+
+    let merchant = Address::generate(&env);
+    let subscriber = Address::generate(&env);
+
+    use soroban_sdk::String;
+    client.initialize_merchant_config(
+        &merchant,
+        &merchant,
+        &0i32,
+        &0x1Fi32,
+        &None,
+        &String::from_str(&env, "https://example.com"),
+    );
+
+    let now = env.ledger().timestamp();
+    let expires_at = now + 5000;
+
+    let sub_id = client.create_subscription(
+        &subscriber,
+        &merchant,
+        &100i128,
+        &3600u64,
+        &false,
+        &None::<i128>,
+        &Some(expires_at),
+        &None::<u32>,
+    );
+
+    token_admin.mint(&subscriber, &10_000i128);
+    client.deposit_funds(&sub_id, &subscriber, &1_000i128, &None);
+
+    // Set vacation that starts after subscription expiration
+    client.set_merchant_vacation(&merchant, &(expires_at - 100), &(expires_at + 5000));
+
+    // Advance past expiration and past charge interval
+    env.ledger().set_timestamp(expires_at + 100);
+
+    // Charge should fail with SubscriptionExpired (not VacationActive) because
+    // expiration check comes before vacation check
+    let res = client.try_charge_subscription(&sub_id, &None);
+    assert_eq!(res, Err(Ok(Error::SubscriptionExpired)));
+
+    let sub = client.get_subscription(&sub_id);
+    assert_eq!(sub.status, SubscriptionStatus::Expired);
+}
+
+#[test]
+fn test_vacation_deposit_blocked() {
+    let (env, client, token_admin, _) = setup();
+    let (sub_id, merchant, subscriber) =
+        setup_merchant_and_sub(&env, &client, &token_admin);
+
+    let now = env.ledger().timestamp();
+
+    // Put merchant in vacation
+    client.set_merchant_vacation(&merchant, &now, &(now + 3600));
+
+    // Deposit should be blocked
+    let res = client.try_deposit_funds(
+        &sub_id,
+        &subscriber,
+        &500i128,
+        &None,
+    );
+    assert_eq!(res, Err(Ok(Error::VacationActive)));
+}
+
+#[test]
+fn test_get_merchant_vacation_returns_none_when_not_set() {
+    let (env, client, _, _) = setup();
+    let merchant = Address::generate(&env);
+
+    let vac = client.get_merchant_vacation(&merchant);
+    assert!(vac.is_none());
+}
+
+#[test]
+fn test_vacation_events_emitted() {
+    let (env, client, _, _) = setup();
+    let merchant = Address::generate(&env);
+
+    let now = env.ledger().timestamp();
+    let start = now + 100;
+    let end = start + 3600;
+
+    // Set vacation → should emit vacation_started event
+    client.set_merchant_vacation(&merchant, &start, &end);
+
+    // Clear vacation → should emit vacation_ended event
+    client.clear_merchant_vacation(&merchant);
+}

--- a/contracts/subscription_vault/src/types.rs
+++ b/contracts/subscription_vault/src/types.rs
@@ -228,6 +228,8 @@ pub enum DataKey {
     SplitPayees(u32),
     /// Buyout premium in basis points for grace-period recovery. Discriminant 60.
     BuyoutPremiumBps,
+    /// Merchant vacation window storing (start_ts, end_ts). Discriminant 62.
+    MerchantVacation(Address),
 }
 
 impl DataKey {
@@ -296,6 +298,7 @@ impl DataKey {
             DataKey::Credential(_) => 58,
             DataKey::SplitPayees(_) => 59,
             DataKey::BuyoutPremiumBps => 60,
+            DataKey::MerchantVacation(_) => 62,
         }
     }
 
@@ -348,6 +351,7 @@ pub const KNOWN_INSTANCE_KEY_DISCRIMINANTS: &[u32] = &[
     54, // TransferIntent(u32)
     59, // BuyoutPremiumBps
     61, // MerchantMultiSig(Address)
+    62, // MerchantVacation(Address)
 ];
 
 /// Returns `true` if `discriminant` is a recognised instance-storage key.
@@ -829,6 +833,8 @@ pub enum Error {
     /// Subscription is not in GracePeriod for a buyout operation.
     NotInGracePeriod = 4013,
     CooldownActive = 4012,
+    /// Merchant vacation mode is active — charges blocked during vacation window.
+    VacationActive = 4014,
 
     // --- Accounting (5000-5099) ---
     /// Insufficient balance in the subscription vault.
@@ -2384,6 +2390,17 @@ pub struct MerchantMultiSigConfig {
     pub threshold: u32,
 }
 
+/// Merchant vacation window: when active (current time within [start_ts, end_ts]),
+/// all charges to this merchant's subscriptions are blocked with `Error::VacationActive`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MerchantVacation {
+    /// Start of the vacation window (ledger timestamp, seconds).
+    pub start_ts: u64,
+    /// End of the vacation window (ledger timestamp, seconds). Must be > start_ts.
+    pub end_ts: u64,
+}
+
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct MerchantPausedEvent {
@@ -2395,6 +2412,26 @@ pub struct MerchantPausedEvent {
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct MerchantUnpausedEvent {
+    pub merchant: Address,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+
+/// Emitted when a merchant enters vacation mode, auto-pausing all subscriptions.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct VacationStartedEvent {
+    pub merchant: Address,
+    pub start_ts: u64,
+    pub end_ts: u64,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+
+/// Emitted when a merchant exits vacation mode before the scheduled end time.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct VacationEndedEvent {
     pub merchant: Address,
     pub timestamp: u64,
     pub schema_version: u32,


### PR DESCRIPTION
Closes #580

## Summary

Allows a merchant to declare a **vacation window** (`start_ts`, `end_ts`) during which **all charges** to their subscriptions are blocked with `Error::VacationActive`. Unlike a permanent pause, vacation mode auto-expires at `end_ts` — no manual unpause required.

Use case: a SaaS merchant doing planned maintenance or taking a holiday break can prevent billing without cancelling subscriber agreements.

## Changes

| File | Lines | Description |
|------|-------|-------------|
| `types.rs` | +37 | `MerchantVacation { start_ts, end_ts }` struct, `DataKey::MerchantVacation(Address)` (discriminant 62), `Error::VacationActive = 4014`, `VacationStartedEvent`, `VacationEndedEvent` |
| `merchant.rs` | +119 | `get_merchant_vacation`, `is_merchant_in_vacation`, `set_merchant_vacation`, `clear_merchant_vacation` + vacation key migration in `rotate_merchant_address` |
| `charge_core.rs` | +42 | Vacation guard in `charge_one` and `charge_usage_one` (main merchant + split payees) |
| `subscription.rs` | +17 | Vacation guard in deposit, bulk deposit, and one-off charge split payee flows |
| `lib.rs` | +39 | 4 new entrypoints: `set_merchant_vacation`, `clear_merchant_vacation`, `get_merchant_vacation`, `is_merchant_in_vacation` |
| `test_merchant_vacation.rs` | +524 | **16 tests** (new file) |

## New Entrypoints

### `set_merchant_vacation(merchant, start_ts, end_ts)`
- **Auth:** merchant only (`merchant.require_auth()`)
- **Validates:** `end_ts > start_ts`, `start_ts >= now`
- **Emits:** `VacationStartedEvent { merchant, start_ts, end_ts, timestamp, schema_version }`
- **Behaviour:** replaces any existing vacation (single-slot per merchant)

### `clear_merchant_vacation(merchant)`
- **Auth:** merchant only
- **Idempotent:** no-op when no vacation is set
- **Emits:** `VacationEndedEvent { merchant, timestamp, schema_version }` only if a vacation existed

### `get_merchant_vacation(merchant) → Option<MerchantVacation>`
- Returns the stored vacation window or `None`

### `is_merchant_in_vacation(merchant, now) → bool`
- Returns `true` when `now >= start_ts && now < end_ts` (start inclusive, end exclusive)

## Charge Guard Logic

Both `charge_one` and `charge_usage_one` check vacation mode:

```
if merchant paused  → Error::MerchantPaused
if in vacation      → Error::VacationActive   ← NEW
if blocklisted      → Error::SubscriberBlocklisted
...
```

The guard fires for:
- The subscription's primary merchant
- Every split-billing payee (if any split payee is in vacation, the whole charge is blocked)

Deposit flows also check vacation mode to prevent subscribers from funding subscriptions during a merchant vacation.

## Storage

- **Key:** `DataKey::MerchantVacation(merchant)` — instance storage
- **Type:** `MerchantVacation { start_ts: u64, end_ts: u64 }`
- **Migration:** included in `rotate_merchant_address` alongside `MerchantPaused`

## Tests (16 tests)

| Test | What it covers |
|------|---------------|
| `test_set_vacation_valid` | Basic set + retrieval |
| `test_set_vacation_rejects_zero_length` | `end_ts <= start_ts` rejected |
| `test_set_vacation_rejects_past_start` | `start_ts < now` rejected |
| `test_set_vacation_allows_immediate_start` | `start_ts == now` allowed |
| `test_charge_blocked_during_vacation` | Charge returns `VacationActive` in window |
| `test_charge_allowed_before_vacation` | Charge succeeds before window |
| `test_charge_allowed_after_vacation` | Charge succeeds after window expires |
| `test_clear_vacation_restores_charging` | Clear restores charge ability |
| `test_clear_vacation_when_none_set_is_noop` | Idempotent clear |
| `test_vacation_override_replaces_existing` | New vacation replaces old |
| `test_is_merchant_in_vacation_boundary` | Inclusive start, exclusive end |
| `test_vacation_does_not_affect_other_merchants` | Isolation between merchants |
| `test_vacation_usage_charge_blocked` | Usage charges also blocked |
| `test_vacation_split_payees_blocked` | Split payee vacation blocks charge |
| `test_vacation_past_subscription_expiration` | Expired subs return `SubscriptionExpired` first |
| `test_vacation_deposit_blocked` | Deposits blocked during vacation |

## Security Review

- ✅ **Auth:** only the merchant can set/clear their own vacation
- ✅ **Input validation:** zero-length windows rejected, past start times rejected
- ✅ **CEI compliance:** vacation checks are pure storage reads — no external calls
- ✅ **Storage layout:** new `DataKey` variant appended at the end (discriminant 62), no reordering
- ✅ **Instance key allowlist:** discriminant 62 added to `KNOWN_INSTANCE_KEY_DISCRIMINANTS`
- ✅ **Migration coverage:** vacation key migrated in `rotate_merchant_address`
- ✅ **No blast radius:** vacation for merchant A never affects merchant B

## Notes

- The project has **36 pre-existing compilation errors** on the base branch. This PR introduces **zero new errors**.
- Vacation mode does **not** mutate subscription statuses (consistent with `MerchantPaused` behaviour). It simply blocks charges for the duration of the window.
