### PR TITLE
bench: metadata write cost scaling benchmark (Closes #615)

### DIFF
--- a/contracts/subscription_vault/Cargo.toml
+++ b/contracts/subscription_vault/Cargo.toml
@@ -90,3 +90,6 @@ path = "benches/gov_tally.rs"
 name = "abi_hash_regression"
 path = "tests/abi_hash_regression.rs"
 
+[[test]]
+name = "metadata_write"
+path = "benches/metadata_write.rs"

--- a/contracts/subscription_vault/benches/metadata_write.rs
+++ b/contracts/subscription_vault/benches/metadata_write.rs
@@ -1,0 +1,102 @@
+//! Metadata write cost benchmark for `set_metadata` (#615).
+//!
+//! Measures the CPU-instruction cost of writing a metadata key at 1, 5, and
+//! `MAX_METADATA_KEYS` (10) key counts, to detect superlinear growth in the
+//! metadata storage layout. Each `set_metadata` call rewrites the
+//! subscription's `DataKey::MetadataKeys` `Vec<String>` (see
+//! `crate::metadata::apply_metadata_value`), so the cost of the n-th write is
+//! expected to grow roughly linearly with n. This test fails if the cost at
+//! `MAX_METADATA_KEYS` grows superlinearly (beyond 2x the linear projection),
+//! acting as a canary for accidental storage churn in the metadata path.
+//!
+//! # Scenarios
+//! 1. **1 key**  - first metadata write on a fresh subscription.
+//! 2. **5 keys** - fifth write (4 keys already present).
+//! 3. **MAX_METADATA_KEYS** - tenth write (9 keys already present, still under the cap).
+
+#![cfg(test)]
+
+use soroban_sdk::{
+    testutils::Address as _,
+    Address, Env, String, Symbol,
+};
+use subscription_vault::{types::MAX_METADATA_KEYS, SubscriptionVault, SubscriptionVaultClient};
+
+const AMOUNT: i128 = 10_000_000;
+const INTERVAL: u64 = 30 * 24 * 60 * 60;
+
+fn setup() -> (Env, SubscriptionVaultClient<'static>, u32, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(SubscriptionVault, ());
+    let client = SubscriptionVaultClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+    client.init(&token, &6u32, &admin, &1_000_000i128, &(7 * 24 * 60 * 60));
+
+    let subscriber = Address::generate(&env);
+    let merchant = Address::generate(&env);
+    let sub_id = client.create_subscription(
+        &subscriber,
+        &merchant,
+        &AMOUNT,
+        &INTERVAL,
+        &false,
+        &None::<i128>,
+        &None::<u64>,
+        &None::<u32>,
+        &None::<Symbol>,
+    );
+
+    (env, client, sub_id, subscriber)
+}
+
+fn measure_nth_write(n: u32) -> u64 {
+    let (env, client, sub_id, authorizer) = setup();
+
+    for i in 1..n {
+        let key = String::from_str(&env, &format!("key_{}", i));
+        let value = String::from_str(&env, "benchmark-value");
+        client.set_metadata(&sub_id, &authorizer, &key, &value);
+    }
+
+    env.cost_estimate().budget().reset_unlimited();
+    let key = String::from_str(&env, &format!("key_{}", n));
+    let value = String::from_str(&env, "benchmark-value");
+    client.set_metadata(&sub_id, &authorizer, &key, &value);
+    env.cost_estimate().resources().instructions.max(0) as u64
+}
+
+#[test]
+fn bench_metadata_write_scaling() {
+    let cost_1 = measure_nth_write(1);
+    let cost_5 = measure_nth_write(5);
+    let cost_max = measure_nth_write(MAX_METADATA_KEYS);
+
+    std::println!(
+        "[metadata_write] cost@1={} cost@5={} cost@MAX={}",
+        cost_1,
+        cost_5,
+        cost_max
+    );
+
+    assert!(
+        cost_max >= cost_5 && cost_5 >= cost_1,
+        "metadata write cost must grow monotonically with key count (cost@1={}, cost@5={}, cost@MAX={})",
+        cost_1,
+        cost_5,
+        cost_max
+    );
+
+    let linear_projection = cost_1.saturating_mul(MAX_METADATA_KEYS as u64);
+    assert!(
+        cost_max <= linear_projection.saturating_mul(2),
+        "metadata write cost is superlinear: cost@MAX={} exceeds 2x linear projection {}",
+        cost_max,
+        linear_projection
+    );
+}


### PR DESCRIPTION
## Summary
Adds the metadata-write cost benchmark requested in #615.

## What's included
- `contracts/subscription_vault/benches/metadata_write.rs` — a cost-budget test (mirroring the existing `benches/` pattern, e.g. `withdraw_fixed_cost.rs` / `batch_charge_scaling.rs`) that measures the CPU-instruction cost of `set_metadata` at **1**, **5**, and **MAX_METADATA_KEYS (10)** key counts.
- A `[[test]] name = "metadata_write"` entry in `contracts/subscription_vault/Cargo.toml` so `cargo test --test metadata_write` picks it up.

## How it detects superlinear growth
Each `set_metadata` rewrites the subscription's `DataKey::MetadataKeys` `Vec<String>` (`apply_metadata_value`). The benchmark:
1. Asserts cost grows monotonically with key count.
2. Asserts `cost@MAX <= 2 * (MAX * cost@1)` — an O(n) `Vec` rewrite lands near the linear projection, so anything beyond 2x signals pathological superlinear churn.

## Note on CI
`main` currently does not compile: 154 pre-existing errors introduced by the merge of #758 (`fix/lib-rs-duplicate-exports-and-mod`), including duplicate imports in `merchant.rs`, missing `DataKey`/`Error` variants referenced from `lib.rs`, missing `Subscription` fields, and a 34-char contract function name. This PR only adds the benchmark + its Cargo registration and does not touch the broken source files. Once the duplicate-export refactor is completed, this benchmark should compile and run via `cargo test --test metadata_write -- --nocapture`.

Closes #615
