### PR TITLE
test: kani proof for cancel refund bound

### DIFF
--- a/contracts/subscription_vault/Cargo.toml
+++ b/contracts/subscription_vault/Cargo.toml
@@ -59,6 +59,10 @@ name = "nonce_verification"
 path = "verification/nonce_verification.rs"
 
 [[test]]
+name = "cancel_refund"
+path = "kani/cancel_refund.rs"
+
+[[test]]
 name = "channel_account_auth"
 path = "tests/channel_account_auth.rs"
 

--- a/contracts/subscription_vault/kani/cancel_refund.rs
+++ b/contracts/subscription_vault/kani/cancel_refund.rs
@@ -1,0 +1,34 @@
+#[cfg(kani)]
+mod verification {
+    use subscription_vault::compute_cancel_refund;
+
+    /// Prove that the cancellation refund never exceeds the incoming prepaid
+    /// balance for any reachable i128 value, including 0 and i128::MAX.
+    ///
+    /// Security property: the escrow amount == prepaid_balance, so no
+    /// underflow-driven drain is possible.
+    #[kani::proof]
+    fn cancel_refund_bounded() {
+        let balance: i128 = kani::any();
+
+        let refund = compute_cancel_refund(balance);
+
+        // Refund must not exceed what was held.
+        assert!(refund <= balance);
+        // Refund must equal the full balance (no hidden deduction).
+        assert_eq!(refund, balance);
+    }
+
+    /// Edge case: zero balance produces zero refund.
+    #[kani::proof]
+    fn cancel_refund_zero_balance() {
+        assert_eq!(compute_cancel_refund(0), 0);
+    }
+
+    /// Edge case: maximum balance does not overflow.
+    #[kani::proof]
+    fn cancel_refund_max_balance() {
+        let refund = compute_cancel_refund(i128::MAX);
+        assert_eq!(refund, i128::MAX);
+    }
+}

--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -596,6 +596,7 @@ pub mod operator {
 
 /// Metadata: per-subscription key-value annotations.
 pub use metadata::*;
+pub use subscription::compute_cancel_refund;
 
 // ── Re-exports ────────────────────────────────────────────────────────────────
 pub use blocklist::{BlocklistAddedEvent, BlocklistEntry, BlocklistRemovedEvent};

--- a/contracts/subscription_vault/src/subscription.rs
+++ b/contracts/subscription_vault/src/subscription.rs
@@ -1108,6 +1108,16 @@ pub fn do_cancel_subscription(
 ///
 /// `authorizer` is recorded verbatim in the emitted event (the admin/operator on
 /// the bulk path, or the subscriber/merchant on the single path).
+/// Returns the token amount to place into cancellation escrow for a subscription
+/// with the given `prepaid_balance`.
+///
+/// The refund is exactly the full prepaid balance — no fee, no deduction. Extracted
+/// as a pure function so the kani harness can prove the bound without Soroban host
+/// dependencies.
+pub fn compute_cancel_refund(prepaid_balance: i128) -> i128 {
+    prepaid_balance
+}
+
 fn apply_cancellation(
     env: &Env,
     subscription_id: u32,
@@ -1123,7 +1133,7 @@ fn apply_cancellation(
     if was_active {
         decrement_subscriber_active_count(env, &sub.subscriber);
     }
-    let refund_amount = sub.prepaid_balance;
+    let refund_amount = compute_cancel_refund(sub.prepaid_balance);
 
     // EFFECTS: zero balance before escrow (CEI pattern).
     sub.prepaid_balance = 0;


### PR DESCRIPTION
Closes #587

---

## What

Kani proof that `cancel_subscription`'s refund path never sends more than the current `prepaid_balance` for any reachable `i128` input, guarding against underflow-driven token drains.

## Changes

**`subscription.rs`** — extract refund math into a pure function:

```rust
pub fn compute_cancel_refund(prepaid_balance: i128) -> i128 {
    prepaid_balance
}
```

`apply_cancellation` now calls it instead of reading the field directly. The function is intentionally trivial — the value of extracting it is that kani can prove the bound without a Soroban `Env`.

**`kani/cancel_refund.rs`** — three proofs:

- `cancel_refund_bounded` — for every `i128` input, `refund <= balance` and `refund == balance`
- `cancel_refund_zero_balance` — zero balance produces zero refund
- `cancel_refund_max_balance` — `i128::MAX` does not overflow

**`lib.rs`** — `pub use subscription::compute_cancel_refund` so the harness can import it from the crate root without a host env.

**`Cargo.toml`** — `[[test]]` entry wiring the harness into `cargo kani`.

## Security note

The proof covers all 2^128 `i128` values. No underflow-driven drain is possible: the escrow amount is exactly the balance held at cancellation time.
