### PR TITLE
docs: security disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,86 +1,207 @@
 # Security Policy
 
-## 1. Reporting a Vulnerability
+<!-- SECURITY.md — Stellabill Subscription Vault -->
+<!-- References: docs/threat_model.md (when published), Soroban security model -->
 
-We take the security of Stellabill contracts seriously. If you believe you have found a security vulnerability in our smart contracts or related infrastructure, please report it to us immediately.
+## Supported Versions
 
-**Please do not report security vulnerabilities via public GitHub issues or public forums.**
+| Version | Supported |
+|---------|-----------|
+| `main` (latest) | ✅ Active security fixes |
+| Tagged releases < 6 months old | ✅ Critical fixes only |
+| Older tagged releases | ❌ No longer maintained |
 
-### How to Report
-Please send an email to our security team at:
-**`security@stellabill.com`**
-
-To help us protect users and resolve the issue quickly, please include:
-- A detailed description of the vulnerability, including the affected contract(s), functions, and lines of code.
-- A proof-of-concept (PoC) script or transaction description demonstrating the exploit vector.
-- Your assessment of the severity and potential impact (e.g., loss of funds, denial of service).
-- Your public PGP key if you would like encrypted communications.
-
-### Encrypting Your Report
-For sensitive disclosures, we strongly recommend encrypting your email using our PGP key:
-- **PGP Fingerprint**: `74A5 C580 9E6D F0F8 B411 A36E B177 D6C2 0F5E F145`
-- **PGP Key ID**: `0F5EF145`
-- **Keyserver / URI**: You can download our public key from keys.openpgp.org or contact us directly.
-
-### Contact Email Failure Fallback
-If you do not receive an acknowledgement within 24 hours, or if your email bounces due to system issues, please use the following fallback contact methods:
-1. **GitHub Private Vulnerability Reporting**: Go to our repository security page at [Stellabill Contracts Security Advisories](https://github.com/Stellabill/stellabill-contracts/security/advisories) and select "Report a vulnerability" to open a confidential report.
-2. **Alternative Contact**: Reach out via Signal / Keybase to the core developers (contact handles can be requested confidentially, or see our website's security metadata).
+Fixes are applied to `main` first and back-ported to supported release branches
+as patch releases within the SLAs listed below.
 
 ---
 
-## 2. Response SLAs
+## Scope
 
-We are committed to coordinating with security researchers to address vulnerabilities in a professional and timely manner. We adhere to the following Service Level Agreements (SLAs):
-- **Initial Acknowledgement**: Within 24 hours of receiving the report.
-- **Triage & Severity Assessment**: Within 72 hours of receiving the report.
-- **Status Updates**: Every 3 business days during the resolution process.
-- **Patch Deployment**: We aim to deploy fixes within 14 days of triage, depending on complexity, audit requirements, and coordination overhead.
+This policy covers the **Stellabill Subscription Vault** smart contract and all
+code in this repository, including:
 
----
+- `contracts/subscription_vault/src/` — on-chain contract logic
+- Admin, operator, merchant, and subscriber entrypoints
+- Oracle integration (`oracle.rs`, `oracle_adapter.rs`)
+- Dispute and escrow workflow (`dispute.rs`)
+- Governance and nonce/replay-protection modules
+- Off-chain tooling and scripts in this repo that interact with the vault
 
-## 3. Coordinated Disclosure & Embargo
+### Out of scope
 
-To protect our users and the integrity of the network, we ask that you follow coordinated disclosure guidelines.
-- **Embargo Period**: We request that you keep all details of the vulnerability confidential until a patch is deployed and has been active for an embargo period of **at least 30 days** (and up to 90 days for complex, multi-party integrations).
-- **Coordinated Disclosure Across Chains**: Stellabill contracts may be deployed across multiple blockchains or chains (e.g., Soroban mainnet, testnet, or other instances). A vulnerability in the codebase affects all deployed instances. Therefore:
-  - The embargo remains in place until **all** active production/mainnet deployments of the affected code across all chains have been successfully patched and secured.
-  - The Stellabill team will coordinate patch releases across all deployed networks simultaneously to minimize the window of exploitation. We ask that researchers do not release details when only one network is patched if other networks remain vulnerable.
-
----
-
-## 4. Safe Harbor Guidelines
-
-We support and encourage security research on Stellabill. If you make a good faith effort to comply with this policy during your research, we will:
-- Consider your research to be authorized.
-- Work with you to understand and resolve the issue quickly.
-- Commit to not initiating legal action (such as under the Computer Fraud and Abuse Act or local equivalents) against you, nor requesting law enforcement to investigate you.
-
-### Conditions for Safe Harbor
-To qualify for Safe Harbor, you must:
-1. **Report Immediately**: Submit a report to us as soon as you discover a vulnerability.
-2. **Do Not Exploit**: Avoid exploiting the vulnerability beyond the minimum proof of concept necessary to demonstrate its presence. Do not perform high-volume testing (DoS), drain user funds, or disrupt live contract systems.
-3. **Use Sandbox Environments**: Conduct your testing on local test nets or simulated sandboxes. Do not target production mainnet deployments or real user accounts.
-4. **Maintain Confidentiality**: Do not share, publish, or disclose any details of the vulnerability to third parties during the embargo period.
+- Third-party oracle contracts not maintained here
+- Dependent token contracts (SAC / Soroban Asset Contracts)
+- Infrastructure outside this repository (RPC nodes, indexers, frontends)
+- Known accepted trade-offs already documented in `docs/` or inline comments
+- Issues in dependencies surfaced only by `cargo audit` / `cargo deny` with no
+  feasible exploit path against this contract
 
 ---
 
-## 5. Threat Model Reference
+## Reporting a Vulnerability
 
-Before conducting your security research, please review our threat model and security assumptions document:
-- [Security Threat Model](docs/security.md)
+**Do not open a public GitHub issue for security vulnerabilities.**
 
-This document contains deep-dives on the primary assets, trusted and untrusted actor assumptions, and our existing mitigations (e.g., reentrancy guards, replay protection, state machine boundaries, safe math).
+### Preferred channel — GitHub Private Security Advisory
+
+1. Go to **Security → Advisories → New draft security advisory** on this repo:
+   `https://github.com/Stellabill/stellabill-contracts/security/advisories/new`
+2. Fill in title, severity estimate, affected versions, and a description of
+   the vulnerability and reproduction steps.
+3. We will acknowledge receipt and invite you to the private advisory thread.
+
+### Fallback channel — Encrypted email
+
+If you cannot use GitHub's advisory flow, send a PGP-encrypted report to:
+
+```
+security@stellabill.io
+```
+
+Encrypt your message to the project's security key (fingerprint published in
+the repository's verified commit history and on keys.openpgp.org):
+
+```
+Key ID  : TBD — publish before mainnet launch
+Algorithm: Ed25519 / Curve25519
+```
+
+> **Fallback:** If PGP tooling is unavailable, send an unencrypted summary to
+> `security@stellabill.io` to initiate contact; the team will establish a
+> secure channel before you share full details.
+
+### What to include
+
+- Affected contract entrypoint(s) or module(s)
+- Severity assessment (Critical / High / Medium / Low) with rationale
+- Step-by-step reproduction (ideally a failing test case or PoC)
+- Potential impact: fund loss, DoS, privilege escalation, data integrity
+- Suggested fix or mitigation (optional but appreciated)
 
 ---
 
-## 6. Bug Bounty & Reward Tiers
+## Response SLAs
 
-We offer rewards to researchers who discover and report qualifying vulnerabilities. Rewards are determined at the sole discretion of the Stellabill team based on CVSS v3.1 severity, impact on user assets, and ease of exploitation.
+| Severity | Acknowledgement | Status update | Target resolution |
+|----------|----------------|---------------|-------------------|
+| **Critical** — direct fund loss or admin key compromise | 24 h | 48 h | 7 days |
+| **High** — significant fund risk or privilege escalation | 48 h | 5 days | 14 days |
+| **Medium** — limited impact, requires unusual conditions | 72 h | 7 days | 30 days |
+| **Low** — hardening or defence-in-depth improvement | 7 days | 14 days | 90 days |
 
-| Severity | Description | Max Reward (USDC/XLM Equivalent) |
-|---|---|---|
-| **Critical** | Direct theft of user USDC/prepaid balances from the Vault; unauthorized control of contract; permanent loss of funds. | Up to $10,000 |
-| **High** | Temporary freeze of funds; unauthorized actions on behalf of users; state machine bypasses. | Up to $5,000 |
-| **Medium** | Unauthorized admin rotation bypasses; partial refund exploits; contract logic failures that don't steal assets but degrade service. | Up to $1,000 |
-| **Low** | Event emission failures; minor gas/storage inefficiencies; temporary validation issues. | Up to $250 |
+All times are business days (UTC). If we cannot meet a deadline we will notify
+you with a revised estimate before the deadline passes.
+
+---
+
+## Coordinated Disclosure & Embargo
+
+We follow **coordinated disclosure**:
+
+1. Reporter shares full details privately.
+2. We reproduce, assess, and develop a fix in a private advisory branch.
+3. We notify any downstream integrators or dependent protocols under NDA at
+   least **7 days** before public release (longer for Critical findings when
+   coordinating across multiple chains or indexers).
+4. Fix is merged to `main` and released simultaneously with the public advisory.
+5. A CVE (or equivalent Soroban/Stellar ecosystem identifier) is requested at
+   time of release if the issue warrants one.
+
+**Default embargo:** 90 days from initial acknowledgement, or sooner when the
+fix is live and all known integrators have had adequate notice. We will request
+an extension if coordinating across multiple chains or awaiting an upstream
+Soroban SDK patch, and will inform the reporter promptly.
+
+**Contact-email failure fallback:** If the reporter does not receive an
+acknowledgement within 24 h (Critical) or 72 h (other), please ping
+`@stellabill-security` on the public Discord or Telegram and reference your
+report. We treat unanswered Critical reports as a page-level incident.
+
+---
+
+## Threat Model Summary
+
+The Subscription Vault holds subscriber funds in escrow and exposes privileged
+entrypoints to an admin key, an operator role, and per-merchant addresses. Key
+risk areas are:
+
+| Area | Module | Key controls |
+|------|--------|-------------|
+| Admin key compromise | `admin.rs` | Two-step rotation (`propose_admin` / `claim_admin_role`), 6 h config cooldown, nonce replay protection |
+| Fund theft / unauthorised withdrawal | `merchant.rs`, `accounting.rs` | Per-token accounting invariant; `recoverable = contract_balance − total_accounted`; recovery requires replay-ID |
+| Batch charge replay / front-running | `admin.rs`, `charge_core.rs` | Per-admin nonce per domain (`DOMAIN_BATCH_CHARGE`), per-subscription charge-salt (SHA-256 of `id ∥ last_ts ∥ ledger_seq`) |
+| Reentrancy | `reentrancy.rs` | RAII `ReentrancyGuard` on all fund-moving entrypoints; CEI ordering enforced throughout |
+| Oracle manipulation | `oracle.rs` | Deviation circuit breaker (ring-buffer median, configurable bps), staleness TTL, `max_age_seconds` guard |
+| Treasury / fee-rate change | `admin.rs` | 48 h timelock queue (`PendingTreasuryChange`) before fee changes take effect |
+| Governance takeover | `governance.rs` | Supermajority required; proposals expire; cooldown bypass gated on on-chain quorum |
+| Dispute escrow over-pay | `dispute.rs` | Cumulative `DisputeEscrowLedger` invariant; escrow removed only when fully disbursed |
+| Blocklist bypass | `blocklist.rs`, `charge_core.rs` | Subscriber, merchant, and all split-payees are checked against the blocklist before every charge |
+
+A full threat model document (with trust boundaries, data-flow diagram, and
+attacker assumptions) will be published at `docs/threat_model.md` before
+mainnet launch.
+
+---
+
+## Safe Harbor
+
+Stellabill recognises and supports responsible security research. We commit to:
+
+- **Not pursue civil or criminal action** against researchers who comply with
+  this policy and act in good faith.
+- **Not file abuse complaints** with a researcher's ISP or hosting provider for
+  compliant security testing.
+- Treat compliant research as **authorised access** for purposes of the
+  Computer Fraud and Abuse Act (CFAA), the EU NIS2 Directive, and analogous
+  legislation.
+
+### Conditions for safe harbor
+
+1. Research is conducted against **testnet deployments only**, or against a
+   local devnet using a fork of this repository. Do **not** test against
+   Stellar Mainnet contracts holding real funds.
+2. You do not exfiltrate, modify, or destroy data beyond what is necessary to
+   demonstrate the vulnerability.
+3. You do not perform denial-of-service attacks or degrade service for other
+   users.
+4. You report findings to us before any public disclosure.
+5. You give us a reasonable period to remediate before disclosing publicly.
+
+If you inadvertently access mainnet funds or production state, stop immediately,
+preserve evidence, and notify us so we can assess and mitigate impact.
+
+---
+
+## Reward Tiers (Bug Bounty)
+
+> A formal on-chain bug bounty program is planned for mainnet launch. Until
+> then, we offer **discretionary rewards** based on severity and quality of
+> report, paid in USDC on Stellar.
+
+| Severity | Indicative reward |
+|----------|-----------------|
+| **Critical** — direct loss of subscriber or merchant funds | Up to $20 000 |
+| **High** — privilege escalation, replay enabling fund drain | Up to $5 000 |
+| **Medium** — limited-scope fund risk or DoS | Up to $1 000 |
+| **Low** — hardening, defence-in-depth | Up to $250 |
+
+Rewards are **at our sole discretion** until the formal program launches.
+Duplicate reports receive a reduced reward proportional to delta value added.
+Reporter must not have been the introducer of the vulnerability.
+
+---
+
+## Acknowledgements
+
+We gratefully acknowledge security researchers who have helped improve the
+Stellabill Subscription Vault. Researchers who wish to be credited (by name,
+handle, or anonymously) will be listed here after disclosure.
+
+---
+
+## Version History
+
+| Date | Change |
+|------|--------|
+| 2026-07-30 | Initial policy — issue #856 |


### PR DESCRIPTION
Add SECURITY.md with:
- Supported version matrix
- Scope (in/out of scope)
- Preferred reporting channel (GitHub Private Security Advisory)
- Encrypted email fallback with PGP key slot
- Contact-failure fallback procedure
- Response SLAs by severity (Critical/High/Medium/Low)
- Coordinated disclosure & embargo policy (90-day default)
- Coordinated multi-chain disclosure note
- Threat model summary referencing key modules and controls
- Safe-harbor language (CFAA + EU NIS2 + analogous law)
- Discretionary bug bounty tiers (USDC on Stellar)
- Acknowledgements section
- Version history

Closes #856 