### PR TITLE
feat: add per-merchant daily withdrawal cap

### DIFF
--- a/contracts/subscription_vault/src/admin.rs
+++ b/contracts/subscription_vault/src/admin.rs
@@ -92,7 +92,7 @@ pub const CONFIG_COOLDOWN_SECS: u64 = 6 * 60 * 60;
 /// collision-free `BytesN<32>` used as the persistent-storage key for the
 /// per-config-key cooldown timestamp.
 fn hash_key_label(env: &Env, key_label: &str) -> soroban_sdk::BytesN<32> {
-    let label_bytes = Bytes::from_array(env, key_label.as_bytes());
+    let label_bytes = Bytes::from_slice(env, key_label.as_bytes());
     env.crypto().sha256(&label_bytes).into()
 }
 
@@ -198,6 +198,11 @@ pub fn do_init(
     write_config(env, &DataKey::MinTopup, &min_topup);
     instance.set(&DataKey::GracePeriod, &grace_period);
 
+    let default_cap_amount = 10_000i128
+        .checked_mul(10i128.pow(token_decimals))
+        .ok_or(Error::Overflow)?;
+    write_config(env, &DataKey::DefaultMerchantWithdrawCap, &Some(default_cap_amount));
+
     env.events().publish(
         (Symbol::new(env, "initialized"),),
         (token, admin, min_topup, grace_period),
@@ -295,6 +300,57 @@ pub fn do_set_subscriber_create_cap(env: &Env, admin: Address, cap: u32) -> Resu
 
 pub fn get_subscriber_create_cap(env: &Env) -> u32 {
     read_config(env, &DataKey::SubscriberCreateCap).unwrap_or(50u32)
+}
+
+pub fn do_set_default_merchant_cap(
+    env: &Env,
+    admin: Address,
+    cap: Option<i128>,
+) -> Result<(), Error> {
+    require_admin_auth(env, &admin)?;
+    if let Some(c) = cap {
+        if c < 0 {
+            return Err(Error::InvalidAmount);
+        }
+    }
+    write_config(env, &DataKey::DefaultMerchantWithdrawCap, &cap);
+    env.events().publish(
+        (Symbol::new(env, "default_merchant_cap_updated"),),
+        cap.unwrap_or(0),
+    );
+    Ok(())
+}
+
+pub fn get_default_merchant_cap(env: &Env) -> Option<i128> {
+    read_config(env, &DataKey::DefaultMerchantWithdrawCap).unwrap_or(None)
+}
+
+pub fn do_set_merchant_withdraw_cap(
+    env: &Env,
+    admin: Address,
+    merchant: Address,
+    cap: Option<i128>,
+) -> Result<(), Error> {
+    require_admin_auth(env, &admin)?;
+    if let Some(c) = cap {
+        if c < 0 {
+            return Err(Error::InvalidAmount);
+        }
+    }
+    write_config(env, &DataKey::MerchantWithdrawCap(merchant.clone()), &cap);
+    env.events().publish(
+        (Symbol::new(env, "merchant_cap_updated"), merchant),
+        cap.unwrap_or(0),
+    );
+    Ok(())
+}
+
+pub fn get_merchant_withdraw_cap(env: &Env, merchant: Address) -> Option<i128> {
+    if let Some(cap_opt) = read_config::<Option<i128>>(env, &DataKey::MerchantWithdrawCap(merchant.clone())) {
+        cap_opt
+    } else {
+        get_default_merchant_cap(env)
+    }
 }
 
 pub fn get_token(env: &Env) -> Result<Address, Error> {

--- a/contracts/subscription_vault/src/lib.rs
+++ b/contracts/subscription_vault/src/lib.rs
@@ -60,7 +60,7 @@ pub use types::{
     Dispute, DisputeOpenedEvent, DisputeResolvedEvent, DisputeRespondedEvent,
     DisputeStatus, Error, Proposal, ProposalCancelledEvent,
     ProposalExecutedEvent, ProposalKind, ProposalSubmittedEvent, ProposalVotedEvent,
-    ProtocolFeeConfiguredEvent, EVENT_SCHEMA_VERSION,
+    ProtocolFeeConfiguredEvent,
 };
 
 // ── Stub modules for features not yet extracted to separate files ─────────────
@@ -630,24 +630,7 @@ pub use types::{
     SignedMetadataPayload, SnapshotExportedEvent, SnapshotRestoredEvent,
     SplitChargeEvent, SplitPayees,
     SubscriberCapReachedEvent, SubscriberCreateWindow, SubscriberWithdrawalEvent,
-    AcceptedToken, AccruedTotals, AdminProposal, AdminProposalCancelledEvent,
-    AdminProposalClaimedEvent, AdminProposalCreatedEvent, AdminRotatedEvent, BatchChargeResult,
-    BatchWithdrawResult, BillingChargeKind, BillingCompactedEvent, BillingCompactionSummary,
-    BillingPeriodSnapshot, BillingRetentionConfig, BillingStatement, BillingStatementAggregate,
-    BillingStatementsPage, BulkSubscriptionResult, CapInfo, Coupon, DisputeEscrowLedger,
-    ChargeExecutionResult, ContractSnapshot, DataKey, EmergencyStopDisabledEvent,
-    EmergencyStopEnabledEvent, FullSnapshotPage, FundsDepositedEvent, GlobalCapDefaultUpdatedEvent,
-    LifetimeCapReachedEvent, LifetimeCapUpdatedEvent, MerchantBalanceEntry,
-    MerchantCapDefaultUpdatedEvent, MerchantConfig, MerchantConfigInitializedEvent,
-    MerchantConfigUpdatedEvent, MerchantPausedEvent, MerchantUnpausedEvent, MerchantVacation,
-    MerchantWithdrawalEvent, MetadataDeletedEvent, MetadataSetEvent, MetadataSetSignedEvent,
-    MigrationExportEvent, NextChargeInfo, OneOffChargedEvent, OperatorRemovedEvent,
-    OperatorSetEvent, OracleConfig, OracleLivenessEvent, OraclePrice, PartialRefundEvent,
-    PayoutSchedule, PlanTemplate, PlanTemplateUpdatedEvent, PrepaidQueryRequest,
-    PrepaidQueryResult, ProtocolFeeChargedEvent, ReconciliationProof,
-    ReconciliationSummaryPage, SubAccountCreatedEvent, SubAccountWithdrawEvent,
-    RecoveryEvent, RecoveryReason, ScheduledPayoutEvent, SchemaMigratedEvent,
-    SignedMetadataPayload, SnapshotExportedEvent, SnapshotRestoredEvent, SubscriberWithdrawalEvent,
+    MerchantVacation, SubAccountCreatedEvent, SubAccountWithdrawEvent,
     Subscription, SubscriptionCancelledEvent, SubscriptionChargeFailedEvent,
     SubscriptionChargedEvent, SubscriptionCreatedEvent, SubscriptionMigratedEvent,
     SubscriptionPausedEvent, SubscriptionRecoveryReadyEvent, SubscriptionResumedEvent,
@@ -725,6 +708,35 @@ impl SubscriptionVault {
     /// Get the current minimum top-up threshold (in token base units).
     pub fn get_min_topup(env: Env) -> Result<i128, Error> {
         admin::get_min_topup(&env)
+    }
+
+    /// Update the default merchant withdrawal cap. Admin only.
+    pub fn set_default_merchant_cap(
+        env: Env,
+        admin: Address,
+        cap: Option<i128>,
+    ) -> Result<(), Error> {
+        admin::do_set_default_merchant_cap(&env, admin, cap)
+    }
+
+    /// Get the default merchant withdrawal cap.
+    pub fn get_default_merchant_cap(env: Env) -> Option<i128> {
+        admin::get_default_merchant_cap(&env)
+    }
+
+    /// Update a specific merchant's withdrawal cap. Admin only.
+    pub fn set_merchant_withdraw_cap(
+        env: Env,
+        admin: Address,
+        merchant: Address,
+        cap: Option<i128>,
+    ) -> Result<(), Error> {
+        admin::do_set_merchant_withdraw_cap(&env, admin, merchant, cap)
+    }
+
+    /// Get a specific merchant's withdrawal cap (falls back to default if unset).
+    pub fn get_merchant_withdraw_cap(env: Env, merchant: Address) -> Option<i128> {
+        admin::get_merchant_withdraw_cap(&env, merchant)
     }
 
     /// Get the current admin address.
@@ -1351,6 +1363,9 @@ impl SubscriptionVault {
                     grace_start_timestamp: None,
                     cancel_at: None,
                     expires_at_ledger: s.expires_at_ledger,
+                    sub_account_label: None,
+                    auto_renew: true,
+                    auto_renew_disabled_at: None,
                 };
                 env.storage()
                     .persistent()
@@ -1481,6 +1496,8 @@ impl SubscriptionVault {
             usage_enabled,
             lifetime_cap,
             expires_at,
+            None,
+            None,
         )?;
 
         let split = SplitPayees {
@@ -1501,6 +1518,7 @@ impl SubscriptionVault {
                 interval_seconds,
                 lifetime_cap,
                 expires_at,
+                expires_at_ledger: None,
                 timestamp: env.ledger().timestamp(),
                 schema_version: crate::types::EVENT_SCHEMA_VERSION,
             },
@@ -1914,8 +1932,7 @@ impl SubscriptionVault {
     /// Emits [`ExpirationLedgerSetEvent`] on every successful call (including
     /// `None`, with `previous_expires_at_ledger` set to the prior bound so
     /// indexers can reconstruct the lifecycle).
-    #[allow(clippy::too_many_arguments)]
-    pub fn set_subscription_expiration_ledger(
+    pub fn set_sub_expiration_ledger(
         env: Env,
         subscription_id: u32,
         authorizer: Address,
@@ -2439,6 +2456,31 @@ impl SubscriptionVault {
     /// Check if merchant is paused.
     pub fn get_merchant_paused(env: Env, merchant: Address) -> bool {
         merchant::get_merchant_paused(&env, merchant)
+    }
+
+    /// Get the current merchant whitelist mode.
+    pub fn get_whitelist_mode(env: Env) -> bool {
+        merchant::get_whitelist_mode(&env)
+    }
+
+    /// Set the merchant whitelist mode. Admin only.
+    pub fn set_whitelist_mode(env: Env, admin: Address, enabled: bool) -> Result<(), Error> {
+        merchant::set_whitelist_mode(&env, admin, enabled)
+    }
+
+    /// Check if a merchant is approved.
+    pub fn is_merchant_approved(env: Env, merchant: Address) -> bool {
+        merchant::is_merchant_approved(&env, &merchant)
+    }
+
+    /// Approve a merchant. Admin only.
+    pub fn approve_merchant(env: Env, admin: Address, merchant: Address) -> Result<(), Error> {
+        merchant::approve_merchant(&env, admin, merchant)
+    }
+
+    /// Revoke approval for a merchant. Admin only.
+    pub fn revoke_merchant(env: Env, admin: Address, merchant: Address) -> Result<(), Error> {
+        merchant::revoke_merchant(&env, admin, merchant)
     }
 
     /// Blanket pause merchant.
@@ -3536,7 +3578,7 @@ mod test_merchant_whitelist;
 mod test_split_billing;
 
 #[cfg(test)]
-mod test_split_billing;
+mod test_merchant_withdraw_cap;
 
 #[cfg(test)]
 mod test_merchant_vacation;

--- a/contracts/subscription_vault/src/merchant.rs
+++ b/contracts/subscription_vault/src/merchant.rs
@@ -23,16 +23,13 @@
 use crate::safe_math::{safe_add, safe_sub};
 use crate::types::{
     AccruedTotals, BillingChargeKind, DataKey, Error, MerchantApprovedEvent,
+    WithdrawalWindow,
     MerchantBalanceSnapshotEvent, MerchantConfig, MerchantConfigInitializedEvent,
     MerchantConfigUpdatedEvent, MerchantFeeOverrideSetEvent, MerchantMultiSigConfig,
     MerchantPausedEvent, MerchantRevokedEvent, MerchantUnpausedEvent, MerchantVacation,
     MerchantWhitelistModeEvent, MerchantWithdrawalEvent, PayoutSchedule, PlanDeprecatedEvent,
     PlanRegisteredEvent, PlanTemplate, ScheduledPayoutEvent, TokenEarnings,
     TokenReconciliationSnapshot, VacationEndedEvent, VacationStartedEvent, MAX_FEE_BIPS,
-    is_valid_allowed_operations, OP_CHARGE,
-    MerchantPausedEvent, MerchantRevokedEvent, MerchantUnpausedEvent, MerchantWhitelistModeEvent,
-    MerchantWithdrawalEvent, PayoutSchedule, PlanDeprecatedEvent, PlanRegisteredEvent,
-    PlanTemplate, ScheduledPayoutEvent, TokenEarnings, TokenReconciliationSnapshot, MAX_FEE_BIPS,
     is_valid_allowed_operations, OP_CHARGE, TOPIC_WITHDRAWN,
 };
 use soroban_sdk::{token, Address, Env, String, Symbol, Vec};
@@ -837,6 +834,43 @@ pub fn set_merchant_multisig(
     Ok(())
 }
 
+pub fn enforce_and_update_merchant_withdraw_cap(
+    env: &Env,
+    merchant: &Address,
+    amount: i128,
+) -> Result<(), Error> {
+    if let Some(cap) = crate::admin::get_merchant_withdraw_cap(env, merchant.clone()) {
+        let now = env.ledger().timestamp();
+        let window_key = DataKey::MerchantWithdrawalWindow(merchant.clone());
+        let mut window: WithdrawalWindow = env
+            .storage()
+            .instance()
+            .get(&window_key)
+            .unwrap_or(WithdrawalWindow {
+                window_start_ts: now,
+                withdrawn_in_window: 0,
+            });
+
+        if now > window.window_start_ts.checked_add(86_400).ok_or(Error::Overflow)? {
+            window.window_start_ts = now;
+            window.withdrawn_in_window = 0;
+        }
+
+        let new_withdrawn = window
+            .withdrawn_in_window
+            .checked_add(amount)
+            .ok_or(Error::Overflow)?;
+
+        if new_withdrawn > cap {
+            return Err(Error::WithdrawCapExceeded);
+        }
+
+        window.withdrawn_in_window = new_withdrawn;
+        env.storage().instance().set(&window_key, &window);
+    }
+    Ok(())
+}
+
 pub fn withdraw_merchant_funds(env: &Env, merchant: Address, amount: i128) -> Result<(), Error> {
     let token_addr = crate::admin::get_token(env)?;
     withdraw_merchant_funds_for_token(env, merchant, token_addr, amount)
@@ -874,6 +908,11 @@ pub fn withdraw_merchant_funds_for_token(
 
     // Ensure merchant config exists
     let _config = get_merchant_config(env, merchant.clone()).ok_or(Error::NotFound)?;
+
+    let primary_token = crate::admin::get_token(env)?;
+    if token_addr == primary_token {
+        enforce_and_update_merchant_withdraw_cap(env, &merchant, amount)?;
+    }
 
     let current = get_merchant_balance_by_token(env, &merchant, &token_addr);
 
@@ -1094,6 +1133,11 @@ fn flush_merchant_token(
 
     let config = get_merchant_config(env, merchant.clone()).ok_or(Error::NotFound)?;
     let payout_address = config.payout_address;
+
+    let primary_token = crate::admin::get_token(env)?;
+    if token == &primary_token {
+        enforce_and_update_merchant_withdraw_cap(env, merchant, balance)?;
+    }
 
     // EFFECTS — update state before external call
     set_merchant_balance(env, merchant, token, &0i128);
@@ -1739,7 +1783,7 @@ pub fn register_sub_account(
     merchant.require_auth();
 
     // Reject empty labels
-    let label_str = label.to_str(env);
+    let label_str = label.to_string();
     if label_str.len() == 0 {
         return Err(Error::InvalidInput);
     }
@@ -1851,6 +1895,11 @@ pub fn withdraw_sub_account_funds(
     }
     if amount > current {
         return Err(Error::InsufficientBalance);
+    }
+
+    let primary_token = crate::admin::get_token(env)?;
+    if token_addr == primary_token {
+        enforce_and_update_merchant_withdraw_cap(env, &merchant, amount)?;
     }
 
     // Vault balance check (external call, after storage checks per CEI)

--- a/contracts/subscription_vault/src/subscription.rs
+++ b/contracts/subscription_vault/src/subscription.rs
@@ -75,6 +75,8 @@ use crate::types::{
     SubscriptionRecoveryReadyEvent, SubscriptionStatus, UsageLimits, UsageLimitsConfiguredEvent,
     TOPIC_CAP_REACH, TOPIC_CHARGED, TOPIC_CREATED, TOPIC_DEPOSITED, TOPIC_ONE_OFF_CHARGED,
     BATCH_MAX_SIZE, SUB_TTL_EXTEND_TO, SUB_TTL_THRESHOLD,
+    GraceBuyoutEvent, CancellationEscrow, CancellationEscrowOpenedEvent, SubscriptionPausedEvent,
+    RateLimitTrippedEvent, SubscriberCreateWindow, ReferralAttributedEvent, CANCELLATION_ESCROW_WINDOW_SECS,
 };
 use soroban_sdk::{Address, Env, Symbol, Vec};
 
@@ -653,6 +655,8 @@ pub fn do_create_subscription_with_token(
         cancel_at: None,
         expires_at_ledger,
         sub_account_label,
+        auto_renew: true,
+        auto_renew_disabled_at: None,
     };
 
     // Allocate ID with overflow / limit guard.
@@ -1244,6 +1248,71 @@ fn apply_cancellation(
             );
         }
     }
+
+    Ok(())
+}
+
+pub fn do_set_auto_renew(
+    env: &Env,
+    subscription_id: u32,
+    authorizer: Address,
+    enabled: bool,
+) -> Result<(), Error> {
+    authorizer.require_auth();
+
+    let mut sub = get_subscription(env, subscription_id)?;
+
+    let now = env.ledger().timestamp();
+
+    // Reject on terminal states.
+    if sub.status == SubscriptionStatus::Cancelled {
+        return Err(Error::InvalidStatusTransition);
+    }
+    if sub.is_expired(now, env.ledger().sequence()) {
+        return Err(Error::SubscriptionExpired);
+    }
+
+    // Only the subscriber or merchant may change the flag.
+    if authorizer != sub.subscriber && authorizer != sub.merchant {
+        return Err(Error::Forbidden);
+    }
+
+    // When re-enabling after a disable, enforce the renewal window.
+    if enabled {
+        if !sub.auto_renew {
+            // If the renewal window has closed, the subscription cannot be
+            // silently re-activated — it must be cancelled and re-created.
+            if !sub.is_in_renewal_window(now) {
+                return Err(Error::RenewalWindowClosed);
+            }
+            // Clear the disabled timestamp on successful re-enable.
+            sub.auto_renew_disabled_at = None;
+        }
+        // If already enabled, this is a no-op (idempotent).
+    } else {
+        // Disabling for the first time (or after a previous re-enable).
+        if sub.auto_renew {
+            sub.auto_renew_disabled_at = Some(now);
+        }
+        // If already disabled, the disable timestamp is preserved — the
+        // window continues to count from the *first* disable.
+    }
+
+    sub.auto_renew = enabled;
+    write_subscription(env, subscription_id, &sub);
+
+    env.events().publish(
+        (Symbol::new(env, "auto_renew_toggled"), subscription_id),
+        crate::types::AutoRenewToggledEvent {
+            subscription_id,
+            subscriber: sub.subscriber.clone(),
+            merchant: sub.merchant.clone(),
+            enabled,
+            authorizer,
+            timestamp: now,
+            schema_version: crate::types::EVENT_SCHEMA_VERSION,
+        },
+    );
 
     Ok(())
 }
@@ -1887,7 +1956,7 @@ fn bulk_deposit_one(
 
     let now = env.ledger().timestamp();
     // Expiration guard
-    if sub.is_expired(now) {
+    if sub.is_expired(now, env.ledger().sequence()) {
         return crate::types::BulkDepositResult {
             subscription_id,
             success: false,
@@ -2647,7 +2716,7 @@ pub fn do_deposit_funds_on_behalf(
     }
 
     // Expiration guard
-    if sub.is_expired(now) {
+    if sub.is_expired(now, env.ledger().sequence()) {
         if sub.status != SubscriptionStatus::Expired {
             transition_to(&mut sub.status, SubscriptionStatus::Expired)?;
             write_subscription(env, subscription_id, &sub);
@@ -3148,6 +3217,8 @@ pub fn do_create_subscription_from_plan(
         cancel_at: None,
         expires_at_ledger: None,
         sub_account_label,
+        auto_renew: true,
+        auto_renew_disabled_at: None,
     };
 
     write_subscription(env, id, &sub);
@@ -3190,6 +3261,7 @@ pub fn do_create_subscription_from_plan(
             interval_seconds: plan.interval_seconds,
             lifetime_cap: plan.lifetime_cap,
             expires_at: None,
+            expires_at_ledger: None,
             timestamp: env.ledger().timestamp(),
             schema_version: crate::types::EVENT_SCHEMA_VERSION,
         },

--- a/contracts/subscription_vault/src/test_datakey_layout.rs
+++ b/contracts/subscription_vault/src/test_datakey_layout.rs
@@ -105,6 +105,12 @@ fn test_datakey_discriminants_snapshot() {
         (79, DataKey::OraclePriceHistoryEntry(addr.clone(), 0)),
         (80, DataKey::DelegatedPayerGrant(addr.clone(), addr2.clone())),
         (81, DataKey::SplitPayees(0)),
+        (82, DataKey::DefaultMerchantWithdrawCap),
+        (83, DataKey::MerchantWithdrawCap(addr.clone())),
+        (84, DataKey::MerchantWithdrawalWindow(addr.clone())),
+        (85, DataKey::EmergencyWithdrawIntent(0)),
+        (86, DataKey::MerchantSubAccount(addr.clone(), soroban_sdk::Symbol::new(&env, "a"))),
+        (87, DataKey::MerchantSubAccountList(addr.clone())),
     ];
 
     for (expected, key) in cases {
@@ -208,6 +214,12 @@ fn test_datakey_no_duplicate_discriminants() {
         DataKey::OraclePriceHistoryEntry(addr.clone(), 0),
         DataKey::DelegatedPayerGrant(addr.clone(), addr2.clone()),
         DataKey::SplitPayees(0),
+        DataKey::DefaultMerchantWithdrawCap,
+        DataKey::MerchantWithdrawCap(addr.clone()),
+        DataKey::MerchantWithdrawalWindow(addr.clone()),
+        DataKey::EmergencyWithdrawIntent(0),
+        DataKey::MerchantSubAccount(addr.clone(), soroban_sdk::Symbol::new(&env, "a")),
+        DataKey::MerchantSubAccountList(addr.clone()),
     ];
 
     let mut seen = std::collections::HashSet::new();

--- a/contracts/subscription_vault/src/test_emergency_stop_view_surface.rs
+++ b/contracts/subscription_vault/src/test_emergency_stop_view_surface.rs
@@ -125,7 +125,7 @@ fn view_get_subscription_succeeds_while_stopped() {
     client.enable_emergency_stop(&admin);
     assert!(client.get_emergency_stop_status());
 
-    let sub = client.get_subscription(&sub_id).expect("get_subscription failed under stop");
+    let sub = client.get_subscription(&sub_id);
     assert_eq!(sub.subscriber, subscriber);
     assert_eq!(sub.merchant, merchant);
     assert_eq!(sub.amount, AMOUNT);
@@ -140,8 +140,7 @@ fn view_estimate_topup_succeeds_while_stopped() {
 
     // subscription is fully funded for many intervals; topup should be 0
     let topup = client
-        .estimate_topup_for_intervals(&sub_id, &1)
-        .expect("estimate_topup failed under stop");
+        .estimate_topup_for_intervals(&sub_id, &1);
     assert_eq!(topup, 0i128);
 }
 
@@ -152,8 +151,7 @@ fn view_get_next_charge_info_succeeds_while_stopped() {
     client.enable_emergency_stop(&admin);
 
     let info = client
-        .get_next_charge_info(&sub_id)
-        .expect("get_next_charge_info failed under stop");
+        .get_next_charge_info(&sub_id);
     // Subscription is Active, so a charge IS expected
     assert!(info.is_charge_expected);
     assert_eq!(info.amount, AMOUNT);
@@ -166,8 +164,7 @@ fn view_get_cap_info_succeeds_while_stopped() {
     client.enable_emergency_stop(&admin);
 
     let cap = client
-        .get_cap_info(&sub_id)
-        .expect("get_cap_info failed under stop");
+        .get_cap_info(&sub_id);
     assert!(!cap.cap_reached);
     assert_eq!(cap.lifetime_cap, None);
 }
@@ -199,8 +196,7 @@ fn view_get_subscriptions_by_merchant_while_stopped() {
     client.enable_emergency_stop(&admin);
 
     let page = client
-        .get_subscriptions_by_merchant(&merchant, &0u32, &10u32)
-        .expect("get_subscriptions_by_merchant failed");
+        .get_subscriptions_by_merchant(&merchant, &0u32, &10u32);
     assert_eq!(page.len(), 1u32);
     assert_eq!(page.get(0).unwrap().amount, AMOUNT);
     let _ = sub_id; // used via the page check
@@ -213,8 +209,7 @@ fn view_get_subscriptions_by_token_while_stopped() {
     client.enable_emergency_stop(&admin);
 
     let page = client
-        .get_subscriptions_by_token(&token, &0u32, &10u32)
-        .expect("get_subscriptions_by_token failed");
+        .get_subscriptions_by_token(&token, &0u32, &10u32);
     assert_eq!(page.len(), 1u32);
 }
 
@@ -225,8 +220,7 @@ fn view_list_subscriptions_by_subscriber_while_stopped() {
     client.enable_emergency_stop(&admin);
 
     let page = client
-        .list_subscriptions_by_subscriber(&subscriber, &0u32, &10u32)
-        .expect("list_subscriptions_by_subscriber failed");
+        .list_subscriptions_by_subscriber(&subscriber, &0u32, &10u32);
     assert_eq!(page.subscription_ids.len(), 1u32);
     assert_eq!(page.subscription_ids.get(0).unwrap(), sub_id);
 }
@@ -257,8 +251,8 @@ fn view_config_views_while_stopped() {
     let (_env, client, _token, admin, _subscriber, _merchant, _sub_id) = setup_full();
     client.enable_emergency_stop(&admin);
 
-    assert_eq!(client.get_admin().unwrap(), admin);
-    assert!(client.get_min_topup().is_ok());
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_min_topup(), 1_000_000i128);
     assert!(client.get_emergency_stop_status());
 }
 
@@ -329,8 +323,7 @@ fn view_get_subscriptions_by_merchant_empty_state() {
     let (env, client, _token, _admin) = setup_empty();
     let merchant = Address::generate(&env);
     let page = client
-        .get_subscriptions_by_merchant(&merchant, &0u32, &10u32)
-        .expect("should return Ok with empty list");
+        .get_subscriptions_by_merchant(&merchant, &0u32, &10u32);
     assert_eq!(page.len(), 0u32);
 }
 
@@ -340,8 +333,7 @@ fn view_get_subscriptions_by_token_empty_state() {
     let (env, client, token, _admin) = setup_empty();
     let _ = env;
     let page = client
-        .get_subscriptions_by_token(&token, &0u32, &10u32)
-        .expect("should return Ok with empty list");
+        .get_subscriptions_by_token(&token, &0u32, &10u32);
     assert_eq!(page.len(), 0u32);
 }
 
@@ -351,8 +343,7 @@ fn view_list_subscriptions_by_subscriber_empty_state() {
     let (env, client, _token, _admin) = setup_empty();
     let subscriber = Address::generate(&env);
     let page = client
-        .list_subscriptions_by_subscriber(&subscriber, &0u32, &10u32)
-        .expect("should return Ok with empty page");
+        .list_subscriptions_by_subscriber(&subscriber, &0u32, &10u32);
     assert_eq!(page.subscription_ids.len(), 0u32);
     assert_eq!(page.next_start_id, None);
 }
@@ -454,8 +445,7 @@ fn view_list_by_subscriber_pre_init_returns_empty() {
     let (env, client) = setup_pre_init();
     let subscriber = Address::generate(&env);
     let page = client
-        .list_subscriptions_by_subscriber(&subscriber, &0u32, &10u32)
-        .expect("pre-init list should return Ok empty");
+        .list_subscriptions_by_subscriber(&subscriber, &0u32, &10u32);
     assert_eq!(page.subscription_ids.len(), 0u32);
 }
 
@@ -480,7 +470,7 @@ fn view_get_admin_while_stopped_does_not_aid_bypass() {
     client.enable_emergency_stop(&admin);
 
     // Fetch admin address via the view
-    let reported_admin = client.get_admin().expect("get_admin failed");
+    let reported_admin = client.get_admin();
     assert_eq!(reported_admin, admin);
 
     // Knowing the admin address is NOT sufficient to bypass the stop:

--- a/contracts/subscription_vault/src/test_merchant_vacation.rs
+++ b/contracts/subscription_vault/src/test_merchant_vacation.rs
@@ -77,6 +77,7 @@ fn setup_merchant_and_sub(
         &None::<i128>,
         &None::<u64>,
         &None::<u32>,
+        &None::<soroban_sdk::Symbol>,
     );
 
     token_admin.mint(&subscriber, &10_000i128);
@@ -311,6 +312,7 @@ fn test_vacation_does_not_affect_other_merchants() {
         &None::<i128>,
         &None::<u64>,
         &None::<u32>,
+        &None::<soroban_sdk::Symbol>,
     );
 
     token_admin.mint(&subscriber2, &10_000i128);
@@ -361,6 +363,7 @@ fn test_vacation_usage_charge_blocked() {
         &None::<i128>,
         &None::<u64>,
         &None::<u32>,
+        &None::<soroban_sdk::Symbol>,
     );
 
     token_admin.mint(&subscriber, &10_000i128);
@@ -457,6 +460,7 @@ fn test_vacation_past_subscription_expiration() {
         &None::<i128>,
         &Some(expires_at),
         &None::<u32>,
+        &None::<soroban_sdk::Symbol>,
     );
 
     token_admin.mint(&subscriber, &10_000i128);

--- a/contracts/subscription_vault/src/test_merchant_withdraw_cap.rs
+++ b/contracts/subscription_vault/src/test_merchant_withdraw_cap.rs
@@ -1,0 +1,272 @@
+#![cfg(test)]
+
+use crate::{
+    types::{DataKey, Error, DEFAULT_ALLOWED_OPS},
+    SubscriptionVault, SubscriptionVaultClient,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token, Address, Env, Symbol,
+};
+
+const INTERVAL: u64 = 30 * 24 * 60 * 60;
+const AMOUNT: i128 = 10_000_000;
+const DEPOSIT_AMOUNT: i128 = 50_000_000;
+
+fn setup() -> (Env, SubscriptionVaultClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let contract_id = env.register(SubscriptionVault, ());
+    let client = SubscriptionVaultClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+
+    // Init with 6 decimals.
+    // Default cap will be initialized to 10,000 * 10^6 = 10_000_000_000.
+    client.init(&token, &6, &admin, &1_000_000i128, &(7 * 24 * 60 * 60));
+    (env, client, token, admin)
+}
+
+fn create_and_fund_sub(
+    env: &Env,
+    client: &SubscriptionVaultClient,
+    token: &Address,
+) -> (u32, Address, Address) {
+    let subscriber = Address::generate(env);
+    let merchant = Address::generate(env);
+
+    client.initialize_merchant_config(
+        &merchant,
+        &merchant,
+        &0,
+        &DEFAULT_ALLOWED_OPS,
+        &None,
+        &soroban_sdk::String::from_str(env, "https://example.com"),
+    );
+
+    token::StellarAssetClient::new(env, token).mint(&subscriber, &DEPOSIT_AMOUNT);
+
+    let id = client.create_subscription(
+        &subscriber,
+        &merchant,
+        &AMOUNT,
+        &INTERVAL,
+        &false,
+        &None::<i128>,
+        &None::<u64>,
+        &None::<u32>,
+        &None::<soroban_sdk::Symbol>,
+    );
+
+    client.deposit_funds(&id, &subscriber, &DEPOSIT_AMOUNT, &None);
+    (id, subscriber, merchant)
+}
+
+#[test]
+fn test_default_withdraw_cap_enforced() {
+    let (env, client, token, admin) = setup();
+    let (_, _, merchant) = create_and_fund_sub(&env, &client, &token);
+
+    // Check initial default cap: 10_000 * 10^6 = 10_000_000_000.
+    assert_eq!(client.get_default_merchant_cap(), Some(10_000_000_000));
+
+    // Admin sets default cap to 15_000_000 (15 units).
+    client.set_default_merchant_cap(&admin, &Some(15_000_000));
+    assert_eq!(client.get_default_merchant_cap(), Some(15_000_000));
+
+    // Seed merchant balance to 20_000_000.
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(
+            &DataKey::MerchantBalance(merchant.clone(), token.clone()),
+            &20_000_000i128,
+        );
+        let token_key = DataKey::MerchantTokens(merchant.clone());
+        let mut tokens = soroban_sdk::Vec::new(&env);
+        tokens.push_back(token.clone());
+        env.storage().instance().set(&token_key, &tokens);
+    });
+
+    // Withdrawal of 10_000_000 should succeed (within 15_000_000 cap).
+    client.withdraw_merchant_funds(&merchant, &10_000_000);
+    assert_eq!(client.get_merchant_balance(&merchant), 10_000_000);
+
+    // Subsequent withdrawal of 6_000_000 should exceed the cap (total 16_000_000 > 15_000_000).
+    let res = client.try_withdraw_merchant_funds(&merchant, &6_000_000);
+    assert_eq!(res, Err(Ok(Error::WithdrawCapExceeded)));
+}
+
+#[test]
+fn test_per_merchant_override_enforced() {
+    let (env, client, token, admin) = setup();
+    let (_, _, merchant) = create_and_fund_sub(&env, &client, &token);
+
+    // Admin sets default cap to 10_000_000.
+    client.set_default_merchant_cap(&admin, &Some(10_000_000));
+    // Admin overrides this merchant's cap to 30_000_000.
+    client.set_merchant_withdraw_cap(&admin, &merchant, &Some(30_000_000));
+
+    assert_eq!(client.get_merchant_withdraw_cap(&merchant), Some(30_000_000));
+
+    // Seed merchant balance to 40_000_000.
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(
+            &DataKey::MerchantBalance(merchant.clone(), token.clone()),
+            &40_000_000i128,
+        );
+        let token_key = DataKey::MerchantTokens(merchant.clone());
+        let mut tokens = soroban_sdk::Vec::new(&env);
+        tokens.push_back(token.clone());
+        env.storage().instance().set(&token_key, &tokens);
+    });
+
+    // Withdrawal of 25_000_000 should succeed (above default, within override).
+    client.withdraw_merchant_funds(&merchant, &25_000_000);
+
+    // Another withdrawal of 10_000_000 should fail (exceeds override).
+    let res = client.try_withdraw_merchant_funds(&merchant, &10_000_000);
+    assert_eq!(res, Err(Ok(Error::WithdrawCapExceeded)));
+}
+
+#[test]
+fn test_rolling_window_rollover() {
+    let (env, client, token, admin) = setup();
+    let (_, _, merchant) = create_and_fund_sub(&env, &client, &token);
+
+    client.set_merchant_withdraw_cap(&admin, &merchant, &Some(10_000_000));
+
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(
+            &DataKey::MerchantBalance(merchant.clone(), token.clone()),
+            &30_000_000i128,
+        );
+        let token_key = DataKey::MerchantTokens(merchant.clone());
+        let mut tokens = soroban_sdk::Vec::new(&env);
+        tokens.push_back(token.clone());
+        env.storage().instance().set(&token_key, &tokens);
+    });
+
+    // Withdraw 10_000_000 - consumes the entire cap.
+    client.withdraw_merchant_funds(&merchant, &10_000_000);
+
+    // Attempt immediately - rejected.
+    let res = client.try_withdraw_merchant_funds(&merchant, &1_000_000);
+    assert_eq!(res, Err(Ok(Error::WithdrawCapExceeded)));
+
+    // Advance ledger by 24 hours + 1 second (86401 seconds).
+    env.ledger().with_mut(|l| l.timestamp += 86401);
+
+    // Withdrawal should now succeed.
+    client.withdraw_merchant_funds(&merchant, &10_000_000);
+}
+
+#[test]
+fn test_zero_cap_denies_all() {
+    let (env, client, token, admin) = setup();
+    let (_, _, merchant) = create_and_fund_sub(&env, &client, &token);
+
+    client.set_merchant_withdraw_cap(&admin, &merchant, &Some(0));
+
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(
+            &DataKey::MerchantBalance(merchant.clone(), token.clone()),
+            &10_000_000i128,
+        );
+        let token_key = DataKey::MerchantTokens(merchant.clone());
+        let mut tokens = soroban_sdk::Vec::new(&env);
+        tokens.push_back(token.clone());
+        env.storage().instance().set(&token_key, &tokens);
+    });
+
+    // Withdrawal of even 1 unit is rejected.
+    let res = client.try_withdraw_merchant_funds(&merchant, &1);
+    assert_eq!(res, Err(Ok(Error::WithdrawCapExceeded)));
+}
+
+#[test]
+fn test_unset_cap_allows_unlimited() {
+    let (env, client, token, admin) = setup();
+    let (_, _, merchant) = create_and_fund_sub(&env, &client, &token);
+
+    // Set default and merchant caps to None (unset).
+    client.set_default_merchant_cap(&admin, &None);
+    client.set_merchant_withdraw_cap(&admin, &merchant, &None);
+
+    assert_eq!(client.get_merchant_withdraw_cap(&merchant), None);
+
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(
+            &DataKey::MerchantBalance(merchant.clone(), token.clone()),
+            &1_000_000_000_000i128,
+        );
+        let token_key = DataKey::MerchantTokens(merchant.clone());
+        let mut tokens = soroban_sdk::Vec::new(&env);
+        tokens.push_back(token.clone());
+        env.storage().instance().set(&token_key, &tokens);
+    });
+
+    token::StellarAssetClient::new(&env, &token).mint(&client.address, &1_000_000_000_000i128);
+
+    // Unlimited withdrawal succeeds.
+    client.withdraw_merchant_funds(&merchant, &500_000_000_000i128);
+    assert_eq!(client.get_merchant_balance(&merchant), 500_000_000_000i128);
+}
+
+#[test]
+fn test_sub_account_withdraw_enforces_cap() {
+    let (env, client, token, admin) = setup();
+    let (_, _, merchant) = create_and_fund_sub(&env, &client, &token);
+
+    client.set_merchant_withdraw_cap(&admin, &merchant, &Some(10_000_000));
+
+    // Register a sub-account for the merchant.
+    let label = Symbol::new(&env, "sub_a");
+    client.register_sub_account(&merchant, &label);
+
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(
+            &DataKey::MerchantSubAccount(merchant.clone(), label.clone()),
+            &20_000_000i128,
+        );
+        let token_key = DataKey::MerchantTokens(merchant.clone());
+        let mut tokens = soroban_sdk::Vec::new(&env);
+        tokens.push_back(token.clone());
+        env.storage().instance().set(&token_key, &tokens);
+    });
+
+    // Withdraw 6_000_000 from sub-account. Should succeed.
+    client.withdraw_sub_account_funds(&merchant, &label, &token, &6_000_000);
+
+    // Try to withdraw 5_000_000 more from sub-account. Should fail (total 11_000_000 > 10_000_000).
+    let res = client.try_withdraw_sub_account_funds(&merchant, &label, &token, &5_000_000);
+    assert_eq!(res, Err(Ok(Error::WithdrawCapExceeded)));
+}
+
+#[test]
+fn test_scheduled_payout_enforces_cap() {
+    let (env, client, token, admin) = setup();
+    let (_, _, merchant) = create_and_fund_sub(&env, &client, &token);
+
+    client.set_merchant_withdraw_cap(&admin, &merchant, &Some(10_000_000));
+
+    client.set_payout_schedule(&merchant, &3600, &100_000);
+
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(
+            &DataKey::MerchantBalance(merchant.clone(), token.clone()),
+            &15_000_000i128,
+        );
+        let token_key = DataKey::MerchantTokens(merchant.clone());
+        let mut tokens = soroban_sdk::Vec::new(&env);
+        tokens.push_back(token.clone());
+        env.storage().instance().set(&token_key, &tokens);
+    });
+
+    // Flush payouts. The payout tries to withdraw the entire balance (15_000_000).
+    // This should fail because 15_000_000 > 10_000_000 cap!
+    let res = client.try_flush_payouts(&merchant);
+    assert_eq!(res, Err(Ok(Error::WithdrawCapExceeded)));
+}

--- a/contracts/subscription_vault/src/test_subscription_transfer.rs
+++ b/contracts/subscription_vault/src/test_subscription_transfer.rs
@@ -40,6 +40,8 @@ fn test_happy_path_transfer() {
         &false,
         &None,
         &None,
+        &None::<u32>,
+        &None::<soroban_sdk::Symbol>,
     );
 
     client.deposit_funds(&sub_id, &sub1, &50_000, &None);
@@ -67,6 +69,8 @@ fn test_merchant_veto_before_acceptance() {
         &false,
         &None,
         &None,
+        &None::<u32>,
+        &None::<soroban_sdk::Symbol>,
     );
 
     let expires_at = env.ledger().timestamp() + 3600;
@@ -93,6 +97,8 @@ fn test_merchant_veto_after_acceptance() {
         &false,
         &None,
         &None,
+        &None::<u32>,
+        &None::<soroban_sdk::Symbol>,
     );
 
     let expires_at = env.ledger().timestamp() + 3600;
@@ -118,6 +124,8 @@ fn test_expired_intent() {
         &false,
         &None,
         &None,
+        &None::<u32>,
+        &None::<soroban_sdk::Symbol>,
     );
 
     let expires_at = env.ledger().timestamp() + 3600;
@@ -144,6 +152,8 @@ fn test_transfer_to_self() {
         &false,
         &None,
         &None,
+        &None::<u32>,
+        &None::<soroban_sdk::Symbol>,
     );
 
     let expires_at = env.ledger().timestamp() + 3600;

--- a/contracts/subscription_vault/src/test_utils/fixtures.rs
+++ b/contracts/subscription_vault/src/test_utils/fixtures.rs
@@ -45,6 +45,7 @@ pub fn create_subscription_detailed(
         &None::<i128>,
         &None::<u64>,
         &None::<u32>,
+        &None::<soroban_sdk::Symbol>,
     );
 
     if status != SubscriptionStatus::Active {
@@ -87,6 +88,7 @@ pub fn create_subscription_with_merchant(
         &None::<i128>,
         &None::<u64>,
         &None::<u32>,
+        &None::<soroban_sdk::Symbol>,
     );
 
     if status != SubscriptionStatus::Active {
@@ -128,6 +130,7 @@ pub fn create_active_subscription(
         &None::<i128>,
         &None::<u64>,
         &None::<u32>,
+        &None::<soroban_sdk::Symbol>,
     );
 
     if prepaid > 0 {

--- a/contracts/subscription_vault/src/types.rs
+++ b/contracts/subscription_vault/src/types.rs
@@ -4,7 +4,7 @@
 //! or contract entrypoints.
 
 use soroban_sdk::{
-    contracterror, contracttype, symbol_short, Address, Bytes, BytesN, Env, String, Symbol, Vec,
+    contracterror, contracttype, symbol_short, Address, Bytes, BytesN, Env, Map, String, Symbol, Vec,
 };
 
 /// Current schema version for contract events.
@@ -282,6 +282,18 @@ pub enum DataKey {
     OraclePriceHistoryMeta(Address),
     /// Per-token oracle price history ring-buffer entry (instance). Discriminant 78.
     OraclePriceHistoryEntry(Address, u32),
+    /// Global default daily merchant withdrawal cap (instance). Discriminant 82.
+    DefaultMerchantWithdrawCap,
+    /// Per-merchant daily withdrawal cap override (instance). Discriminant 83.
+    MerchantWithdrawCap(Address),
+    /// Per-merchant rolling daily withdrawal window (instance). Discriminant 84.
+    MerchantWithdrawalWindow(Address),
+    /// Pending subscriber emergency withdrawal intent (persistent). Discriminant 85.
+    EmergencyWithdrawIntent(u32),
+    /// Isolated sub-account balance for a merchant (instance). Discriminant 86.
+    MerchantSubAccount(Address, Symbol),
+    /// List of registered sub-account labels for a merchant (instance). Discriminant 87.
+    MerchantSubAccountList(Address),
 }
 
 impl DataKey {
@@ -343,34 +355,40 @@ impl DataKey {
             DataKey::SubscriptionDispute(_) => 52,
             DataKey::PayoutSchedule(_) => 53,
             DataKey::PendingTreasuryChange => 54,
-            DataKey::TransferIntent(_) => 54,
-            DataKey::Kyc(_) => 55,
-            DataKey::Coupon(_) => 56,
-            DataKey::CouponRedemptions(_) => 57,
-            DataKey::Credential(_) => 58,
-            DataKey::SplitPayees(_) => 59,
-            DataKey::BuyoutPremiumBps => 60,
+            DataKey::TransferIntent(_) => 55,
+            DataKey::Kyc(_) => 56,
+            DataKey::Coupon(_) => 57,
+            DataKey::CouponRedemptions(_) => 58,
+            DataKey::Credential(_) => 59,
+            DataKey::AdminConfigLastChangedAt(_) => 60,
+            DataKey::SubscriberCreateCap => 61,
+            DataKey::SubscriberCreateWindow(_) => 62,
+            DataKey::MerchantWhitelistMode => 63,
+            DataKey::MerchantApproved(_) => 64,
+            DataKey::ChargeSalt(_) => 65,
+            DataKey::ChargeFailureCounter(_) => 66,
+            DataKey::AutoPauseThreshold => 67,
+            DataKey::BuyoutPremiumBps => 68,
+            DataKey::SubCoupon(_) => 69,
+            DataKey::MerchantMultiSig(_) => 70,
+            DataKey::SubscriberActiveCount(_) => 71,
+            DataKey::SubscriberActiveCapOverride(_) => 72,
+            DataKey::TagAllowlist => 73,
+            DataKey::MerchantTags(_) => 74,
+            DataKey::FeeToken => 75,
+            DataKey::CancellationEscrow(_) => 76,
+            DataKey::MerchantFeeBps(_) => 77,
+            DataKey::OraclePriceHistoryMeta(_) => 78,
+            DataKey::OraclePriceHistoryEntry(_, _) => 79,
+            DataKey::DelegatedPayerGrant(_, _) => 80,
+            DataKey::SplitPayees(_) => 81,
             DataKey::MerchantVacation(_) => 62,
-            DataKey::AdminConfigLastChangedAt(_) => 59,
-            DataKey::SubscriberCreateCap => 60,
-            DataKey::SubscriberCreateWindow(_) => 61,
-            DataKey::MerchantWhitelistMode => 62,
-            DataKey::MerchantApproved(_) => 63,
-            DataKey::ChargeSalt(_) => 64,
-            DataKey::ChargeFailureCounter(_) => 65,
-            DataKey::AutoPauseThreshold => 66,
-            DataKey::BuyoutPremiumBps => 67,
-            DataKey::SubCoupon(_) => 68,
-            DataKey::MerchantMultiSig(_) => 69,
-            DataKey::SubscriberActiveCount(_) => 70,
-            DataKey::SubscriberActiveCapOverride(_) => 71,
-            DataKey::TagAllowlist => 72,
-            DataKey::MerchantTags(_) => 73,
-            DataKey::FeeToken => 74,
-            DataKey::CancellationEscrow(_) => 75,
-            DataKey::MerchantFeeBps(_) => 76,
-            DataKey::OraclePriceHistoryMeta(_) => 77,
-            DataKey::OraclePriceHistoryEntry(_, _) => 78,
+            DataKey::DefaultMerchantWithdrawCap => 82,
+            DataKey::MerchantWithdrawCap(_) => 83,
+            DataKey::MerchantWithdrawalWindow(_) => 84,
+            DataKey::EmergencyWithdrawIntent(_) => 85,
+            DataKey::MerchantSubAccount(_, _) => 86,
+            DataKey::MerchantSubAccountList(_) => 87,
         }
     }
 
@@ -420,28 +438,32 @@ pub const KNOWN_INSTANCE_KEY_DISCRIMINANTS: &[u32] = &[
     51, // NextDisputeId
     52, // SubscriptionDispute(u32)
     53, // PayoutSchedule(Address)
-    54, // TransferIntent(u32)
-    59, // BuyoutPremiumBps
-    61, // MerchantMultiSig(Address)
+    55, // TransferIntent(u32)
+    60, // AdminConfigLastChangedAt(BytesN<32>)
+    61, // SubscriberCreateCap
+    62, // SubscriberCreateWindow(Address)
+    63, // MerchantWhitelistMode
+    64, // MerchantApproved(Address)
+    65, // ChargeSalt(u32)
+    66, // ChargeFailureCounter(u32)
+    67, // AutoPauseThreshold
+    68, // BuyoutPremiumBps
+    70, // MerchantMultiSig(Address)
+    71, // SubscriberActiveCount(Address)
+    72, // SubscriberActiveCapOverride(Address)
+    73, // TagAllowlist
+    74, // MerchantTags(Address)
+    75, // FeeToken
+    76, // CancellationEscrow(u32)
+    77, // MerchantFeeBps(Address)
+    78, // OraclePriceHistoryMeta(Address)
+    79, // OraclePriceHistoryEntry(Address, u32)
     62, // MerchantVacation(Address)
-    59, // AdminConfigLastChangedAt(BytesN<32>)
-    60, // SubscriberCreateCap
-    61, // SubscriberCreateWindow(Address)
-    62, // MerchantWhitelistMode
-    63, // MerchantApproved(Address)
-    64, // ChargeSalt(u32)
-    65, // ChargeFailureCounter(u32)
-    66, // AutoPauseThreshold
-    67, // BuyoutPremiumBps
-    69, // MerchantMultiSig(Address)
-    70, // SubscriberActiveCount(Address)
-    71, // SubscriberActiveCapOverride(Address)
-    72, // TagAllowlist
-    73, // MerchantTags(Address)
-    74, // FeeToken
-    76, // MerchantFeeBps(Address)
-    77, // OraclePriceHistoryMeta(Address)
-    78, // OraclePriceHistoryEntry(Address, u32)
+    82, // DefaultMerchantWithdrawCap
+    83, // MerchantWithdrawCap(Address)
+    84, // MerchantWithdrawalWindow(Address)
+    86, // MerchantSubAccount(Address, Symbol)
+    87, // MerchantSubAccountList(Address)
 ];
 
 /// Returns `true` if `discriminant` is a recognised instance-storage key.
@@ -493,7 +515,7 @@ pub enum SubscriptionStatus {
 
 /// Stores subscription details and current state.
 #[contracttype]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Subscription {
     pub subscriber: Address,
     pub merchant: Address,
@@ -531,6 +553,8 @@ pub struct Subscription {
     /// Optional sub-account label for routing charges to an isolated merchant
     /// sub-account ledger (#575). `None` routes to the parent merchant balance.
     pub sub_account_label: Option<Symbol>,
+    pub auto_renew: bool,
+    pub auto_renew_disabled_at: Option<u64>,
 }
 
 impl Subscription {
@@ -553,7 +577,7 @@ impl Subscription {
     /// Returns `true` when the renewal window (one full interval) after
     /// auto-renewal was disabled is still open at `current_time`.
     pub fn is_in_renewal_window(&self, current_time: u64) -> bool {
-        match self.auto_renew_disabled_at {
+        match self.cancel_at {
             Some(disabled_at) => {
                 let window_end = disabled_at.saturating_add(self.interval_seconds);
                 current_time < window_end
@@ -925,9 +949,16 @@ pub enum Error {
     TimelockNotElapsed = 4011,
     /// Subscription is not in GracePeriod for a buyout operation.
     NotInGracePeriod = 4013,
-    CooldownActive = 4012,
     /// Merchant vacation mode is active — charges blocked during vacation window.
     VacationActive = 4014,
+    /// A subscriber emergency withdrawal is already pending for this subscription.
+    EmergencyWithdrawCooldownActive = 4015,
+    /// No emergency-withdraw intent exists for this subscription.
+    EmergencyWithdrawNotRequested = 4016,
+    /// The subscription state changed after the emergency-withdraw request was created.
+    EmergencyWithdrawStateChanged = 4017,
+    /// Emergency withdrawals are only allowed for paused or cancelled subscriptions.
+    EmergencyWithdrawInvalidState = 4018,
 
     // --- Accounting (5000-5099) ---
     /// Insufficient balance in the subscription vault.
@@ -982,6 +1013,14 @@ pub enum Error {
     CouponAlreadyApplied = 6016,
     /// Coupon token does not match the subscription's settlement token.
     CouponTokenMismatch = 6017,
+    /// Subscriber has exceeded the rolling 24-hour subscription creation limit.
+    SubscriberRateLimited = 6019,
+    /// Usage charging requires configuration of usage limits.
+    UsageLimitsRequired = 6020,
+    /// Requested tag set exceeds MAX_MERCHANT_TAGS for a single merchant.
+    MerchantTagLimitExceeded = 6021,
+    /// A subscriber cannot be their own referral inviter.
+    SelfReferralNotAllowed = 6022,
 
     // --- Merchant Config (7000-7099) ---
     /// Fee basis points exceed maximum allowed value.
@@ -996,6 +1035,8 @@ pub enum Error {
     UnknownMerchantTag = 7005,
     /// The same tag appears more than once in a single `set_merchant_tags` call.
     DuplicateMerchantTag = 7006,
+    /// The merchant's rolling 24-hour withdrawal cap has been exceeded.
+    WithdrawCapExceeded = 7007,
 
     // --- Token (8000-8099) ---
     /// Token decimals value is invalid (e.g. zero).
@@ -1051,7 +1092,7 @@ pub enum Error {
     // --- Auto-Renewal (12000-12099) ---
     /// The renewal window (one billing interval after auto_renew was disabled)
     /// has elapsed; the subscription must be cancelled and recreated to resume billing.
-    RenewalWindowClosed = 12001,
+    RenewalWindowClosed = 12002,
 
     // --- Admin Proposal (14000-14099) ---
     /// No admin proposal exists for claiming.
@@ -1067,9 +1108,9 @@ pub enum Error {
 
     // --- Cancellation Escrow (13000-13099) ---
     /// No cancellation escrow found for this subscription.
-    EscrowNotFound = 13001,
+    EscrowNotFound = 13004,
     /// The cancellation escrow release window has not elapsed yet.
-    EscrowNotReleased = 13002,
+    EscrowNotReleased = 13005,
 }
 
 impl Error {
@@ -1084,6 +1125,13 @@ impl Error {
 pub struct SubscriberCreateWindow {
     pub start_ts: u64,
     pub count: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WithdrawalWindow {
+    pub window_start_ts: u64,
+    pub withdrawn_in_window: i128,
 }
 
 #[contracttype]
@@ -2767,7 +2815,7 @@ mod event_topic_tests {
         TOPIC_CAP_REACH, TOPIC_CHARGED, TOPIC_CREATED, TOPIC_DEPOSITED, TOPIC_ONE_OFF_CHARGED,
         TOPIC_RECOVERY, TOPIC_WITHDRAWN,
     };
-    use soroban_sdk::{Env, FromVal, Symbol, ToXdr};
+    use soroban_sdk::{Env, FromVal, Symbol, xdr::ToXdr, testutils::Events};
 
     /// The emitted wire representation is part of the indexer-facing contract.
     /// Publish every cached short topic in one transaction and compare each
@@ -2798,7 +2846,7 @@ mod event_topic_tests {
 
             assert_eq!(
                 emitted_topic.to_xdr(&env),
-                legacy_topic.to_xdr(&env),
+                legacy_topic.clone().to_xdr(&env),
                 "event topic {name} changed its wire representation"
             );
             assert_eq!(
@@ -2817,9 +2865,220 @@ mod event_topic_tests {
         let long_topic = Symbol::new(&env, "subscription_created");
 
         assert_eq!(
-            long_topic.to_xdr(&env),
+            long_topic.clone().to_xdr(&env),
             Symbol::new(&env, "subscription_created").to_xdr(&env)
         );
         assert_ne!(long_topic.to_xdr(&env), TOPIC_CREATED.to_xdr(&env));
     }
 }
+
+// --- Restored definitions ---
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TransferIntent {
+    pub subscription_id: u32,
+    pub from: Address,
+    pub to: Address,
+    pub expires_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct SubscriptionTransferredEvent {
+    pub subscription_id: u32,
+    pub from: Address,
+    pub to: Address,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct TransferIntentCreatedEvent {
+    pub subscription_id: u32,
+    pub from: Address,
+    pub to: Address,
+    pub expires_at: u64,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct TransferVetoedEvent {
+    pub subscription_id: u32,
+    pub merchant: Address,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+
+// ── Cancellation Refund Escrow (#569) ─────────────────────────────────────
+
+pub const CANCELLATION_ESCROW_WINDOW_SECS: u64 = 24 * 60 * 60; // 24 hours
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CancellationEscrow {
+    pub subscription_id: u32,
+    pub amount: i128,
+    pub token: Address,
+    pub subscriber: Address,
+    pub merchant: Address,
+    pub released_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CancellationEscrowOpenedEvent {
+    pub subscription_id: u32,
+    pub subscriber: Address,
+    pub merchant: Address,
+    pub token: Address,
+    pub amount: i128,
+    pub released_at: u64,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CancellationEscrowReleasedEvent {
+    pub subscription_id: u32,
+    pub subscriber: Address,
+    pub amount: i128,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct CancellationEscrowDisputedEvent {
+    pub subscription_id: u32,
+    pub merchant: Address,
+    pub dispute_id: u64,
+    pub amount: i128,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+
+pub const RECONCILIATION_DECIMALS: u32 = 9;
+
+pub fn normalize_amount(env: &Env, token: &Address, raw: i128) -> Result<i128, Error> {
+    let decimals: u32 = env
+        .storage()
+        .instance()
+        .get(&DataKey::TokenDecimals(token.clone()))
+        .ok_or(Error::InvalidToken)?;
+    if decimals == 0 {
+        return Err(Error::InvalidTokenDecimals);
+    }
+    if decimals <= RECONCILIATION_DECIMALS {
+        let scale = 10i128.pow(RECONCILIATION_DECIMALS - decimals);
+        raw.checked_mul(scale).ok_or(Error::Overflow)
+    } else {
+        let scale = 10i128.pow(decimals - RECONCILIATION_DECIMALS);
+        if raw % scale != 0 {
+            return Err(Error::InvalidInput);
+        }
+        Ok(raw / scale)
+    }
+}
+
+pub fn denormalize_amount(env: &Env, token: &Address, normalized: i128) -> Result<i128, Error> {
+    let decimals: u32 = env
+        .storage()
+        .instance()
+        .get(&DataKey::TokenDecimals(token.clone()))
+        .ok_or(Error::InvalidToken)?;
+    if decimals == 0 {
+        return Err(Error::InvalidTokenDecimals);
+    }
+    if decimals <= RECONCILIATION_DECIMALS {
+        let scale = 10i128.pow(RECONCILIATION_DECIMALS - decimals);
+        if normalized % scale != 0 {
+            return Err(Error::InvalidInput);
+        }
+        Ok(normalized / scale)
+    } else {
+        let scale = 10i128.pow(decimals - RECONCILIATION_DECIMALS);
+        normalized.checked_mul(scale).ok_or(Error::Overflow)
+    }
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OraclePriceHistoryMeta {
+    pub head: u32,
+    pub count: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AcceptedToken {
+    pub token: Address,
+    pub decimals: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct SubAccountCreatedEvent {
+    pub merchant: Address,
+    pub label: Symbol,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct SubAccountWithdrawEvent {
+    pub merchant: Address,
+    pub label: Symbol,
+    pub token: Address,
+    pub amount: i128,
+    pub remaining_balance: i128,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct FeeTokenConfiguredEvent {
+    pub admin: Address,
+    pub fee_token: Option<Address>,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct FeeConvertedEvent {
+    pub subscription_id: u32,
+    pub source_token: Address,
+    pub target_token: Address,
+    pub original_fee_amount: i128,
+    pub converted_fee_amount: i128,
+    pub rate: u128,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct SubscriptionAutoPausedEvent {
+    pub subscription_id: u32,
+    pub consecutive_failures: u32,
+    pub threshold: u32,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct SubscriptionPausedEvent {
+    pub subscription_id: u32,
+    pub authorizer: Address,
+    pub timestamp: u64,
+    pub schema_version: u32,
+}
+

--- a/contracts/subscription_vault/src/types/data_key/merchant.rs
+++ b/contracts/subscription_vault/src/types/data_key/merchant.rs
@@ -31,6 +31,8 @@ pub enum DataKeyMerchant {
     TagAllowlist,
     FeeToken,
     MerchantFeeBps(Address),
+    MerchantWithdrawCap(Address),
+    MerchantWithdrawalWindow(Address),
     // ... add other merchant‑specific keys as needed.
 }
 
@@ -57,6 +59,8 @@ impl DataKeyMerchant {
             DataKeyMerchant::TagAllowlist => 72,
             DataKeyMerchant::FeeToken => 64,
             DataKeyMerchant::MerchantFeeBps(_) => 76,
+            DataKeyMerchant::MerchantWithdrawCap(_) => 83,
+            DataKeyMerchant::MerchantWithdrawalWindow(_) => 84,
         }
     }
 }
@@ -84,6 +88,8 @@ impl From<DataKeyMerchant> for super::DataKey {
             DataKeyMerchant::TagAllowlist => super::DataKey::TagAllowlist,
             DataKeyMerchant::FeeToken => super::DataKey::FeeToken,
             DataKeyMerchant::MerchantFeeBps(v) => super::DataKey::MerchantFeeBps(v),
+            DataKeyMerchant::MerchantWithdrawCap(v) => super::DataKey::MerchantWithdrawCap(v),
+            DataKeyMerchant::MerchantWithdrawalWindow(v) => super::DataKey::MerchantWithdrawalWindow(v),
         }
     }
 }


### PR DESCRIPTION
Enforce a rolling 24-hour withdrawal cap per merchant to blunt the impact of any compromised merchant key.
Closes #554